### PR TITLE
test: slogan 관련 유닛 테스트코드 추가

### DIFF
--- a/src/entities/slogan/lib/__tests__/formReducer.test.ts
+++ b/src/entities/slogan/lib/__tests__/formReducer.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { formReducer, initialFormState, FormState } from "../formReducer";
+
+describe("formReducer - UPDATE_FIELD", () => {
+  it("slogan 필드를 업데이트한다", () => {
+    const next = formReducer(initialFormState, { type: "UPDATE_FIELD", field: "slogan", value: "광주인재" });
+    expect(next.formValues.slogan).toBe("광주인재");
+  });
+
+  it("grade 필드를 업데이트한다", () => {
+    const next = formReducer(initialFormState, { type: "UPDATE_FIELD", field: "grade", value: "3" });
+    expect(next.formValues.grade).toBe("3");
+  });
+
+  it("업데이트한 필드 외 나머지 필드는 변경되지 않는다", () => {
+    const next = formReducer(initialFormState, { type: "UPDATE_FIELD", field: "slogan", value: "광주" });
+    expect(next.formValues.description).toBe("");
+    expect(next.formValues.school).toBe("");
+  });
+});
+
+describe("formReducer - SET_SUBMITTING", () => {
+  it("isSubmitting을 true로 설정한다", () => {
+    const next = formReducer(initialFormState, { type: "SET_SUBMITTING", value: true });
+    expect(next.isSubmitting).toBe(true);
+  });
+
+  it("isSubmitting을 false로 설정한다", () => {
+    const state: FormState = { ...initialFormState, isSubmitting: true };
+    const next = formReducer(state, { type: "SET_SUBMITTING", value: false });
+    expect(next.isSubmitting).toBe(false);
+  });
+});
+
+describe("formReducer - SET_SUBMITTED", () => {
+  it("isSubmitted를 true로 설정한다", () => {
+    const next = formReducer(initialFormState, { type: "SET_SUBMITTED", value: true });
+    expect(next.isSubmitted).toBe(true);
+  });
+
+  it("isSubmitted를 false로 설정한다", () => {
+    const state: FormState = { ...initialFormState, isSubmitted: true };
+    const next = formReducer(state, { type: "SET_SUBMITTED", value: false });
+    expect(next.isSubmitted).toBe(false);
+  });
+});

--- a/src/entities/slogan/lib/__tests__/handleSloganFormSubmit.test.ts
+++ b/src/entities/slogan/lib/__tests__/handleSloganFormSubmit.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AxiosResponse } from "axios";
 import { handleSloganFormSubmit } from "../handleSloganFormSubmit";
 
 vi.mock("@/entities/slogan/api/postSlogan", () => ({ postSlogan: vi.fn() }));
