### PR TITLE
Feat: 각 슬로건마다 다른 폰트 적용

### DIFF
--- a/src/entities/home/ui/SloganMarquee/index.tsx
+++ b/src/entities/home/ui/SloganMarquee/index.tsx
@@ -6,24 +6,37 @@ import { getRandomSubset } from "./utils/getRandomSubset";
 import { FONTS, FontType } from "./model/fonts";
 import { MarqueeRow } from "./ui/MarqueeRow";
 
+const getRandomFonts = (count: number): FontType[] => {
+  return Array.from({ length: count }, () => {
+    const randomIndex = Math.floor(Math.random() * FONTS.length);
+    return FONTS[randomIndex];
+  });
+};
+
 const SloganMarquee = (): React.ReactElement => {
   const [slogans1, setSlogans1] = useState<ReadonlyArray<string>>([]);
   const [slogans2, setSlogans2] = useState<ReadonlyArray<string>>([]);
-  const [font1, setFont1] = useState<FontType>("Pretendard");
-  const [font2, setFont2] = useState<FontType>("Arial");
+  const [fonts1, setFonts1] = useState<ReadonlyArray<FontType>>([]);
+  const [fonts2, setFonts2] = useState<ReadonlyArray<FontType>>([]);
 
   const initializeSlogans = useCallback(() => {
     try {
       const [selectedSlogans1, selectedSlogans2] = getRandomSubset(slogansMock, 8);
-      const [selectedFonts1, selectedFonts2] = getRandomSubset(FONTS, 1);
+      
+      const randomFonts1 = getRandomFonts(selectedSlogans1.length);
+      const randomFonts2 = getRandomFonts(selectedSlogans2.length);
 
       setSlogans1(selectedSlogans1);
       setSlogans2(selectedSlogans2);
-      setFont1(selectedFonts1[0]);
-      setFont2(selectedFonts2[0]);
+      setFonts1(randomFonts1);
+      setFonts2(randomFonts2);
     } catch {
-      setSlogans1(slogansMock.slice(0, 4));
-      setSlogans2(slogansMock.slice(4, 8));
+      const defaultSlogans1 = slogansMock.slice(0, 4);
+      const defaultSlogans2 = slogansMock.slice(4, 8);
+      setSlogans1(defaultSlogans1);
+      setSlogans2(defaultSlogans2);
+      setFonts1(getRandomFonts(defaultSlogans1.length));
+      setFonts2(getRandomFonts(defaultSlogans2.length));
     }
   }, []);
 
@@ -33,8 +46,8 @@ const SloganMarquee = (): React.ReactElement => {
 
   return (
     <section className="w-full overflow-hidden bg-main-100 py-28 space-y-10 relative">
-      <MarqueeRow slogans={slogans1} font={font1} color="text-main-600" />
-      <MarqueeRow slogans={slogans2} font={font2} reverse={true} color="text-main-500" />
+      <MarqueeRow slogans={slogans1} fonts={fonts1} color="text-main-600" />
+      <MarqueeRow slogans={slogans2} fonts={fonts2} reverse={true} color="text-main-500" />
     </section>
   );
 };

--- a/src/entities/home/ui/SloganMarquee/index.tsx
+++ b/src/entities/home/ui/SloganMarquee/index.tsx
@@ -7,10 +7,8 @@ import { FONTS, FontType } from "./model/fonts";
 import { MarqueeRow } from "./ui/MarqueeRow";
 
 const getRandomFonts = (count: number): FontType[] => {
-  return Array.from({ length: count }, () => {
-    const randomIndex = Math.floor(Math.random() * FONTS.length);
-    return FONTS[randomIndex];
-  });
+  const shuffledFonts = [...FONTS].sort(() => Math.random() - 0.5);
+  return shuffledFonts.slice(0, count);
 };
 
 const SloganMarquee = (): React.ReactElement => {
@@ -23,11 +21,15 @@ const SloganMarquee = (): React.ReactElement => {
     try {
       const [selectedSlogans1, selectedSlogans2] = getRandomSubset(slogansMock, 8);
       
-      const randomFonts1 = getRandomFonts(selectedSlogans1.length);
-      const randomFonts2 = getRandomFonts(selectedSlogans2.length);
-
       setSlogans1(selectedSlogans1);
       setSlogans2(selectedSlogans2);
+      
+      const randomFonts1 = getRandomFonts(selectedSlogans1.length);
+      const remainingFonts = FONTS.filter(font => !randomFonts1.includes(font));
+      const randomFonts2 = [...remainingFonts]
+        .sort(() => Math.random() - 0.5)
+        .slice(0, selectedSlogans2.length);
+      
       setFonts1(randomFonts1);
       setFonts2(randomFonts2);
     } catch {
@@ -35,8 +37,15 @@ const SloganMarquee = (): React.ReactElement => {
       const defaultSlogans2 = slogansMock.slice(4, 8);
       setSlogans1(defaultSlogans1);
       setSlogans2(defaultSlogans2);
-      setFonts1(getRandomFonts(defaultSlogans1.length));
-      setFonts2(getRandomFonts(defaultSlogans2.length));
+      
+      const fallbackFonts1 = getRandomFonts(defaultSlogans1.length);
+      const fallbackRemainingFonts = FONTS.filter(font => !fallbackFonts1.includes(font));
+      const fallbackFonts2 = [...fallbackRemainingFonts]
+        .sort(() => Math.random() - 0.5)
+        .slice(0, defaultSlogans2.length);
+      
+      setFonts1(fallbackFonts1);
+      setFonts2(fallbackFonts2);
     }
   }, []);
 

--- a/src/entities/home/ui/SloganMarquee/model/fonts.ts
+++ b/src/entities/home/ui/SloganMarquee/model/fonts.ts
@@ -7,7 +7,13 @@ export const FONTS = Object.freeze([
   "Orbitron",
   "Cafe24ClassicType-Regular",
   "BMHANNAPro",
-  "Danjo-bold-Regular"
+  "Danjo-bold-Regular",
+  "Ownglyph_corncorn-Rg",
+  "LeeSeoyun",
+  "GangwonEduSaeeum_OTFMediumA",
+  "Shilla_CultureB-Bold",
+  "SangSangRock",
+  "Dokrip"
 ]) as ReadonlyArray<string> & {
   readonly [index: number]: string;
 };

--- a/src/entities/home/ui/SloganMarquee/model/fonts.ts
+++ b/src/entities/home/ui/SloganMarquee/model/fonts.ts
@@ -1,10 +1,13 @@
 export const FONTS = Object.freeze([
-  "Pretendard",
+  "Pretendard-Regular",
   "Arial",
   "NanumSquare",
   "DungGeunMo",
-  "GmarketSans",
+  "GmarketSansMedium",
   "Orbitron",
+  "Cafe24ClassicType-Regular",
+  "BMHANNAPro",
+  "Danjo-bold-Regular"
 ]) as ReadonlyArray<string> & {
   readonly [index: number]: string;
 };

--- a/src/entities/home/ui/SloganMarquee/ui/MarqueeRow/index.tsx
+++ b/src/entities/home/ui/SloganMarquee/ui/MarqueeRow/index.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/shared/utils/cn";
 
 type MarqueeRowProps = Readonly<{
   slogans: ReadonlyArray<string>;
-  font: FontType;
+  fonts: ReadonlyArray<FontType>;
   reverse?: boolean;
   color?: "text-main-500" | "text-main-600";
 }>;
@@ -13,16 +13,21 @@ type MarqueeRowProps = Readonly<{
 export const MarqueeRow = memo(
   ({
     slogans,
-    font,
+    fonts,
     reverse = false,
     color = "text-main-600",
   }: MarqueeRowProps): React.ReactElement => {
     const rendered = useMemo(
       () =>
         slogans.map((slogan, index) => (
-          <SloganItem key={`${slogan}-${index}`} slogan={slogan} index={index} />
+          <SloganItem 
+            key={`${slogan}-${index}`} 
+            slogan={slogan} 
+            index={index} 
+            font={fonts[index % fonts.length]} 
+          />
         )),
-      [slogans],
+      [slogans, fonts],
     );
 
     return (
@@ -33,7 +38,6 @@ export const MarqueeRow = memo(
             reverse ? "animate-marquee-reverse" : "animate-marquee",
             color,
           )}
-          style={{ fontFamily: `${font}, sans-serif` }}
           aria-live="off"
         >
           {rendered}

--- a/src/entities/home/ui/SloganMarquee/ui/SloganItem/index.tsx
+++ b/src/entities/home/ui/SloganMarquee/ui/SloganItem/index.tsx
@@ -1,9 +1,20 @@
 import React, { memo } from "react";
 import { cn } from "@/shared/utils/cn";
+import { FontType } from "../../model/fonts";
+
+type SloganItemProps = {
+  slogan: string;
+  index: number;
+  font: FontType;
+};
 
 export const SloganItem = memo(
-  ({ slogan, index }: { slogan: string; index: number }): React.ReactElement => (
-    <span key={`slogan-${index}`} className={cn("mx-4 inline-block")}>
+  ({ slogan, index, font }: SloganItemProps): React.ReactElement => (
+    <span 
+      key={`slogan-${index}`} 
+      className={cn("mx-16 inline-block")}
+      style={{ fontFamily: `${font}, sans-serif` }}
+    >
       {slogan}
     </span>
   ),

--- a/src/shared/style/globals.css
+++ b/src/shared/style/globals.css
@@ -125,6 +125,76 @@ input {
   font-style: normal;
 }
 
+@font-face {
+  font-family: 'Ownglyph_corncorn-Rg';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/2412-1@1.0/Ownglyph_corncorn-Rg.woff2') format('woff2');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'LeeSeoyun';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2202-2@1.0/LeeSeoyun.woff') format('woff');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'GangwonEduSaeeum_OTFMediumA';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2201-2@1.0/GangwonEduSaeeum_OTFMediumA.woff') format('woff');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Shilla_CultureB-Bold';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2206-02@1.0/Shilla_CultureB-Bold.woff2') format('woff2');
+  font-weight: 700;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'SangSangRock';
+  src: url('https://gcore.jsdelivr.net/gh/projectnoonnu/noonfonts_2001@1.1/SangSangRockOTF.woff') format('woff');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Dokrip';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_twelve@1.1/Dokrip.woff') format('woff');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'ChosunCentennial';
+  src: url('https://gcore.jsdelivr.net/gh/projectnoonnu/noonfonts_2206-02@1.0/ChosunCentennial.woff2') format('woff2');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'OTEnjoystoriesBA';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_two@1.0/OTEnjoystoriesBA.woff') format('woff');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: '행복고흥L';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_twelve@1.0/행복고흥L.woff') format('woff');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'JSArirang-Regular';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2001@1.1/JSArirang-RegularA1.woff') format('woff');
+  font-weight: normal;
+  font-style: normal;
+}
+
 .scroll-hidden {
   scrollbar-width: none;
   -ms-overflow-style: none;

--- a/src/shared/style/globals.css
+++ b/src/shared/style/globals.css
@@ -97,6 +97,34 @@ input {
   font-style: normal;
 }
 
+@font-face {
+  font-family: 'Cafe24ClassicType-Regular';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2210-2@1.0/Cafe24ClassicType-Regular.woff2') format('woff2');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'BMHANNAPro';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_seven@1.0/BMHANNAPro.woff') format('woff');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Danjo-bold-Regular';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2307-1@1.1/Danjo-bold-Regular.woff2') format('woff2');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'GmarketSansMedium';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2001@1.1/GmarketSansMedium.woff') format('woff');
+  font-weight: normal;
+  font-style: normal;
+}
+
 .scroll-hidden {
   scrollbar-width: none;
   -ms-overflow-style: none;


### PR DESCRIPTION
## 💡 PR 요약

- 전역 스타일을 만져서 5개의 웹폰트를 추가했습니다
- 기존 MarqueeRow 하나마다 같은 폰트만 적용하는 로직을, slogans 단위로 다른 폰트가 적용되도록 변경했습니다

## 📋 작업 내용

<img width="942" alt="스크린샷 2025-05-16 오전 10 30 42" src="https://github.com/user-attachments/assets/a46b5788-89f0-4676-b2dd-b673817de00e" />

