### PR TITLE
fix: 모바일 환경에서 지도가 세로로 길게 표시되게끔 수정했습니다

### DIFF
--- a/src/widgets/main/FinalsSixthSection/index.tsx
+++ b/src/widgets/main/FinalsSixthSection/index.tsx
@@ -32,7 +32,7 @@ const FinalsSixthSection = () => {
           </p>
           <Map
             address="광주광역시 동구 필문대로 309 조선대학교 해오름관"
-            className={cn("h-[300px]")}
+            className={cn("h-[300px] mobile:h-[30rem]")}
           />
         </div>
       </div>


### PR DESCRIPTION


## 📋 작업 내용

<img width="389" height="681" alt="Screenshot 2025-09-14 at 10 38 44 PM" src="https://github.com/user-attachments/assets/1a294e7e-5fd5-4565-92e1-b25b89ba5ceb" />