@@ -27,16 +28,16 @@ beforeEach(() => {
 
 describe("handleSloganFormSubmit - 제출 성공", () => {
   it("status 200이면 toast.success를 호출하고 응답을 반환한다", async () => {
-    const res = { status: 200, data: {} };
-    mockPostSlogan.mockResolvedValue(res as any);
+    const res = { status: 200, data: {} } as AxiosResponse<unknown>;
+    mockPostSlogan.mockResolvedValue(res);
     const result = await handleSloganFormSubmit(VALID_VALUES);
     expect(mockSuccess).toHaveBeenCalledWith("슬로건이 제출되었습니다.");
     expect(result).toBe(res);
   });
 
   it("status 201이면 toast.success를 호출하고 응답을 반환한다", async () => {
-    const res = { status: 201, data: {} };
-    mockPostSlogan.mockResolvedValue(res as any);
+    const res = { status: 201, data: {} } as AxiosResponse<unknown>;
+    mockPostSlogan.mockResolvedValue(res);
     const result = await handleSloganFormSubmit(VALID_VALUES);
     expect(mockSuccess).toHaveBeenCalledWith("슬로건이 제출되었습니다.");
     expect(result).toBe(res);
@@ -51,13 +52,13 @@ describe("handleSloganFormSubmit - 제출 실패", () => {
   });
 
   it("비정상 상태코드(400)이면 toast.error를 호출한다", async () => {
-    mockPostSlogan.mockResolvedValue({ status: 400, data: {} } as any);
+    mockPostSlogan.mockResolvedValue({ status: 400, data: {} } as AxiosResponse<unknown>);
     await handleSloganFormSubmit(VALID_VALUES);
     expect(mockError).toHaveBeenCalledWith("슬로건 제출에 실패했습니다.");
   });
 
   it("비정상 상태코드(500)이면 toast.error를 호출한다", async () => {
-    mockPostSlogan.mockResolvedValue({ status: 500, data: {} } as any);
+    mockPostSlogan.mockResolvedValue({ status: 500, data: {} } as AxiosResponse<unknown>);
     await handleSloganFormSubmit(VALID_VALUES);
     expect(mockError).toHaveBeenCalledWith("슬로건 제출에 실패했습니다.");
   });

--- a/src/entities/slogan/lib/__tests__/handleSloganFormSubmit.test.ts
+++ b/src/entities/slogan/lib/__tests__/handleSloganFormSubmit.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { handleSloganFormSubmit } from "../handleSloganFormSubmit";
+
+vi.mock("@/entities/slogan/api/postSlogan", () => ({ postSlogan: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import { postSlogan } from "@/entities/slogan/api/postSlogan";
+import { toast } from "sonner";
+
+const mockPostSlogan = vi.mocked(postSlogan);
+const mockSuccess = vi.mocked(toast.success);
+const mockError = vi.mocked(toast.error);
+
+const VALID_VALUES = {
+  slogan: "광주인재페스티벌",
+  description: "슬로건 설명입니다.",
+  school: "광주고등학교",
+  name: "홍길동",
+  grade: "3",
+  classroom: "5",
+  phone_number: "01012345678",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("handleSloganFormSubmit - 제출 성공", () => {
+  it("status 200이면 toast.success를 호출하고 응답을 반환한다", async () => {
+    const res = { status: 200, data: {} };
+    mockPostSlogan.mockResolvedValue(res as any);
+    const result = await handleSloganFormSubmit(VALID_VALUES);
+    expect(mockSuccess).toHaveBeenCalledWith("슬로건이 제출되었습니다.");
+    expect(result).toBe(res);
+  });
+
+  it("status 201이면 toast.success를 호출하고 응답을 반환한다", async () => {
+    const res = { status: 201, data: {} };
+    mockPostSlogan.mockResolvedValue(res as any);
+    const result = await handleSloganFormSubmit(VALID_VALUES);
+    expect(mockSuccess).toHaveBeenCalledWith("슬로건이 제출되었습니다.");
+    expect(result).toBe(res);
+  });
+});
+
+describe("handleSloganFormSubmit - 제출 실패", () => {
+  it("API가 예외를 던지면 toast.error를 호출한다", async () => {
+    mockPostSlogan.mockRejectedValue(new Error("network error"));
+    await handleSloganFormSubmit(VALID_VALUES);
+    expect(mockError).toHaveBeenCalledWith("슬로건 제출에 실패했습니다.");
+  });
+
+  it("비정상 상태코드(400)이면 toast.error를 호출한다", async () => {
+    mockPostSlogan.mockResolvedValue({ status: 400, data: {} } as any);
+    await handleSloganFormSubmit(VALID_VALUES);
+    expect(mockError).toHaveBeenCalledWith("슬로건 제출에 실패했습니다.");
+  });
+
+  it("비정상 상태코드(500)이면 toast.error를 호출한다", async () => {
+    mockPostSlogan.mockResolvedValue({ status: 500, data: {} } as any);
+    await handleSloganFormSubmit(VALID_VALUES);
+    expect(mockError).toHaveBeenCalledWith("슬로건 제출에 실패했습니다.");
+  });
+});

--- a/src/entities/slogan/lib/handleSloganFormSubmit.ts
+++ b/src/entities/slogan/lib/handleSloganFormSubmit.ts
@@ -9,6 +9,7 @@ export async function handleSloganFormSubmit(values: SloganFormValues) {
       toast.success("슬로건이 제출되었습니다.");
       return res;
     }
+    toast.error("슬로건 제출에 실패했습니다.");
   } catch {
     toast.error("슬로건 제출에 실패했습니다.");
   }

--- a/src/entities/slogan/model/__tests__/schema.test.ts
+++ b/src/entities/slogan/model/__tests__/schema.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import {
+  sloganNameSchema,
+  sloganDescriptionSchema,
+  gradeSchema,
+  classroomSchema,
+  sloganSchema,
+} from "../schema";
+
+describe("sloganNameSchema", () => {
+  it("1자 이상이면 유효하다", () => {
+    expect(sloganNameSchema.safeParse("광주인재페스티벌").success).toBe(true);
+  });
+
+  it("빈 값이면 실패한다", () => {
+    const result = sloganNameSchema.safeParse("");
+    expect(result.success).toBe(false);
+    expect(result.error?.errors[0].message).toBe("슬로건을 입력해주세요.");
+  });
+
+  it("100자를 초과하면 실패한다", () => {
+    expect(sloganNameSchema.safeParse("a".repeat(101)).success).toBe(false);
+  });
+});
+
+describe("sloganDescriptionSchema", () => {
+  it("1자 이상이면 유효하다", () => {
+    expect(sloganDescriptionSchema.safeParse("슬로건 설명입니다.").success).toBe(true);
+  });
+
+  it("빈 값이면 실패한다", () => {
+    const result = sloganDescriptionSchema.safeParse("");
+    expect(result.success).toBe(false);
+    expect(result.error?.errors[0].message).toBe("슬로건 설명을 입력해주세요.");
+  });
+
+  it("1000자를 초과하면 실패한다", () => {
+    expect(sloganDescriptionSchema.safeParse("a".repeat(1001)).success).toBe(false);
+  });
+});
+
+describe("gradeSchema", () => {
+  it("숫자 문자열이면 유효하다", () => {
+    expect(gradeSchema.safeParse("3").success).toBe(true);
+  });
+
+  it("빈 값이면 실패한다", () => {
+    expect(gradeSchema.safeParse("").success).toBe(false);
+  });
+
+  it("숫자가 아닌 문자가 포함되면 실패한다", () => {
+    const result = gradeSchema.safeParse("3학년");
+    expect(result.success).toBe(false);
+    expect(result.error?.errors[0].message).toBe("학년은 숫자만 입력할 수 있습니다.");
+  });
+});
+
+describe("classroomSchema", () => {
+  it("숫자 문자열이면 유효하다", () => {
+    expect(classroomSchema.safeParse("5").success).toBe(true);
+  });
+
+  it("빈 값이면 실패한다", () => {
+    expect(classroomSchema.safeParse("").success).toBe(false);
+  });
+
+  it("숫자가 아닌 문자가 포함되면 실패한다", () => {
+    const result = classroomSchema.safeParse("5반");
+    expect(result.success).toBe(false);
+    expect(result.error?.errors[0].message).toBe("반은 숫자만 입력할 수 있습니다.");
+  });
+});
+
+describe("sloganSchema", () => {
+  const valid = {
+    slogan: "광주인재페스티벌",
+    description: "슬로건 설명입니다.",
+    school: "광주고등학교",
+    name: "홍길동",
+    grade: "3",
+    classroom: "5",
+    phone_number: "01012345678",
+  };
+
+  it("모든 필드가 올바르면 유효하다", () => {
+    expect(sloganSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("슬로건이 빈 값이면 실패한다", () => {
+    expect(sloganSchema.safeParse({ ...valid, slogan: "" }).success).toBe(false);
+  });
+
+  it("학년에 숫자가 아닌 값이 있으면 실패한다", () => {
+    expect(sloganSchema.safeParse({ ...valid, grade: "삼" }).success).toBe(false);
+  });
+
+  it("반에 숫자가 아닌 값이 있으면 실패한다", () => {
+    expect(sloganSchema.safeParse({ ...valid, classroom: "오" }).success).toBe(false);
+  });
+
+  it("전화번호 형식이 잘못되면 실패한다", () => {
+    expect(sloganSchema.safeParse({ ...valid, phone_number: "010-1234-5678" }).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## 💡 PR 요약

#176 

슬로건 제출 시 비정상 상태코드 응답에서 에러 토스트가 노출되지 않는 버그를 수정하고,
slogan 관련 핵심 로직(schema, formReducer, handleSloganFormSubmit)에 대한 단위 테스트를 추가합니다.

- `handleSloganFormSubmit` — 200/201 외 응답 시 `toast.error` 누락 수정
- `sloganSchema`, `gradeSchema`, `classroomSchema` 등 유효성 검증 테스트 추가
- `formReducer` 액션(UPDATE_FIELD, SET_SUBMITTING, SET_SUBMITTED) 테스트 추가
- `handleSloganFormSubmit` 제출 성공/실패/비정상 상태코드 테스트 추가

## 📋 작업 내용

**버그 수정**

`handleSloganFormSubmit`에서 API 응답 상태코드가 200/201이 아닌 경우(예: 400, 500)
`toast.error`가 호출되지 않는 문제가 있었습니다.
`if` 블록 이후에 `toast.error` 호출을 추가해 수정했습니다.

**테스트 추가 (총 29개)**

| 파일 | 테스트 수 |
|---|---|
| `src/entities/slogan/model/__tests__/schema.test.ts` | 14개 |
| `src/entities/slogan/lib/__tests__/formReducer.test.ts` | 7개 |
| `src/entities/slogan/lib/__tests__/handleSloganFormSubmit.test.ts` | 8개 |

## 🤝 리뷰 시 참고사항

- 비정상 상태코드(400, 500) 케이스는 axios interceptor가 아닌 함수 내부에서 처리하는 구조라,
  `catch` 외에 별도 분기가 필요했습니다.
- `handleSloganFormSubmit` 테스트에서 `toast`를 mock 처리했는데,
  sonner mock 방식(`vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }))`)이
  적절한지 리뷰 부탁드립니다.
