### PR TITLE
test: auth 관련 유닛 테스트 추가

### DIFF
--- a/.claude/commands/write-test.md
+++ b/.claude/commands/write-test.md
@@ -1,0 +1,72 @@
+Write unit tests for the specified file or feature: $ARGUMENTS
+
+## Project Testing Context
+
+- **Framework**: Vitest + React Testing Library
+- **Coverage**: `@vitest/coverage-istanbul`
+- **Setup file**: `vitest.setup.ts` (`@testing-library/jest-dom` 자동 적용)
+- **Path alias**: `@/` maps to `src/`
+- **Run tests**: `npm run test:run src/path/to/file.test.ts`
+- **Run all**: `npm run test:run`
+- **Coverage**: `npm run test:coverage`
+
+## Instructions
+
+1. **Read the target file first** before writing any tests. Understand what it actually does.
+
+2. **Follow existing test patterns** — check nearby `__tests__/` files for conventions used in this codebase.
+
+3. **Test structure**:
+   - Place test file in `__tests__/` directory next to the source file
+   - `foo.ts` → `__tests__/foo.test.ts`
+   - Group with `describe`, name cases with `it`
+   - Import `describe`, `it`, `expect`, `vi`, `beforeEach`, `afterEach` from `vitest` (globals: false)
+
+4. **Mocking**:
+   - API 함수: `vi.mock("@/entities/.../api/...")`
+   - 외부 라이브러리: `vi.mock("sonner")`, `vi.mock("next/navigation")` 등
+   - `vi.mocked(fn)`으로 타입 안전하게 사용
+   - 각 테스트 전 `vi.clearAllMocks()` 호출
+
+5. **React components**: `render`, `screen`, `userEvent` from `@testing-library/react`
+   ```ts
+   import { render, screen } from "@testing-library/react";
+   import userEvent from "@testing-library/user-event";
+   ```
+
+6. **Next.js middleware**: `NextRequest`를 직접 생성해서 테스트
+   ```ts
+   import { NextRequest } from "next/server";
+   new NextRequest(new URL("/path", "http://localhost"), {
+     headers: { Cookie: "accessToken=abc; refreshToken=xyz" },
+   });
+   ```
+
+7. **Date-dependent logic**: `vi.setSystemTime(new Date(...))` + `vi.useRealTimers()`
+
+8. **cookies (jsdom)**: `document.cookie`로 직접 설정/초기화
+   ```ts
+   beforeEach(() => {
+     document.cookie.split(";").forEach(c => {
+       const name = c.split("=")[0].trim();
+       if (name) document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+     });
+   });
+   ```
+
+9. **What to test**:
+   - Happy path (정상 동작)
+   - Error states (API 실패, 유효성 오류)
+   - Edge cases (오픈 리다이렉트 방지, 권한 분기 등)
+   - User interactions (UI 컴포넌트)
+
+10. **What NOT to test**:
+    - 구현 세부사항 (내부 상태, private 메서드)
+    - 서드파티 라이브러리 내부 동작
+    - 단순 pass-through 코드
+
+11. After writing, run the tests to confirm they pass:
+    ```bash
+    npm run test:run src/path/to/__tests__/file.test.ts
+    ```
+    Fix any failures before finishing.

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { middleware } from "../middleware";
+
+vi.mock("@/shared/config/authConfig", () => ({
+  publicPages: ["/home", "/signin", "/signup", "/admin", "/vote", "/slogan"],
+  publicIn18: ["/booking"],
+  publicIn27: ["/vote"],
+  ticketOpenDate: new Date("2025-09-18T20:00:00"),
+  performerTicketOpenDate: new Date("2025-09-15T20:00:00"),
+  festivalDate: new Date("2025-09-27T00:00:00"),
+  sloganStartDate: new Date("2026-05-18T00:00:00+09:00"),
+  sloganEndDate: new Date("2026-05-28T23:59:59+09:00"),
+}));
+
+function makeRequest(path: string, cookies: Record<string, string> = {}) {
+  const cookieHeader = Object.entries(cookies)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("; ");
+
+  return new NextRequest(new URL(path, "http://localhost"), {
+    headers: cookieHeader ? { Cookie: cookieHeader } : {},
+  });
+}
+
+function getLocation(res: Response) {
+  return res.headers.get("location");
+}
+
+describe("middleware - 라우팅 보호", () => {
+  it("토큰 없이 보호된 경로 접근 시 /signin으로 리다이렉트한다", () => {
+    const res = middleware(makeRequest("/my-page"));
+    expect(res.status).toBe(307);
+    expect(getLocation(res)).toContain("/signin");
+  });
+
+  it("리다이렉트 URL에 next 파라미터가 포함된다", () => {
+    const res = middleware(makeRequest("/my-page"));
+    expect(getLocation(res)).toContain("next=%2Fmy-page");
+  });
+
+  it("토큰이 있으면 보호된 경로를 통과시킨다", () => {
+    const res = middleware(makeRequest("/my-page", { accessToken: "abc", refreshToken: "xyz" }));
+    expect(res.status).toBe(200);
+  });
+
+  it("/home은 토큰 없이 접근 가능하다", () => {
+    expect(middleware(makeRequest("/home")).status).toBe(200);
+  });
+
+  it("/signin은 토큰 없이 접근 가능하다", () => {
+    expect(middleware(makeRequest("/signin")).status).toBe(200);
+  });
+});
+
+describe("middleware - /signin 리다이렉트", () => {
+  it("로그인 상태에서 /signin 접근 시 /home으로 리다이렉트한다", () => {
+    const res = middleware(makeRequest("/signin", { accessToken: "abc", refreshToken: "xyz" }));
+    expect(res.status).toBe(307);
+    expect(getLocation(res)).toContain("/home");
+  });
+
+  it("올바른 next 파라미터가 있으면 해당 경로로 리다이렉트한다", () => {
+    const res = middleware(
+      makeRequest("/signin?next=%2Fvote", { accessToken: "abc", refreshToken: "xyz" }),
+    );
+    expect(getLocation(res)).toContain("/vote");
+  });
+
+  it("오픈 리다이렉트 방지: next가 /signin이면 /home으로 이동한다", () => {
+    const res = middleware(
+      makeRequest("/signin?next=%2Fsignin", { accessToken: "abc", refreshToken: "xyz" }),
+    );
+    expect(getLocation(res)).toContain("/home");
+  });
+
+  it("오픈 리다이렉트 방지: next가 외부 URL이면 /home으로 이동한다", () => {
+    const res = middleware(
+      makeRequest("/signin?next=https%3A%2F%2Fevil.com", { accessToken: "abc", refreshToken: "xyz" }),
+    );
+    expect(getLocation(res)).toContain("/home");
+  });
+});
+
+describe("middleware - 어드민 접근 제어", () => {
+  it("ROLE_ADMIN이 아니면 /admin 접근 시 /home으로 리다이렉트한다", () => {
+    const res = middleware(
+      makeRequest("/admin/dashboard", { accessToken: "abc", refreshToken: "xyz", role: "ROLE_USER" }),
+    );
+    expect(res.status).toBe(307);
+    expect(getLocation(res)).toContain("/home");
+  });
+
+  it("ROLE_ADMIN이면 /admin 접근이 허용된다", () => {
+    const res = middleware(
+      makeRequest("/admin/dashboard", { accessToken: "abc", refreshToken: "xyz", role: "ROLE_ADMIN" }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("/admin/lottery/:id는 비어드민도 접근 가능하다", () => {
+    const res = middleware(
+      makeRequest("/admin/lottery/123", { accessToken: "abc", refreshToken: "xyz", role: "ROLE_USER" }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("/admin/score/:id는 비어드민도 접근 가능하다", () => {
+    const res = middleware(
+      makeRequest("/admin/score/456", { accessToken: "abc", refreshToken: "xyz", role: "ROLE_USER" }),
+    );
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("middleware - 슬로건 게이트", () => {
+  it("슬로건 기간 이전에는 /slogan 접근 시 /home으로 리다이렉트한다", () => {
+    vi.setSystemTime(new Date("2026-04-01T00:00:00"));
+    const res = middleware(makeRequest("/slogan", { accessToken: "abc", refreshToken: "xyz" }));
+    expect(res.status).toBe(307);
+    expect(getLocation(res)).toContain("/home");
+    vi.useRealTimers();
+  });
+
+  it("슬로건 기간 내에는 /slogan 접근이 허용된다", () => {
+    vi.setSystemTime(new Date("2026-05-20T00:00:00"));
+    const res = middleware(makeRequest("/slogan", { accessToken: "abc", refreshToken: "xyz" }));
+    expect(res.status).toBe(200);
+    vi.useRealTimers();
+  });
+
+  it("슬로건 기간 이후에는 /slogan 접근 시 /home으로 리다이렉트한다", () => {
+    vi.setSystemTime(new Date("2026-06-01T00:00:00"));
+    const res = middleware(makeRequest("/slogan", { accessToken: "abc", refreshToken: "xyz" }));
+    expect(res.status).toBe(307);
+    expect(getLocation(res)).toContain("/home");
+    vi.useRealTimers();
+  });
+});

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -113,6 +113,31 @@ describe("middleware - 어드민 접근 제어", () => {
   });
 });
 
+describe("middleware - publicIn27 (축제 날짜 접근 제한)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("축제 이전에는 비어드민의 /vote 접근을 /home으로 리다이렉트한다", () => {
+    vi.setSystemTime(new Date("2025-09-20T00:00:00"));
+    const res = middleware(makeRequest("/vote", { role: "ROLE_USER" }));
+    expect(res.status).toBe(307);
+    expect(getLocation(res)).toContain("/home");
+  });
+
+  it("축제 이후에는 비어드민도 /vote 접근이 허용된다", () => {
+    vi.setSystemTime(new Date("2025-09-28T00:00:00"));
+    const res = middleware(makeRequest("/vote", { role: "ROLE_USER" }));
+    expect(res.status).toBe(200);
+  });
+
+  it("어드민은 축제 이전에도 /vote 접근이 허용된다", () => {
+    vi.setSystemTime(new Date("2025-09-20T00:00:00"));
+    const res = middleware(makeRequest("/vote", { accessToken: "abc", refreshToken: "xyz", role: "ROLE_ADMIN" }));
+    expect(res.status).toBe(200);
+  });
+});
+
 describe("middleware - 슬로건 게이트", () => {
   afterEach(() => {
     vi.useRealTimers();

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 import { middleware } from "../middleware";
 
@@ -114,19 +114,21 @@ describe("middleware - 어드민 접근 제어", () => {
 });
 
 describe("middleware - 슬로건 게이트", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("슬로건 기간 이전에는 /slogan 접근 시 /home으로 리다이렉트한다", () => {
     vi.setSystemTime(new Date("2026-04-01T00:00:00"));
     const res = middleware(makeRequest("/slogan", { accessToken: "abc", refreshToken: "xyz" }));
     expect(res.status).toBe(307);
     expect(getLocation(res)).toContain("/home");
-    vi.useRealTimers();
   });
 
   it("슬로건 기간 내에는 /slogan 접근이 허용된다", () => {
     vi.setSystemTime(new Date("2026-05-20T00:00:00"));
     const res = middleware(makeRequest("/slogan", { accessToken: "abc", refreshToken: "xyz" }));
     expect(res.status).toBe(200);
-    vi.useRealTimers();
   });
 
   it("슬로건 기간 이후에는 /slogan 접근 시 /home으로 리다이렉트한다", () => {
@@ -134,6 +136,5 @@ describe("middleware - 슬로건 게이트", () => {
     const res = middleware(makeRequest("/slogan", { accessToken: "abc", refreshToken: "xyz" }));
     expect(res.status).toBe(307);
     expect(getLocation(res)).toContain("/home");
-    vi.useRealTimers();
   });
 });

--- a/src/entities/user/model/__tests__/schema.test.ts
+++ b/src/entities/user/model/__tests__/schema.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import {
+  passwordSchema,
+  verificationCodeSchema,
+  signinSchema,
+  signUpSchema,
+} from "../schema";
+
+describe("passwordSchema", () => {
+  it("8자 이상 영문+숫자 포함이면 유효하다", () => {
+    expect(passwordSchema.safeParse("abc12345").success).toBe(true);
+  });
+
+  it("8자 미만이면 실패한다", () => {
+    const result = passwordSchema.safeParse("ab1234");
+    expect(result.success).toBe(false);
+    expect(result.error?.errors[0].message).toBe("비밀번호는 최소 8자 이상이어야 합니다.");
+  });
+
+  it("숫자가 없으면 실패한다", () => {
+    const result = passwordSchema.safeParse("abcdefgh");
+    expect(result.success).toBe(false);
+    expect(result.error?.errors[0].message).toBe("비밀번호는 영문과 숫자를 포함해야 합니다.");
+  });
+
+  it("영문이 없으면 실패한다", () => {
+    const result = passwordSchema.safeParse("12345678");
+    expect(result.success).toBe(false);
+    expect(result.error?.errors[0].message).toBe("비밀번호는 영문과 숫자를 포함해야 합니다.");
+  });
+});
+
+describe("verificationCodeSchema", () => {
+  it("6자리면 유효하다", () => {
+    expect(verificationCodeSchema.safeParse("123456").success).toBe(true);
+  });
+
+  it("빈 값이면 실패한다", () => {
+    const result = verificationCodeSchema.safeParse("");
+    expect(result.success).toBe(false);
+    expect(result.error?.errors[0].message).toBe("인증번호를 입력해주세요.");
+  });
+
+  it("6자리 미만이면 실패한다", () => {
+    const result = verificationCodeSchema.safeParse("12345");
+    expect(result.success).toBe(false);
+    expect(result.error?.errors[0].message).toBe("인증번호는 6자리여야 합니다.");
+  });
+
+  it("6자리 초과면 실패한다", () => {
+    const result = verificationCodeSchema.safeParse("1234567");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("signinSchema", () => {
+  it("올바른 전화번호와 비밀번호면 유효하다", () => {
+    expect(signinSchema.safeParse({ phoneNumber: "01012345678", password: "pass1234" }).success).toBe(true);
+  });
+
+  it("전화번호 형식이 잘못되면 실패한다", () => {
+    expect(signinSchema.safeParse({ phoneNumber: "010-1234-5678", password: "pass1234" }).success).toBe(false);
+  });
+
+  it("비밀번호가 짧으면 실패한다", () => {
+    expect(signinSchema.safeParse({ phoneNumber: "01012345678", password: "ab1" }).success).toBe(false);
+  });
+});
+
+describe("signUpSchema", () => {
+  it("모든 필드가 올바르면 유효하다", () => {
+    expect(
+      signUpSchema.safeParse({
+        phoneNumber: "01012345678",
+        verificationCode: "123456",
+        password: "pass1234",
+        passwordConfirm: "pass1234",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("인증코드가 없으면 실패한다", () => {
+    expect(
+      signUpSchema.safeParse({
+        phoneNumber: "01012345678",
+        verificationCode: "",
+        password: "pass1234",
+        passwordConfirm: "pass1234",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/src/entities/user/model/__tests__/schema.test.ts
+++ b/src/entities/user/model/__tests__/schema.test.ts
@@ -50,6 +50,7 @@ describe("verificationCodeSchema", () => {
   it("6자리 초과면 실패한다", () => {
     const result = verificationCodeSchema.safeParse("1234567");
     expect(result.success).toBe(false);
+    expect(result.error?.errors[0].message).toBe("인증번호는 6자리여야 합니다.");
   });
 });
 

--- a/src/shared/utils/__tests__/auth.test.ts
+++ b/src/shared/utils/__tests__/auth.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { setTokens, clearTokens, getTokenFromCookie, isLoggedIn } from "../auth";
+
+const FUTURE = new Date(Date.now() + 3_600_000).toISOString();
+
+function clearAllCookies() {
+  document.cookie.split(";").forEach(cookie => {
+    const name = cookie.split("=")[0].trim();
+    if (name) {
+      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+    }
+  });
+}
+
+describe("setTokens", () => {
+  beforeEach(clearAllCookies);
+
+  it("accessToken과 refreshToken을 쿠키에 저장한다", () => {
+    setTokens("access-abc", FUTURE, "refresh-xyz", FUTURE);
+    expect(getTokenFromCookie("accessToken")).toBe("access-abc");
+    expect(getTokenFromCookie("refreshToken")).toBe("refresh-xyz");
+  });
+});
+
+describe("clearTokens", () => {
+  beforeEach(clearAllCookies);
+
+  it("accessToken과 refreshToken 쿠키를 삭제한다", () => {
+    setTokens("access-abc", FUTURE, "refresh-xyz", FUTURE);
+    clearTokens();
+    expect(getTokenFromCookie("accessToken")).toBeNull();
+    expect(getTokenFromCookie("refreshToken")).toBeNull();
+  });
+});
+
+describe("getTokenFromCookie", () => {
+  beforeEach(clearAllCookies);
+
+  it("쿠키에 저장된 값을 반환한다", () => {
+    document.cookie = "myToken=hello123; path=/;";
+    expect(getTokenFromCookie("myToken")).toBe("hello123");
+  });
+
+  it("존재하지 않는 쿠키면 null을 반환한다", () => {
+    expect(getTokenFromCookie("nonExistent")).toBeNull();
+  });
+});
+
+describe("isLoggedIn", () => {
+  beforeEach(clearAllCookies);
+
+  it("accessToken과 refreshToken이 모두 있으면 true를 반환한다", () => {
+    setTokens("access-abc", FUTURE, "refresh-xyz", FUTURE);
+    expect(isLoggedIn()).toBe(true);
+  });
+
+  it("토큰이 하나도 없으면 false를 반환한다", () => {
+    expect(isLoggedIn()).toBe(false);
+  });
+
+  it("accessToken만 있으면 false를 반환한다", () => {
+    document.cookie = "accessToken=access-abc; path=/;";
+    expect(isLoggedIn()).toBe(false);
+  });
+
+  it("refreshToken만 있으면 false를 반환한다", () => {
+    document.cookie = "refreshToken=refresh-xyz; path=/;";
+    expect(isLoggedIn()).toBe(false);
+  });
+});

--- a/src/widgets/signin/lib/__tests__/handleSigninFormSubmit.test.ts
+++ b/src/widgets/signin/lib/__tests__/handleSigninFormSubmit.test.ts
@@ -34,9 +34,17 @@ function setLocationSearch(search: string) {
   });
 }
 
+function clearAllCookies() {
+  document.cookie.split(";").forEach(c => {
+    const name = c.split("=")[0].trim();
+    if (name) document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+  });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   setLocationSearch("");
+  clearAllCookies();
 });
 
 describe("handleSigninFormSubmit - 유효성 검사", () => {
@@ -61,7 +69,7 @@ describe("handleSigninFormSubmit - 유효성 검사", () => {
 });
 
 describe("handleSigninFormSubmit - 로그인 성공", () => {
-  it("setTokens를 올바른 인자로 호출한다", async () => {
+  it("setTokens를 올바른 인자로 호출하고 role 쿠키를 저장한다", async () => {
     mockSignin.mockResolvedValue(MOCK_RESPONSE);
     await handleSigninFormSubmit(
       INITIAL_STATE,
@@ -73,6 +81,7 @@ describe("handleSigninFormSubmit - 로그인 성공", () => {
       MOCK_RESPONSE.refresh_token,
       MOCK_RESPONSE.refresh_token_expired_at,
     );
+    expect(document.cookie).toContain(`role=${MOCK_RESPONSE.role}`);
   });
 
   it("next 파라미터 없으면 /home으로 리다이렉트한다", async () => {

--- a/src/widgets/signin/lib/__tests__/handleSigninFormSubmit.test.ts
+++ b/src/widgets/signin/lib/__tests__/handleSigninFormSubmit.test.ts
@@ -26,13 +26,17 @@ function makeFormData(data: Record<string, string>) {
   return fd;
 }
 
-beforeEach(() => {
-  vi.clearAllMocks();
+function setLocationSearch(search: string) {
   Object.defineProperty(window, "location", {
-    value: { search: "" },
+    value: { search },
     writable: true,
     configurable: true,
   });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setLocationSearch("");
 });
 
 describe("handleSigninFormSubmit - 유효성 검사", () => {
@@ -83,11 +87,7 @@ describe("handleSigninFormSubmit - 로그인 성공", () => {
 
   it("올바른 next 파라미터가 있으면 해당 경로로 리다이렉트한다", async () => {
     mockSignin.mockResolvedValue(MOCK_RESPONSE);
-    Object.defineProperty(window, "location", {
-      value: { search: "?next=/vote" },
-      writable: true,
-      configurable: true,
-    });
+    setLocationSearch("?next=/vote");
     const result = await handleSigninFormSubmit(
       INITIAL_STATE,
       makeFormData({ phoneNumber: "01012345678", password: "pass1234" }),
@@ -97,11 +97,7 @@ describe("handleSigninFormSubmit - 로그인 성공", () => {
 
   it("오픈 리다이렉트 방지: next가 /signin이면 /home으로 리다이렉트한다", async () => {
     mockSignin.mockResolvedValue(MOCK_RESPONSE);
-    Object.defineProperty(window, "location", {
-      value: { search: "?next=/signin" },
-      writable: true,
-      configurable: true,
-    });
+    setLocationSearch("?next=/signin");
     const result = await handleSigninFormSubmit(
       INITIAL_STATE,
       makeFormData({ phoneNumber: "01012345678", password: "pass1234" }),
@@ -111,11 +107,7 @@ describe("handleSigninFormSubmit - 로그인 성공", () => {
 
   it("오픈 리다이렉트 방지: next가 외부 URL이면 /home으로 리다이렉트한다", async () => {
     mockSignin.mockResolvedValue(MOCK_RESPONSE);
-    Object.defineProperty(window, "location", {
-      value: { search: "?next=https://evil.com" },
-      writable: true,
-      configurable: true,
-    });
+    setLocationSearch("?next=https://evil.com");
     const result = await handleSigninFormSubmit(
       INITIAL_STATE,
       makeFormData({ phoneNumber: "01012345678", password: "pass1234" }),

--- a/src/widgets/signin/lib/__tests__/handleSigninFormSubmit.test.ts
+++ b/src/widgets/signin/lib/__tests__/handleSigninFormSubmit.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { handleSigninFormSubmit } from "../handleSigninFormSubmit";
+
+vi.mock("@/entities/user/api/signin", () => ({ signin: vi.fn() }));
+vi.mock("@/shared/utils/auth", () => ({ setTokens: vi.fn() }));
+
+import { signin } from "@/entities/user/api/signin";
+import { setTokens } from "@/shared/utils/auth";
+
+const mockSignin = vi.mocked(signin);
+const mockSetTokens = vi.mocked(setTokens);
+
+const MOCK_RESPONSE = {
+  access_token: "access-abc",
+  access_token_expired_at: new Date(Date.now() + 3_600_000).toISOString(),
+  refresh_token: "refresh-xyz",
+  refresh_token_expired_at: new Date(Date.now() + 86_400_000).toISOString(),
+  role: "ROLE_USER" as const,
+};
+
+const INITIAL_STATE = { values: {}, isValid: false, submitted: false };
+
+function makeFormData(data: Record<string, string>) {
+  const fd = new FormData();
+  Object.entries(data).forEach(([k, v]) => fd.append(k, v));
+  return fd;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(window, "location", {
+    value: { search: "" },
+    writable: true,
+    configurable: true,
+  });
+});
+
+describe("handleSigninFormSubmit - 유효성 검사", () => {
+  it("전화번호 형식이 잘못되면 API를 호출하지 않고 isValid: false를 반환한다", async () => {
+    const result = await handleSigninFormSubmit(
+      INITIAL_STATE,
+      makeFormData({ phoneNumber: "010-1234-5678", password: "pass1234" }),
+    );
+    expect(result.isValid).toBe(false);
+    expect(result.submitted).toBe(true);
+    expect(mockSignin).not.toHaveBeenCalled();
+  });
+
+  it("비밀번호가 짧으면 API를 호출하지 않고 isValid: false를 반환한다", async () => {
+    const result = await handleSigninFormSubmit(
+      INITIAL_STATE,
+      makeFormData({ phoneNumber: "01012345678", password: "ab1" }),
+    );
+    expect(result.isValid).toBe(false);
+    expect(mockSignin).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleSigninFormSubmit - 로그인 성공", () => {
+  it("setTokens를 올바른 인자로 호출한다", async () => {
+    mockSignin.mockResolvedValue(MOCK_RESPONSE);
+    await handleSigninFormSubmit(
+      INITIAL_STATE,
+      makeFormData({ phoneNumber: "01012345678", password: "pass1234" }),
+    );
+    expect(mockSetTokens).toHaveBeenCalledWith(
+      MOCK_RESPONSE.access_token,
+      MOCK_RESPONSE.access_token_expired_at,
+      MOCK_RESPONSE.refresh_token,
+      MOCK_RESPONSE.refresh_token_expired_at,
+    );
+  });
+
+  it("next 파라미터 없으면 /home으로 리다이렉트한다", async () => {
+    mockSignin.mockResolvedValue(MOCK_RESPONSE);
+    const result = await handleSigninFormSubmit(
+      INITIAL_STATE,
+      makeFormData({ phoneNumber: "01012345678", password: "pass1234" }),
+    );
+    expect(result.shouldRedirect).toBe(true);
+    expect(result.redirectTo).toBe("/home");
+  });
+
+  it("올바른 next 파라미터가 있으면 해당 경로로 리다이렉트한다", async () => {
+    mockSignin.mockResolvedValue(MOCK_RESPONSE);
+    Object.defineProperty(window, "location", {
+      value: { search: "?next=/vote" },
+      writable: true,
+      configurable: true,
+    });
+    const result = await handleSigninFormSubmit(
+      INITIAL_STATE,
+      makeFormData({ phoneNumber: "01012345678", password: "pass1234" }),
+    );
+    expect(result.redirectTo).toBe("/vote");
+  });
+
+  it("오픈 리다이렉트 방지: next가 /signin이면 /home으로 리다이렉트한다", async () => {
+    mockSignin.mockResolvedValue(MOCK_RESPONSE);
+    Object.defineProperty(window, "location", {
+      value: { search: "?next=/signin" },
+      writable: true,
+      configurable: true,
+    });
+    const result = await handleSigninFormSubmit(
+      INITIAL_STATE,
+      makeFormData({ phoneNumber: "01012345678", password: "pass1234" }),
+    );
+    expect(result.redirectTo).toBe("/home");
+  });
+
+  it("오픈 리다이렉트 방지: next가 외부 URL이면 /home으로 리다이렉트한다", async () => {
+    mockSignin.mockResolvedValue(MOCK_RESPONSE);
+    Object.defineProperty(window, "location", {
+      value: { search: "?next=https://evil.com" },
+      writable: true,
+      configurable: true,
+    });
+    const result = await handleSigninFormSubmit(
+      INITIAL_STATE,
+      makeFormData({ phoneNumber: "01012345678", password: "pass1234" }),
+    );
+    expect(result.redirectTo).toBe("/home");
+  });
+});
+
+describe("handleSigninFormSubmit - 로그인 실패", () => {
+  it("API 오류 시 isValid: false와 에러 메시지를 반환한다", async () => {
+    mockSignin.mockRejectedValue(new Error("아이디 또는 비밀번호가 올바르지 않습니다."));
+    const result = await handleSigninFormSubmit(
+      INITIAL_STATE,
+      makeFormData({ phoneNumber: "01012345678", password: "pass1234" }),
+    );
+    expect(result.isValid).toBe(false);
+    expect(result.error).toContain("아이디 또는 비밀번호가 올바르지 않습니다.");
+  });
+});

--- a/src/widgets/signup/lib/__tests__/handleSignupFormSubmit.test.ts
+++ b/src/widgets/signup/lib/__tests__/handleSignupFormSubmit.test.ts
@@ -37,6 +37,7 @@ describe("handleSignupFormSubmit - 유효성 검사", () => {
     );
     expect(result.isValid).toBe(false);
     expect(mockSignUp).not.toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalled();
   });
 
   it("인증코드가 6자리가 아니면 isValid: false를 반환한다", async () => {
@@ -46,6 +47,7 @@ describe("handleSignupFormSubmit - 유효성 검사", () => {
     );
     expect(result.isValid).toBe(false);
     expect(mockSignUp).not.toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalled();
   });
 
   it("비밀번호가 8자 미만이면 isValid: false를 반환한다", async () => {
@@ -55,6 +57,7 @@ describe("handleSignupFormSubmit - 유효성 검사", () => {
     );
     expect(result.isValid).toBe(false);
     expect(mockSignUp).not.toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalled();
   });
 });
 

--- a/src/widgets/signup/lib/__tests__/handleSignupFormSubmit.test.ts
+++ b/src/widgets/signup/lib/__tests__/handleSignupFormSubmit.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { handleSignupFormSubmit } from "../handleSignupFormSubmit";
+
+vi.mock("@/entities/user/api/signup", () => ({ signUp: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
+
+import { signUp } from "@/entities/user/api/signup";
+import { toast } from "sonner";
+
+const mockSignUp = vi.mocked(signUp);
+const mockToastError = vi.mocked(toast.error);
+
+const INITIAL_STATE = { values: {}, isValid: false, submitted: false };
+
+const VALID_FORM = {
+  phoneNumber: "01012345678",
+  verificationCode: "123456",
+  password: "pass1234",
+  passwordConfirm: "pass1234",
+};
+
+function makeFormData(data: Record<string, string>) {
+  const fd = new FormData();
+  Object.entries(data).forEach(([k, v]) => fd.append(k, v));
+  return fd;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("handleSignupFormSubmit - 유효성 검사", () => {
+  it("전화번호 형식이 잘못되면 API를 호출하지 않고 isValid: false를 반환한다", async () => {
+    const result = await handleSignupFormSubmit(
+      INITIAL_STATE,
+      makeFormData({ ...VALID_FORM, phoneNumber: "010-1234-5678" }),
+    );
+    expect(result.isValid).toBe(false);
+    expect(mockSignUp).not.toHaveBeenCalled();
+  });
+
+  it("인증코드가 6자리가 아니면 isValid: false를 반환한다", async () => {
+    const result = await handleSignupFormSubmit(
+      INITIAL_STATE,
+      makeFormData({ ...VALID_FORM, verificationCode: "12345" }),
+    );
+    expect(result.isValid).toBe(false);
+    expect(mockSignUp).not.toHaveBeenCalled();
+  });
+
+  it("비밀번호가 8자 미만이면 isValid: false를 반환한다", async () => {
+    const result = await handleSignupFormSubmit(
+      INITIAL_STATE,
+      makeFormData({ ...VALID_FORM, password: "ab1", passwordConfirm: "ab1" }),
+    );
+    expect(result.isValid).toBe(false);
+    expect(mockSignUp).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleSignupFormSubmit - 비밀번호 확인", () => {
+  it("비밀번호와 확인이 다르면 isValid: false와 에러 메시지를 반환한다", async () => {
+    const result = await handleSignupFormSubmit(
+      INITIAL_STATE,
+      makeFormData({ ...VALID_FORM, passwordConfirm: "different1" }),
+    );
+    expect(result.isValid).toBe(false);
+    expect(result.error).toBe("비밀번호가 일치하지 않습니다.");
+    expect(mockToastError).toHaveBeenCalledWith("비밀번호가 일치하지 않습니다.");
+    expect(mockSignUp).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleSignupFormSubmit - 회원가입 성공", () => {
+  it("/signin으로 리다이렉트한다", async () => {
+    mockSignUp.mockResolvedValue({ success: true, message: "가입 완료" });
+    const result = await handleSignupFormSubmit(INITIAL_STATE, makeFormData(VALID_FORM));
+    expect(result.isValid).toBe(true);
+    expect(result.shouldRedirect).toBe(true);
+    expect(result.redirectTo).toBe("/signin");
+  });
+
+  it("signUp API에 올바른 데이터를 전달한다", async () => {
+    mockSignUp.mockResolvedValue({ success: true, message: "가입 완료" });
+    await handleSignupFormSubmit(INITIAL_STATE, makeFormData(VALID_FORM));
+    expect(mockSignUp).toHaveBeenCalledWith({
+      phone_number: "01012345678",
+      code: "123456",
+      password: "pass1234",
+    });
+  });
+});
+
+describe("handleSignupFormSubmit - 회원가입 실패", () => {
+  it("API 오류 시 isValid: false와 에러 메시지를 반환한다", async () => {
+    mockSignUp.mockRejectedValue(new Error("이미 가입된 번호입니다."));
+    const result = await handleSignupFormSubmit(INITIAL_STATE, makeFormData(VALID_FORM));
+    expect(result.isValid).toBe(false);
+    expect(result.error).toBe("이미 가입된 번호입니다.");
+    expect(mockToastError).toHaveBeenCalledWith("이미 가입된 번호입니다.");
+  });
+
+  it("알 수 없는 오류면 기본 메시지를 반환한다", async () => {
+    mockSignUp.mockRejectedValue("unknown");
+    const result = await handleSignupFormSubmit(INITIAL_STATE, makeFormData(VALID_FORM));
+    expect(result.error).toBe("회원가입에 실패했습니다.");
+  });
+});


### PR DESCRIPTION
## 💡 PR 요약

auth 관련 핵심 로직에 대한 유닛 테스트를 추가합니다.

## 📋 테스트 목록

| 파일 | 테스트 내용 |
|------|------------|
| `src/entities/user/model/__tests__/schema.test.ts` | 전화번호 / 비밀번호 / 인증코드 유효성 |
| `src/shared/utils/__tests__/auth.test.ts` | 토큰 저장·삭제·조회, 로그인 상태 확인 |
| `src/__tests__/middleware.test.ts` | 라우팅 보호, 오픈 리다이렉트 방지, 어드민 접근, 슬로건 게이트 |
| `src/widgets/signin/lib/__tests__/handleSigninFormSubmit.test.ts` | 로그인 리다이렉트, 오픈 리다이렉트 방지 |
| `src/widgets/signup/lib/__tests__/handleSignupFormSubmit.test.ts` | 비밀번호 확인, 회원가입 성공/실패 |

## ✅ 테스트 결과

- 총 **61개 테스트** 전부 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)