### PR TITLE
refactor: 슬로건 테스트 서버에 맞게 리팩토링

### DIFF
--- a/src/app/api/server/[...path]/route.ts
+++ b/src/app/api/server/[...path]/route.ts
@@ -30,8 +30,10 @@ async function handleRequest(request: NextRequest): Promise<NextResponse> {
     }
 
     const response = await fetch(url, options);
-    const data = await response.json();
-    return NextResponse.json(data);
+    const contentLength = response.headers.get("content-length");
+    const hasBody = contentLength !== "0" && response.status !== 204;
+    const data = hasBody ? await response.json().catch(() => null) : null;
+    return NextResponse.json(data, { status: response.status });
   } catch (error) {
     console.error(`${method} ${url}:`, error);
     return NextResponse.json({ status: 500 });

--- a/src/app/slogan/page.tsx
+++ b/src/app/slogan/page.tsx
@@ -1,5 +1,5 @@
-import { redirect } from "next/navigation";
+import SloganPage from "@/views/slogan/ui/SloganPage";
 
 export default function Slogan() {
-  redirect("/home");
+  return <SloganPage />;
 }

--- a/src/entities/slogan/api/postSlogan.ts
+++ b/src/entities/slogan/api/postSlogan.ts
@@ -2,9 +2,11 @@ import instance from "@/shared/lib/axios";
 import { SloganFormValues } from "../model/schema";
 
 export const postSlogan = async (data: SloganFormValues) => {
+  const { phone_number, classroom, grade, ...rest } = data;
   return await instance.post("/slogan", {
-    ...data,
-    grade: Number(data.grade),
-    classroom: Number(data.classroom),
+    ...rest,
+    phoneNumber: phone_number,
+    grade: Number(grade),
+    classNum: Number(classroom),
   });
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -32,10 +32,6 @@ export function middleware(request: NextRequest) {
   const accessToken = request.cookies.get("accessToken")?.value;
   const refreshToken = request.cookies.get("refreshToken")?.value;
 
-  if (pathname === "/slogan") {
-    return NextResponse.redirect(new URL("/home", request.url));
-  }
-
   if (pathname === "/signin" && accessToken && refreshToken) {
     const nextParam = searchParams.get("next");
     if (nextParam && nextParam.startsWith("/") && nextParam !== "/signin") {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { publicPages, festivalDate, publicIn27 } from "@/shared/config/authConfig";
+import {
+  publicPages,
+  festivalDate,
+  publicIn27,
+  sloganStartDate,
+  sloganEndDate,
+} from "@/shared/config/authConfig";
 
 export const config = {
   matcher: [
@@ -12,6 +18,7 @@ export const config = {
 export function middleware(request: NextRequest) {
   const { pathname, searchParams } = request.nextUrl;
   const role = request.cookies.get("role")?.value;
+  const now = new Date();
 
   const isPublicAdminPath =
     pathname.match(/^\/admin\/lottery\/[^/]+$/) || pathname.match(/^\/admin\/score\/[^/]+$/);
@@ -31,6 +38,10 @@ export function middleware(request: NextRequest) {
 
   const accessToken = request.cookies.get("accessToken")?.value;
   const refreshToken = request.cookies.get("refreshToken")?.value;
+
+  if (pathname === "/slogan" && (now < sloganStartDate || now > sloganEndDate)) {
+    return NextResponse.redirect(new URL("/home", request.url));
+  }
 
   if (pathname === "/signin" && accessToken && refreshToken) {
     const nextParam = searchParams.get("next");

--- a/src/shared/config/authConfig.ts
+++ b/src/shared/config/authConfig.ts
@@ -1,4 +1,4 @@
-export const publicPages = ["/home", "/signin", "/signup", "/admin", "/vote"];
+export const publicPages = ["/home", "/signin", "/signup", "/admin", "/vote", "/slogan"];
 
 export const publicIn18 = ["/booking"];
 

--- a/src/shared/config/authConfig.ts
+++ b/src/shared/config/authConfig.ts
@@ -7,3 +7,5 @@ export const publicIn27 = ["/vote"];
 export const ticketOpenDate = new Date("2025-09-18T20:00:00");
 export const performerTicketOpenDate = new Date("2025-09-15T20:00:00");
 export const festivalDate = new Date("2025-09-27T00:00:00");
+export const sloganStartDate = new Date("2026-05-18T00:00:00+09:00");
+export const sloganEndDate = new Date("2026-05-28T23:59:59+09:00");

--- a/src/shared/lib/axios.ts
+++ b/src/shared/lib/axios.ts
@@ -3,7 +3,7 @@ import { getTokenFromCookie, setTokens, clearTokens } from "@/shared/utils/auth"
 import { refresh } from "@/shared/api/refresh";
 import { publicPages } from "@/shared/config/authConfig";
 
-export const baseURL = "";
+export const baseURL = "/api/server";
 
 const instance = axios.create({
   baseURL: baseURL,

--- a/src/widgets/main/PreliminaryFourthSection/index.tsx
+++ b/src/widgets/main/PreliminaryFourthSection/index.tsx
@@ -1,7 +1,6 @@
 // import ImageCarousel from "@/entities/home/ui/ImageCarousel";
 import { cn } from "@/shared/utils/cn";
 import { SectionTitle } from "@/shared/ui/SectionTitle";
-import ImageCarousel from "@/entities/home/ui/ImageCarousel";
 import YouTubeLazyEmbed from "@/shared/ui/YouTubeLazyEmbed";
 
 // const SLIDES_1 = [
@@ -16,33 +15,6 @@ import YouTubeLazyEmbed from "@/shared/ui/YouTubeLazyEmbed";
 //   "/images/Preliminary/slide2_3.jpg",
 // ];
 
-const SLIDES_3 = [
-  "/images/25일/1.jpg",
-  "/images/25일/2.jpg",
-  "/images/25일/3.jpg",
-  "/images/25일/4.jpg",
-  "/images/25일/5.jpg",
-  "/images/25일/6.jpg",
-  "/images/25일/7.jpg",
-  "/images/25일/8.jpg",
-  "/images/25일/9.jpg",
-  "/images/25일/10.jpg",
-  "/images/25일/11.jpg",
-  "/images/26일/1.jpg",
-  "/images/26일/2.jpg",
-  "/images/26일/3.jpg",
-  "/images/26일/4.jpg",
-  "/images/26일/5.jpg",
-  "/images/26일/6.jpg",
-  "/images/26일/7.jpg",
-  "/images/26일/8.jpg",
-  "/images/26일/9.jpg",
-  "/images/26일/10.jpg",
-  "/images/26일/11.jpg",
-  "/images/26일/12.jpg",
-  "/images/26일/13.jpg",
-];
-
 const PreliminaryFourthSection = () => {
   return (
     <section id="PreliminaryFourthSection" className={cn("flex flex-col items-center")}>
@@ -51,35 +23,6 @@ const PreliminaryFourthSection = () => {
           title="2025 광탈페 예선 다시보기"
           className={cn("mt-[66px] mobile:mt-[1.7rem] mb-[24px]")}
         />
-
-        <h2
-          className={cn(
-            "text-body2b mobile:text-body3b place-self-start mb-18 mobile:mb-0 mobile:ml-12",
-          )}
-        >
-          2025 광탈페 예선 참가팀 소개
-        </h2>
-
-        <div
-          className={cn(
-            "flex w-full items-start gap-10 justify-between mobile:flex-col mobile:mb-[38px]",
-          )}
-        >
-          <div className={cn("w-[50%] mobile:w-full mobile:mt-16")}>
-            <ImageCarousel wide slides={SLIDES_3} />
-          </div>
-          <div className={cn("w-[50%] mobile:w-full mobile:px-16")}>
-            <video
-              src="https://kr.object.ncloudstorage.com/gwangju-talent-festival-bucket/예선.mp4"
-              className="w-full h-full object-cover rounded-xl"
-              autoPlay
-              loop
-              muted
-              playsInline
-              preload="metadata"
-            />
-          </div>
-        </div>
 
         <div className={cn("flex w-full gap-10 mobile:flex-col")}>
           <div

--- a/src/widgets/main/SloganSecondSection/index.tsx
+++ b/src/widgets/main/SloganSecondSection/index.tsx
@@ -9,8 +9,8 @@ import { formatDate } from "@/shared/utils/formatDate";
 
 const SLOGAN_YEAR = 2026;
 
-const SLOGAN_START = new Date(`${SLOGAN_YEAR}-05-04T00:00:00+09:00`);
-const SLOGAN_END = new Date(`${SLOGAN_YEAR}-05-08T17:59:59+09:00`);
+const SLOGAN_START = new Date(`${SLOGAN_YEAR}-05-18T00:00:00+09:00`);
+const SLOGAN_END = new Date(`${SLOGAN_YEAR}-05-28T23:59:59+09:00`);
 
 const SloganSecondSection = () => {
   const router = useRouter();
@@ -32,7 +32,7 @@ const SloganSecondSection = () => {
   const submissionPeriodText = React.useMemo(() => {
     const startText = formatDate(SLOGAN_START);
     const endText = formatDate(SLOGAN_END);
-    return `공모기간 : ${SLOGAN_YEAR}.${startText}~${endText} 18:00까지`;
+    return `공모기간 : ${SLOGAN_YEAR}.${startText}~${endText} 24:00까지`;
   }, []);
 
   return (

--- a/src/widgets/main/SloganSecondSection/index.tsx
+++ b/src/widgets/main/SloganSecondSection/index.tsx
@@ -6,11 +6,9 @@ import Button from "@/shared/ui/Button";
 import { cn } from "@/shared/utils/cn";
 import { SectionTitle } from "@/shared/ui/SectionTitle";
 import { formatDate } from "@/shared/utils/formatDate";
+import { sloganStartDate, sloganEndDate } from "@/shared/config/authConfig";
 
-const SLOGAN_YEAR = 2026;
-
-const SLOGAN_START = new Date(`${SLOGAN_YEAR}-05-18T00:00:00+09:00`);
-const SLOGAN_END = new Date(`${SLOGAN_YEAR}-05-28T23:59:59+09:00`);
+const SLOGAN_YEAR = sloganStartDate.getFullYear();
 
 const SloganSecondSection = () => {
   const router = useRouter();
@@ -20,7 +18,7 @@ const SloganSecondSection = () => {
   React.useEffect(() => {
     const checkPeriod = () => {
       const now = new Date();
-      setIsSloganPeriod(now >= SLOGAN_START && now <= SLOGAN_END);
+      setIsSloganPeriod(now >= sloganStartDate && now <= sloganEndDate);
     };
 
     checkPeriod();
@@ -30,8 +28,8 @@ const SloganSecondSection = () => {
   }, []);
 
   const submissionPeriodText = React.useMemo(() => {
-    const startText = formatDate(SLOGAN_START);
-    const endText = formatDate(SLOGAN_END);
+    const startText = formatDate(sloganStartDate);
+    const endText = formatDate(sloganEndDate);
     return `공모기간 : ${SLOGAN_YEAR}.${startText}~${endText} 24:00까지`;
   }, []);
 


### PR DESCRIPTION
## 💡 PR 요약
슬로건 페이지 오픈 및 공모 시작일 수정

## 📋 작업 내용
- /slogan 강제 리다이렉트(/home) 제거
- publicPages에 /slogan 추가 (비로그인 접근 허용)
- [빈 응답 본문 처리 및 백엔드 status 코드 전달](https://github.com/School-of-Company/Gwangju-talent-festival-Client/commit/37083bb500b4e303296e2b83ed2dc92c2bc0ad0e)
- [요청 필드명을 서버 스펙에 맞게 매핑](https://github.com/School-of-Company/Gwangju-talent-festival-Client/commit/2413220dd733945d89953dabe1dc708f1e2a73ab)