### PR TITLE
Fix: 로그인페이지 리다이렉트 문제 해결

### DIFF
--- a/src/entities/user/lib/authFormState.ts
+++ b/src/entities/user/lib/authFormState.ts
@@ -5,7 +5,7 @@ export interface authFormState {
   isValid: boolean;
   submitted: boolean;
   isLoading?: boolean;
-  error?: string;
+  error?: string | string[];
 }
 
 export type authFormValues = SignInFormValues | SignUpFormValues;

--- a/src/widgets/signin/lib/handleSigninFormSubmit.ts
+++ b/src/widgets/signin/lib/handleSigninFormSubmit.ts
@@ -1,10 +1,10 @@
+"use server";
+
 import { signinSchema, SignInFormValues } from "@/entities/user/model/schema";
 import { authFormState } from "@/entities/user/lib/authFormState";
 import { signin } from "@/entities/user/api/signin";
 import { setTokens } from "@/shared/utils/auth";
-import { toast } from "sonner";
 import { redirect } from "next/navigation";
-import { ZodError } from "zod";
 
 export const handleSigninFormSubmit = async (
   _previousState: authFormState,
@@ -18,12 +18,11 @@ export const handleSigninFormSubmit = async (
   const result = signinSchema.safeParse(values);
 
   if (!result.success) {
-    result.error.errors.forEach((err: ZodError['errors'][0]) => toast.error(err.message));
     return {
       values,
       isValid: false,
       submitted: true,
-      error: "입력값이 올바르지 않습니다.",
+      error: result.error.errors.map((err) => err.message), 
     };
   }
 
@@ -42,8 +41,6 @@ export const handleSigninFormSubmit = async (
       response.refresh_token_expired_at
     );
     
-    toast.success("로그인 성공");
-    
     redirect("/home");
     
     return {
@@ -54,7 +51,6 @@ export const handleSigninFormSubmit = async (
     };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : "로그인에 실패했습니다.";
-    toast.error(errorMessage);
     
     return {
       values,
@@ -63,5 +59,7 @@ export const handleSigninFormSubmit = async (
       isLoading: false,
       error: errorMessage,
     };
+  } finally {
+    redirect("/home");
   }
 };

--- a/src/widgets/signin/ui/SigninFormContainer/index.tsx
+++ b/src/widgets/signin/ui/SigninFormContainer/index.tsx
@@ -2,10 +2,11 @@
 
 import Input from "@/shared/ui/Input";
 import { cn } from "@/shared/utils/cn";
-import { useActionState } from "react";
+import { useActionState, useEffect } from "react";
 import SubmitButton from "@/entities/user/ui/SubmitButton";
 import { authFormState } from "@/entities/user/lib/authFormState";
 import { handleSigninFormSubmit } from "@/widgets/signin/lib/handleSigninFormSubmit";
+import { toast } from "sonner";
 
 const SigninFormContainer = () => {
   const initialState: authFormState = {
@@ -16,6 +17,15 @@ const SigninFormContainer = () => {
   };
 
   const [state, formAction] = useActionState(handleSigninFormSubmit, initialState);
+
+  useEffect(() => {    
+    if (state.error) {
+      const errors = Array.isArray(state.error) ? state.error : [state.error];
+      errors.forEach((error) => toast.error(error));
+    } else if (state.isValid) {
+      toast.success("로그인 성공");
+    }
+  }, [state.submitted, state.error, state.isValid]);
 
   return (
     <div className={cn("w-full mb-4")}>


### PR DESCRIPTION
## 💡 PR 요약

/api/signin 핸들러에서 200 떠서, handleSigninFormSubmit 함수의 try문 안에서 redirect를 호출해도 /home으로 이동하지 않는 문제를 해결했습니다.

## 📋 작업 내용

handleSigninFormSubmit 함수를 서버액션으로 선언하고 redirect를 catch 이후에 호출하도록 변경했어요.

 이에 따라 에러 처리 로직을 UI component 계층으로 이동했습니다.