### PR TITLE
refactor: 로그인 페이지 로고 및 링크 색상 orange로 변경

### DIFF
--- a/src/views/signin/ui/SigninPage/index.tsx
+++ b/src/views/signin/ui/SigninPage/index.tsx
@@ -10,7 +10,7 @@ const SigninPage = () => {
       <div className={cn("w-full max-w-md flex flex-col items-center")}>
         <div className={cn("mb-20 mobile:mb-0")}>
           <Logo
-            color={colors.main[600]}
+            color={colors.orange[500]}
             width={200}
             height={200}
             className="mobile:w-[150px] mobile:h-[100px]"
@@ -19,7 +19,7 @@ const SigninPage = () => {
         <SigninFormContainer />
         <p className="text-body2r mt-28 text-gray-500 mobile:text-caption1r mobile:mt-10 ">
           저희 사이트에 처음 방문하셨나요?{" "}
-          <Link href="/signup" className="text-main-600 hover:underline">
+          <Link href="/signup" className="text-orange-500 hover:underline">
             회원가입 하러가기
           </Link>
         </p>


### PR DESCRIPTION
## 💡 PR 요약

- 로그인 페이지 광탈페 로고 색상 변경 (`main[600]` → `orange[500]`)
- 회원가입 링크 색상 변경 (`text-main-600` → `text-orange-500`)

## 📋 작업 내용

`src/views/signin/ui/SigninPage/index.tsx`
- Logo `color` prop: `colors.main[600]` → `colors.orange[500]`
- 회원가입 링크 클래스: `text-main-600` → `text-orange-500`