### PR TITLE
refactor: 회원가입 페이지 로고 색상 변경 및 전화번호 label 통일

### DIFF
--- a/src/views/signup/ui/SignupPage/index.tsx
+++ b/src/views/signup/ui/SignupPage/index.tsx
@@ -10,7 +10,7 @@ const SignupPage = () => {
       <div className={cn("w-full max-w-md flex flex-col items-center")}>
         <div className={cn("mb-20 mobile:mb-0")}>
           <Logo
-            color={colors.main[600]}
+            color={colors.orange[500]}
             width={200}
             height={200}
             className="mobile:w-[150px] mobile:h-[100px]"

--- a/src/views/signup/ui/SignupPage/index.tsx
+++ b/src/views/signup/ui/SignupPage/index.tsx
@@ -19,7 +19,7 @@ const SignupPage = () => {
         <SignupFormContainer />
         <p className="text-body2r mt-28 text-gray-500 mobile:text-caption1r mobile:mt-10 ">
           이미 회원가입을 하셨나요?{" "}
-          <Link href="/signin" className="text-main-600 hover:underline">
+          <Link href="/signin" className="text-orange-500 hover:underline">
             로그인 하러가기
           </Link>
         </p>

--- a/src/widgets/signup/ui/SignupFormContainer/index.tsx
+++ b/src/widgets/signup/ui/SignupFormContainer/index.tsx
@@ -78,7 +78,7 @@ const SignupFormContainer = () => {
         <input type="hidden" name="formType" value="signup" />
         <div className={cn("space-y-16")}>
           <div className={cn("flex flex-col gap-2")}>
-            <label className={cn("text-sm font-medium")}>전화번호</label>
+            <label className={cn("text-body3b")}>전화번호</label>
             <div className={cn("flex items-end gap-8")}>
               <div className={cn("w-full")}>
                 <Input


### PR DESCRIPTION
## 💡 PR 요약

- 회원가입 페이지 광탈페 로고 색상 변경 (`main[600]` → `orange[500]`)
- 전화번호 label 폰트 클래스 다른 필드와 통일

## 📋 작업 내용

**`src/views/signup/ui/SignupPage/index.tsx`**
- Logo `color` prop: `colors.main[600]` → `colors.orange[500]`

**`src/widgets/signup/ui/SignupFormContainer/index.tsx`**
- 전화번호 label: `text-sm font-medium` → `text-body3b` (인증번호·비밀번호 등 다른 label과 통일)