### PR TITLE
feat: 슬로건 페이지에 바뀐 색 적용

### DIFF
--- a/src/entities/slogan/ui/HighlightText/index.tsx
+++ b/src/entities/slogan/ui/HighlightText/index.tsx
@@ -9,7 +9,7 @@ interface HighlightTextProps {
 const HighlightText = ({
   text,
   searchTerm,
-  highlightClassName = "text-main-600 font-semibold",
+  highlightClassName = "text-new-main font-semibold",
 }: HighlightTextProps) => {
   if (!searchTerm.trim()) {
     return <span>{text}</span>;

--- a/src/entities/slogan/ui/HighlightText/index.tsx
+++ b/src/entities/slogan/ui/HighlightText/index.tsx
@@ -9,7 +9,7 @@ interface HighlightTextProps {
 const HighlightText = ({
   text,
   searchTerm,
-  highlightClassName = "text-new-main font-semibold",
+  highlightClassName = "text-orange-500 font-semibold",
 }: HighlightTextProps) => {
   if (!searchTerm.trim()) {
     return <span>{text}</span>;

--- a/src/entities/slogan/ui/SloganFormSuccess/index.tsx
+++ b/src/entities/slogan/ui/SloganFormSuccess/index.tsx
@@ -23,7 +23,7 @@ const SloganFormSuccess = () => {
       className="flex flex-col items-center justify-center w-full text-center"
       style={{ height: "calc(100vh - 81px)" }}
     >
-      <Logo height={131} color={colors.main[600]} width={211} />
+      <Logo height={131} color={colors.new.main} width={211} />
       <div className="mt-[52px]">
         <h1 className="sm:text-title2b text-title4b text-center">응모가 완료되었습니다!</h1>{" "}
         <div className="text-caption1r mobile:text-caption2r text-gray-400 mt-10">
@@ -35,8 +35,8 @@ const SloganFormSuccess = () => {
             onClick={handleShare}
             className="flex gap-24 cursor-pointer items-center justify-center mt-12 sm:mt-24"
           >
-            <Share color={colors.main[600]} height={24} width={24} />
-            <span className="text-body2r text- underline text-main-600">
+            <Share color={colors.new.main} height={24} width={24} />
+            <span className="text-body2r text- underline text-new-main">
               친구들에게도 공유해주세요
             </span>
           </div>

--- a/src/entities/slogan/ui/SloganFormSuccess/index.tsx
+++ b/src/entities/slogan/ui/SloganFormSuccess/index.tsx
@@ -23,7 +23,7 @@ const SloganFormSuccess = () => {
       className="flex flex-col items-center justify-center w-full text-center"
       style={{ height: "calc(100vh - 81px)" }}
     >
-      <Logo height={131} color={colors.new.main} width={211} />
+      <Logo height={131} color={colors.orange[500]} width={211} />
       <div className="mt-[52px]">
         <h1 className="sm:text-title2b text-title4b text-center">응모가 완료되었습니다!</h1>{" "}
         <div className="text-caption1r mobile:text-caption2r text-gray-400 mt-10">
@@ -35,8 +35,8 @@ const SloganFormSuccess = () => {
             onClick={handleShare}
             className="flex gap-24 cursor-pointer items-center justify-center mt-12 sm:mt-24"
           >
-            <Share color={colors.new.main} height={24} width={24} />
-            <span className="text-body2r text- underline text-new-main">
+            <Share color={colors.orange[500]} height={24} width={24} />
+            <span className="text-body2r text- underline text-orange-500">
               친구들에게도 공유해주세요
             </span>
           </div>

--- a/src/shared/ui/Button/index.tsx
+++ b/src/shared/ui/Button/index.tsx
@@ -5,11 +5,11 @@ type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 };
 
 const variant = {
-  default: "bg-new-main text-white",
+  default: "bg-orange-500 text-white",
   secondary: "text-white bg-main-300",
-  third: "bg-new-sub3 text-new-main",
+  third: "bg-orange-200 text-orange-500",
   disabled: "bg-gray-100 cursor-not-allowed border border-gray-200 text-gray-800",
-  outline: "border border-solid border-new-main text-new-main",
+  outline: "border border-solid border-orange-500 text-orange-500",
 };
 
 const Button = ({

--- a/src/shared/ui/Button/index.tsx
+++ b/src/shared/ui/Button/index.tsx
@@ -5,11 +5,11 @@ type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 };
 
 const variant = {
-  default: "bg-main-600 text-white",
+  default: "bg-new-main text-white",
   secondary: "text-white bg-main-300",
-  third: "bg-main-100 text-main-600",
-  disabled: "bg-gray-300 cursor-not-allowed text-white",
-  outline: "border border-solid border-main-600 text-main-600",
+  third: "bg-new-sub3 text-new-main",
+  disabled: "bg-gray-100 cursor-not-allowed text-white border border-gray-200 text-gray-800",
+  outline: "border border-solid border-new-main text-new-main",
 };
 
 const Button = ({

--- a/src/shared/ui/Button/index.tsx
+++ b/src/shared/ui/Button/index.tsx
@@ -8,7 +8,7 @@ const variant = {
   default: "bg-new-main text-white",
   secondary: "text-white bg-main-300",
   third: "bg-new-sub3 text-new-main",
-  disabled: "bg-gray-100 cursor-not-allowed text-white border border-gray-200 text-gray-800",
+  disabled: "bg-gray-100 cursor-not-allowed border border-gray-200 text-gray-800",
   outline: "border border-solid border-new-main text-new-main",
 };
 

--- a/src/shared/utils/color.ts
+++ b/src/shared/utils/color.ts
@@ -24,6 +24,13 @@ export const colors = {
   },
   black: "#121212",
   white: "#FFFFFF",
+  new: {
+    main: "#FF9644",
+    sub1: "#FFAD6D",
+    sub2: "#FFCE99",
+    sub3: "#FFEAD4",
+    sub4: "#FFFDF1",
+  },
 } as const;
 
 export const rgbs = {
@@ -52,4 +59,11 @@ export const rgbs = {
   },
   black: "18, 18, 18", // #121212
   white: "255, 255, 255", // #FFFFFF
+  new: {
+    main: "255, 150, 68", // #FF9644
+    sub1: "255, 173, 109", // #FFAD6D
+    sub2: "255, 206, 153", // #FFCE99
+    sub3: "255, 234, 212", // #FFEAD4
+    sub4: "255, 253, 241", // #FFFDF1
+  },
 } as const;

--- a/src/shared/utils/color.ts
+++ b/src/shared/utils/color.ts
@@ -24,12 +24,12 @@ export const colors = {
   },
   black: "#121212",
   white: "#FFFFFF",
-  new: {
-    main: "#FF9644",
-    sub1: "#FFAD6D",
-    sub2: "#FFCE99",
-    sub3: "#FFEAD4",
-    sub4: "#FFFDF1",
+  orange: {
+    "100": "#FFFDF1",
+    "200": "#FFEAD4",
+    "300": "#FFCE99",
+    "400": "#FFAD6D",
+    "500": "#FF9644",
   },
 } as const;
 
@@ -59,11 +59,11 @@ export const rgbs = {
   },
   black: "18, 18, 18", // #121212
   white: "255, 255, 255", // #FFFFFF
-  new: {
-    main: "255, 150, 68", // #FF9644
-    sub1: "255, 173, 109", // #FFAD6D
-    sub2: "255, 206, 153", // #FFCE99
-    sub3: "255, 234, 212", // #FFEAD4
-    sub4: "255, 253, 241", // #FFFDF1
+  orange: {
+    100: "255, 253, 241", // #FFFDF1
+    200: "255, 234, 212", // #FFEAD4
+    300: "255, 206, 153", // #FFCE99
+    400: "255, 173, 109", // #FFAD6D
+    500: "255, 150, 68", // #FF9644
   },
 } as const;

--- a/src/views/slogan/ui/SloganPage/index.tsx
+++ b/src/views/slogan/ui/SloganPage/index.tsx
@@ -9,7 +9,7 @@ export default function SloganPage() {
   const [agree, setAgree] = useState(true);
   const [danger, setDanger] = useState(true);
   return (
-    <div className={cn("w-full max-w-[708px]")}>
+    <div className={cn("w-full max-w-[708px] mx-auto")}>
       <SloganFormContainer />
       <Modal type="danger" setIsOpen={setDanger} isOpen={danger} />
       {danger === false && <Modal type="agree" setIsOpen={setAgree} isOpen={agree} />}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -128,6 +128,13 @@ export default {
         },
         black: "#121212",
         white: "#FFFFFF",
+        new: {
+          main: "#FF9644",
+          sub1: "#FFAD6D",
+          sub2: "#FFCE99",
+          sub3: "#FFEAD4",
+          sub4: "#FFFDF1",
+        },
       },
     },
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -128,12 +128,12 @@ export default {
         },
         black: "#121212",
         white: "#FFFFFF",
-        new: {
-          main: "#FF9644",
-          sub1: "#FFAD6D",
-          sub2: "#FFCE99",
-          sub3: "#FFEAD4",
-          sub4: "#FFFDF1",
+        orange: {
+          "100": "#FFFDF1",//4
+          "200": "#FFEAD4",//3
+          "300": "#FFCE99",//2
+          "400": "#FFAD6D",//1
+          "500": "#FF9644",//main
         },
       },
     },


### PR DESCRIPTION
## 💡 PR 요약

새로 추가된 색을 슬로건 페이지에 적용했습니다

## 📋 작업 내용

새로 추가된 색 슬로건 페이지에 적용
가운데 정렬
<img width="2879" height="1453" alt="image" src="https://github.com/user-attachments/assets/153ddc41-6b7e-4ba7-ac65-2c7ed8354d7a" />
<img width="2879" height="1458" alt="image" src="https://github.com/user-attachments/assets/c10ad5d0-70a7-44e9-ad83-f973d6d32c3d" />

<img width="2879" height="1303" alt="image" src="https://github.com/user-attachments/assets/3bb8539c-6411-4bd2-8a26-f52ee6736850" />
<img width="2879" height="1346" alt="image" src="https://github.com/user-attachments/assets/2ef41efa-f4bd-4f7d-9432-9b5e1f2b9e86" />

<img width="2876" height="1334" alt="image" src="https://github.com/user-attachments/assets/671e3f7d-1602-46b1-bddf-b626d1d39513" />
<img width="2879" height="1286" alt="image" src="https://github.com/user-attachments/assets/5f2b3dad-fbf9-44a6-9d9b-7f83b3d37d6d" />
