### PR TITLE
feat: 메인페이지 수정

### DIFF
--- a/src/shared/const/headerValues.ts
+++ b/src/shared/const/headerValues.ts
@@ -8,9 +8,9 @@ export const isHiddenPath = (pathname: string): boolean => {
 };
 
 export const links = [
-    { section: "SloganSecondSection", label: "2025 광탈페 슬로건" },
-    // { section: "section3", label: "FaQ" },
-    { section: "PreliminaryFourthSection", label: "2025 광탈페 예선 다시보기" },
-    { section: "FinalsSixthSection", label: "2025 광탈페 본선 다시보기" },
-    { section: "ReservationFifthSection", label: "본선 수상팀 명단" },
+  { section: "SloganSecondSection", label: "2025 광탈페 슬로건" },
+  // { section: "section3", label: "FaQ" },
+  { section: "PreliminaryFourthSection", label: "2025 광탈페 예선 다시보기" },
+  { section: "FinalsSixthSection", label: "2025 광탈페 본선 다시보기" },
+  // { section: "ReservationFifthSection", label: "본선 수상팀 명단" },
 ];

--- a/src/views/home/ui/HomePage/index.tsx
+++ b/src/views/home/ui/HomePage/index.tsx
@@ -10,10 +10,10 @@ const PreliminaryFourthSection = dynamic(() => import("@/widgets/main/Preliminar
   ssr: false,
 });
 
-const ReservationFifthSection = dynamic(() => import("@/widgets/main/ReservationFifthSection"), {
-  loading: () => <SectionPlaceholder />,
-  ssr: false,
-});
+// const ReservationFifthSection = dynamic(() => import("@/widgets/main/ReservationFifthSection"), {
+//   loading: () => <SectionPlaceholder />,
+//   ssr: false,
+// });
 
 const FinalsSixthSection = dynamic(() => import("@/widgets/main/FinalsSixthSection"), {
   loading: () => <SectionPlaceholder />,
@@ -57,9 +57,9 @@ const HomePage = () => {
         <FinalsSixthSection />
       </LazySection>
 
-      <LazySection fallback={<SectionPlaceholder height="500px" />} rootMargin="300px">
+      {/* <LazySection fallback={<SectionPlaceholder height="500px" />} rootMargin="300px">
         <ReservationFifthSection />
-      </LazySection>
+      </LazySection> */}
 
       <LazySection fallback={<SectionPlaceholder height="500px" />} rootMargin="300px">
         <SeventhSection />

--- a/src/widgets/main/FinalsSixthSection/index.tsx
+++ b/src/widgets/main/FinalsSixthSection/index.tsx
@@ -18,7 +18,7 @@ const FinalsSixthSection = () => {
     <section id="FinalsSixthSection" className={cn("flex flex-col items-center my-20")}>
       <div className={cn("w-[70%] mobile:w-full")}>
         <SectionTitle
-          title="2025 광탈페 본선"
+          title="2025 광탈페 본선 다시보기"
           className={cn("mt-[66px] mobile:mt-[1.7rem] mb-28")}
         />
 


### PR DESCRIPTION
## 💡 PR 요약

메인페이지 헤더에 본선 수상팀 명단 주석 처리
2025 광탈페 본선 -> 2025 광탈페 본선 다시보기로 수정
본선 수상팀 명단 섹션 주석

## 📋 작업 내용

> 해당 PR에서 작업한 내용을 자세히 설명해주세요. + 스크린 샷샷
<img width="3120" height="1716" alt="image" src="https://github.com/user-attachments/assets/1c71ea2e-80e1-48e0-b70a-a69e9b940eb5" />
<img width="1984" height="1456" alt="image" src="https://github.com/user-attachments/assets/8be7bcfc-9a69-4e3e-9ddb-8c1665828821" />
<img width="2839" height="158" alt="image" src="https://github.com/user-attachments/assets/afcc7085-1e09-4654-b00a-1f4e60356e27" />
<img width="2264" height="804" alt="image" src="https://github.com/user-attachments/assets/999d66f3-1bed-4d30-bfd9-3ebccece4fe8" />


## 🤝 리뷰 시 참고사항

인스타 링크 연결은 잘 돼서 수정하지 않았습니다.
챗봇은 제가 수정할 수 있는게 아닌거 같아서 수정하지 않았습니다..

