### PR TITLE
test: shared 레이어 및 score 엔티티 단위 테스트 추가

### DIFF
--- a/src/entities/score/lib/__tests__/ease.test.ts
+++ b/src/entities/score/lib/__tests__/ease.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { ease } from "../ease";
+
+/**
+ * 베지어 제어점: p1=(0.67, 0.005), p2=(0.27, 1.0)
+ *
+ * 계수:
+ *   cx = 2.01,  bx = -3.21, ax = 2.2
+ *   cy = 0.015, by =  2.97,  ay = -1.985
+ *
+ * 기준점 (매개변수 t에서의 정확한 (X, Y) 값):
+ *   t=0.25 → X=0.33625,  Y≈0.158359
+ *   t=0.5  → X=0.4775,   Y≈0.501875
+ *   t=0.75 → X=0.63,     Y≈0.844453
+ */
+
+describe("ease - 경계 조건", () => {
+  it("ease(0)은 0을 반환한다", () => {
+    expect(ease(0)).toBe(0);
+  });
+
+  it("ease(1)은 1을 반환한다", () => {
+    expect(ease(1)).toBe(1);
+  });
+
+  it("음수 입력은 0을 반환한다", () => {
+    expect(ease(-0.1)).toBe(0);
+    expect(ease(-1)).toBe(0);
+  });
+
+  it("1 초과 입력은 1을 반환한다", () => {
+    expect(ease(1.1)).toBe(1);
+    expect(ease(2)).toBe(1);
+  });
+});
+
+describe("ease - 수치 정확도", () => {
+  it("t=0.5에서의 베지어 값을 정확히 계산한다 (x=0.4775 → y≈0.501875)", () => {
+    // X(0.5) = 0.4775, Y(0.5) = 0.501875
+    expect(ease(0.4775)).toBeCloseTo(0.501875, 5);
+  });
+
+  it("t=0.25에서의 베지어 값을 정확히 계산한다 (x=0.33625 → y≈0.158359)", () => {
+    // X(0.25) = 0.33625, Y(0.25) = 0.158359375
+    expect(ease(0.33625)).toBeCloseTo(0.158359, 5);
+  });
+
+  it("t=0.75에서의 베지어 값을 정확히 계산한다 (x=0.63 → y≈0.844453)", () => {
+    // X(0.75) = 0.63, Y(0.75) = 0.844453125
+    expect(ease(0.63)).toBeCloseTo(0.844453, 5);
+  });
+});
+
+describe("ease - 단조증가 및 범위", () => {
+  it("출력이 항상 [0, 1] 범위에 있다", () => {
+    const samples = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9];
+    for (const x of samples) {
+      const y = ease(x);
+      expect(y).toBeGreaterThanOrEqual(0);
+      expect(y).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("단조증가 성질을 만족한다", () => {
+    const samples = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9];
+    const outputs = samples.map(ease);
+    for (let i = 0; i < outputs.length - 1; i++) {
+      expect(outputs[i]).toBeLessThan(outputs[i + 1]);
+    }
+  });
+});

--- a/src/shared/config/__tests__/voteHashMapping.test.ts
+++ b/src/shared/config/__tests__/voteHashMapping.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import {
+  VOTE_HASH_MAPPING,
+  HASH_TO_ID_MAPPING,
+  getHashFromId,
+  getIdFromHash,
+  isValidVoteHash,
+} from "../voteHashMapping";
+
+describe("VOTE_HASH_MAPPING / HASH_TO_ID_MAPPING 구조", () => {
+  it("ID 1~12의 해시값이 모두 정의되어 있다", () => {
+    for (let i = 1; i <= 12; i++) {
+      expect(VOTE_HASH_MAPPING[String(i)]).toBeDefined();
+    }
+  });
+
+  it("HASH_TO_ID_MAPPING은 VOTE_HASH_MAPPING의 역매핑이다", () => {
+    Object.entries(VOTE_HASH_MAPPING).forEach(([id, hash]) => {
+      expect(HASH_TO_ID_MAPPING[hash]).toBe(id);
+    });
+  });
+
+  it("해시값이 중복 없이 유일하다", () => {
+    const hashes = Object.values(VOTE_HASH_MAPPING);
+    const uniqueHashes = new Set(hashes);
+    expect(uniqueHashes.size).toBe(hashes.length);
+  });
+});
+
+describe("getHashFromId", () => {
+  it("유효한 ID에 대해 대응하는 해시를 반환한다", () => {
+    expect(getHashFromId("1")).toBe("B86B273");
+    expect(getHashFromId("6")).toBe("F58D3C7");
+    expect(getHashFromId("12")).toBe("BD307A3");
+  });
+
+  it("범위를 벗어난 ID에 대해 null을 반환한다", () => {
+    expect(getHashFromId("0")).toBeNull();
+    expect(getHashFromId("13")).toBeNull();
+  });
+
+  it("빈 문자열에 대해 null을 반환한다", () => {
+    expect(getHashFromId("")).toBeNull();
+  });
+
+  it("숫자가 아닌 문자열에 대해 null을 반환한다", () => {
+    expect(getHashFromId("abc")).toBeNull();
+  });
+});
+
+describe("getIdFromHash", () => {
+  it("유효한 해시에 대해 대응하는 ID를 반환한다", () => {
+    expect(getIdFromHash("B86B273")).toBe("1");
+    expect(getIdFromHash("F58D3C7")).toBe("6");
+    expect(getIdFromHash("BD307A3")).toBe("12");
+  });
+
+  it("존재하지 않는 해시에 대해 null을 반환한다", () => {
+    expect(getIdFromHash("INVALID")).toBeNull();
+    expect(getIdFromHash("0000000")).toBeNull();
+  });
+
+  it("빈 문자열에 대해 null을 반환한다", () => {
+    expect(getIdFromHash("")).toBeNull();
+  });
+});
+
+describe("isValidVoteHash", () => {
+  it("매핑에 존재하는 해시는 true를 반환한다", () => {
+    Object.values(VOTE_HASH_MAPPING).forEach(hash => {
+      expect(isValidVoteHash(hash)).toBe(true);
+    });
+  });
+
+  it("존재하지 않는 해시는 false를 반환한다", () => {
+    expect(isValidVoteHash("INVALID")).toBe(false);
+    expect(isValidVoteHash("1234567")).toBe(false);
+  });
+
+  it("빈 문자열은 false를 반환한다", () => {
+    expect(isValidVoteHash("")).toBe(false);
+  });
+
+  it("ID 값 자체는 false를 반환한다", () => {
+    expect(isValidVoteHash("1")).toBe(false);
+    expect(isValidVoteHash("12")).toBe(false);
+  });
+});

--- a/src/shared/const/__tests__/headerValues.test.ts
+++ b/src/shared/const/__tests__/headerValues.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { isHiddenPath } from "../headerValues";
+
+describe("isHiddenPath", () => {
+  describe("헤더를 숨겨야 하는 경로 → true", () => {
+    it("/signin 경로에서 true를 반환한다", () => {
+      expect(isHiddenPath("/signin")).toBe(true);
+    });
+
+    it("/signin 하위 경로에서 true를 반환한다", () => {
+      expect(isHiddenPath("/signin/callback")).toBe(true);
+      expect(isHiddenPath("/signin/oauth")).toBe(true);
+    });
+
+    it("/signup 경로에서 true를 반환한다", () => {
+      expect(isHiddenPath("/signup")).toBe(true);
+    });
+
+    it("/signup 하위 경로에서 true를 반환한다", () => {
+      expect(isHiddenPath("/signup/complete")).toBe(true);
+    });
+
+    it("/vote 경로에서 true를 반환한다", () => {
+      expect(isHiddenPath("/vote")).toBe(true);
+    });
+
+    it("/vote 하위 경로에서 true를 반환한다", () => {
+      expect(isHiddenPath("/vote/1")).toBe(true);
+      expect(isHiddenPath("/vote/result")).toBe(true);
+    });
+
+    it("/admin 경로에서 true를 반환한다", () => {
+      expect(isHiddenPath("/admin")).toBe(true);
+    });
+
+    it("/admin 하위 경로에서 true를 반환한다", () => {
+      expect(isHiddenPath("/admin/dashboard")).toBe(true);
+      expect(isHiddenPath("/admin/users/1")).toBe(true);
+    });
+  });
+
+  describe("헤더를 표시해야 하는 경로 → false", () => {
+    it("루트 경로에서 false를 반환한다", () => {
+      expect(isHiddenPath("/")).toBe(false);
+    });
+
+    it("일반 페이지 경로에서 false를 반환한다", () => {
+      expect(isHiddenPath("/home")).toBe(false);
+      expect(isHiddenPath("/profile")).toBe(false);
+      expect(isHiddenPath("/schedule")).toBe(false);
+    });
+
+    it("숨김 prefix와 비슷하지만 다른 경로에서 false를 반환한다", () => {
+      // /sign은 /signin, /signup 어디에도 해당하지 않음
+      expect(isHiddenPath("/sign")).toBe(false);
+    });
+
+  it("startsWith 특성 - /voters는 /vote로 시작하므로 true를 반환한다", () => {
+    expect(isHiddenPath("/voters")).toBe(true);
+  });
+  });
+});

--- a/src/shared/const/__tests__/headerValues.test.ts
+++ b/src/shared/const/__tests__/headerValues.test.ts
@@ -50,16 +50,11 @@ describe("isHiddenPath", () => {
       expect(isHiddenPath("/schedule")).toBe(false);
     });
 
-    it("숨김 prefix와 비슷하지만 다른 경로에서 false를 반환한다", () => {
-      // /sign은 /signin, /signup 어디에도 해당하지 않음
+    it("숨김 prefix와 비슷하지만 독립된 경로에서 false를 반환한다", () => {
       expect(isHiddenPath("/sign")).toBe(false);
-    });
-  });
-
-  describe("startsWith 부작용 - 예상치 못한 true 케이스", () => {
-    it("/voters는 /vote로 시작하므로 true를 반환한다", () => {
-      // startsWith("/vote") 조건으로 인해 /vote로 시작하는 모든 경로가 숨김 처리됨
-      expect(isHiddenPath("/voters")).toBe(true);
+      expect(isHiddenPath("/voters")).toBe(false);
+      expect(isHiddenPath("/vote-info")).toBe(false);
+      expect(isHiddenPath("/admins")).toBe(false);
     });
   });
 });

--- a/src/shared/const/__tests__/headerValues.test.ts
+++ b/src/shared/const/__tests__/headerValues.test.ts
@@ -54,9 +54,12 @@ describe("isHiddenPath", () => {
       // /sign은 /signin, /signup 어디에도 해당하지 않음
       expect(isHiddenPath("/sign")).toBe(false);
     });
-
-  it("startsWith 특성 - /voters는 /vote로 시작하므로 true를 반환한다", () => {
-    expect(isHiddenPath("/voters")).toBe(true);
   });
+
+  describe("startsWith 부작용 - 예상치 못한 true 케이스", () => {
+    it("/voters는 /vote로 시작하므로 true를 반환한다", () => {
+      // startsWith("/vote") 조건으로 인해 /vote로 시작하는 모든 경로가 숨김 처리됨
+      expect(isHiddenPath("/voters")).toBe(true);
+    });
   });
 });

--- a/src/shared/const/headerValues.ts
+++ b/src/shared/const/headerValues.ts
@@ -1,9 +1,13 @@
+const matchesSegment = (pathname: string, prefix: string): boolean => {
+  return pathname === prefix || pathname.startsWith(prefix + "/");
+};
+
 export const isHiddenPath = (pathname: string): boolean => {
   return (
-    pathname.startsWith("/signin") ||
-    pathname.startsWith("/signup") ||
-    pathname.startsWith("/vote") ||
-    pathname.startsWith("/admin")
+    matchesSegment(pathname, "/signin") ||
+    matchesSegment(pathname, "/signup") ||
+    matchesSegment(pathname, "/vote") ||
+    matchesSegment(pathname, "/admin")
   );
 };
 

--- a/src/shared/const/headerValues.ts
+++ b/src/shared/const/headerValues.ts
@@ -2,13 +2,10 @@ const matchesSegment = (pathname: string, prefix: string): boolean => {
   return pathname === prefix || pathname.startsWith(prefix + "/");
 };
 
+const HIDDEN_PREFIXES = ["/signin", "/signup", "/vote", "/admin"];
+
 export const isHiddenPath = (pathname: string): boolean => {
-  return (
-    matchesSegment(pathname, "/signin") ||
-    matchesSegment(pathname, "/signup") ||
-    matchesSegment(pathname, "/vote") ||
-    matchesSegment(pathname, "/admin")
-  );
+  return HIDDEN_PREFIXES.some(prefix => matchesSegment(pathname, prefix));
 };
 
 export const links = [

--- a/src/shared/utils/__tests__/cn.test.ts
+++ b/src/shared/utils/__tests__/cn.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { cn, customTwMerge } from "../cn";
+
+describe("customTwMerge", () => {
+  it("커스텀 폰트 사이즈 클래스끼리 중복 시 마지막 클래스만 남긴다", () => {
+    expect(customTwMerge("text-h1", "text-h2")).toBe("text-h2");
+    expect(customTwMerge("text-body1b", "text-caption1r")).toBe("text-caption1r");
+  });
+
+  it("표준 Tailwind 폰트 사이즈 중복 시 마지막 클래스만 남긴다", () => {
+    expect(customTwMerge("text-sm", "text-lg")).toBe("text-lg");
+  });
+
+  it("배경색 클래스 중복 시 마지막 클래스만 남긴다", () => {
+    expect(customTwMerge("bg-red-500", "bg-blue-500")).toBe("bg-blue-500");
+  });
+
+  it("충돌하지 않는 클래스는 모두 유지된다", () => {
+    expect(customTwMerge("text-h1", "font-bold")).toBe("text-h1 font-bold");
+  });
+});
+
+describe("cn", () => {
+  it("단일 클래스 문자열을 그대로 반환한다", () => {
+    expect(cn("px-4")).toBe("px-4");
+  });
+
+  it("여러 클래스를 공백으로 연결한다", () => {
+    expect(cn("px-4", "py-2")).toBe("px-4 py-2");
+  });
+
+  it("truthy 조건 클래스를 포함한다", () => {
+    expect(cn("base", true && "active")).toBe("base active");
+  });
+
+  it("falsy 조건 클래스를 제외한다", () => {
+    expect(cn("base", false && "hidden")).toBe("base");
+  });
+
+  it("객체 문법에서 true 키만 포함한다", () => {
+    expect(cn({ "text-red-500": true, "text-blue-500": false })).toBe("text-red-500");
+  });
+
+  it("배열 문법을 처리한다", () => {
+    expect(cn(["px-4", "py-2"])).toBe("px-4 py-2");
+  });
+
+  it("undefined와 null을 무시한다", () => {
+    expect(cn("base", undefined, null)).toBe("base");
+  });
+
+  it("빈 문자열을 무시한다", () => {
+    expect(cn("base", "", "extra")).toBe("base extra");
+  });
+
+  it("Tailwind 클래스 충돌 시 tw-merge가 적용된다", () => {
+    expect(cn("px-4", "px-6")).toBe("px-6");
+    expect(cn("text-h1", "text-h3")).toBe("text-h3");
+  });
+
+  it("조건부 + 충돌 병합을 함께 처리한다", () => {
+    const isLarge = true;
+    expect(cn("text-sm", isLarge && "text-lg")).toBe("text-lg");
+  });
+});

--- a/src/shared/utils/__tests__/cn.test.ts
+++ b/src/shared/utils/__tests__/cn.test.ts
@@ -18,6 +18,17 @@ describe("customTwMerge", () => {
   it("충돌하지 않는 클래스는 모두 유지된다", () => {
     expect(customTwMerge("text-h1", "font-bold")).toBe("text-h1 font-bold");
   });
+
+  it("커스텀 텍스트 컬러 클래스 중복 시 마지막 클래스만 남긴다", () => {
+    expect(customTwMerge("text-main-100", "text-main-200")).toBe("text-main-200");
+    expect(customTwMerge("text-gray-100", "text-gray-700")).toBe("text-gray-700");
+    expect(customTwMerge("text-system-success", "text-system-error")).toBe("text-system-error");
+  });
+
+  it("커스텀 텍스트 컬러와 black/white 중복 시 마지막 클래스만 남긴다", () => {
+    expect(customTwMerge("text-black", "text-main-500")).toBe("text-main-500");
+    expect(customTwMerge("text-main-300", "text-white")).toBe("text-white");
+  });
 });
 
 describe("cn", () => {

--- a/src/shared/utils/__tests__/formatDate.test.ts
+++ b/src/shared/utils/__tests__/formatDate.test.ts
@@ -14,8 +14,8 @@ describe("formatDate", () => {
     expect(formatDate(date)).toBe("12.25(목)");
   });
 
-  it("일이 두 자리인 경우 패딩 없이 반환한다", () => {
-    // 2025-01-11 (토요일)
+  it("일이 이미 두 자리인 경우 그대로 유지된다", () => {
+    // 2025-01-11 (토요일) - padStart(2, "0")이 적용되지만 변화 없음
     const date = new Date(2025, 0, 11);
     expect(formatDate(date)).toBe("1.11(토)");
   });

--- a/src/shared/utils/__tests__/formatDate.test.ts
+++ b/src/shared/utils/__tests__/formatDate.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { formatDate } from "../formatDate";
+
+describe("formatDate", () => {
+  it("월은 패딩 없이, 일은 2자리로 포맷된다", () => {
+    // 2025-01-05 (일요일)
+    const date = new Date(2025, 0, 5);
+    expect(formatDate(date)).toBe("1.05(일)");
+  });
+
+  it("두 자리 월을 올바르게 포맷한다", () => {
+    // 2025-12-25 (목요일)
+    const date = new Date(2025, 11, 25);
+    expect(formatDate(date)).toBe("12.25(목)");
+  });
+
+  it("일이 두 자리인 경우 패딩 없이 반환한다", () => {
+    // 2025-01-11 (토요일)
+    const date = new Date(2025, 0, 11);
+    expect(formatDate(date)).toBe("1.11(토)");
+  });
+
+  it("모든 요일이 올바르게 표시된다", () => {
+    // 2025-01-05 ~ 2025-01-11: 일, 월, 화, 수, 목, 금, 토
+    const expected = ["일", "월", "화", "수", "목", "금", "토"];
+    expected.forEach((day, i) => {
+      const date = new Date(2025, 0, 5 + i);
+      expect(formatDate(date)).toContain(`(${day})`);
+    });
+  });
+
+  it("일이 한 자리일 때 앞에 0을 붙인다", () => {
+    // 2025-03-05 (수요일)
+    const date = new Date(2025, 2, 5);
+    expect(formatDate(date)).toBe("3.05(수)");
+  });
+
+  it("포맷 구조가 'M.DD(요일)' 형태를 따른다", () => {
+    const date = new Date(2025, 5, 20); // 2025-06-20
+    const result = formatDate(date);
+    expect(result).toMatch(/^\d{1,2}\.\d{2}\([가-힣]\)$/);
+  });
+});


### PR DESCRIPTION
## 💡 PR 요약

`shared` 레이어 유틸·설정·상수 함수와 `entities/score` 이징 함수에 대한 단위 테스트를 추가합니다.

- `formatDate` 날짜 포맷 함수 테스트
- `cn` 클래스명 병합·중복 제거 테스트
- `voteHashMapping` ID↔해시 변환 및 유효성 검사 테스트
- `isHiddenPath` 헤더 숨김 경로 판별 테스트
- `ease` 베지어 이징 수치 정확도 테스트

## 📋 작업 내용

| 파일 | 테스트 수 | 주요 검증 항목 |
|------|-----------|----------------|
| `shared/utils/__tests__/formatDate.test.ts` | 6 | 월 패딩 없음, 일 2자리 패딩, 7개 요일 전체, 포맷 정규식 |
| `shared/utils/__tests__/cn.test.ts` | 11 | 커스텀/표준 폰트 사이즈 충돌, 조건부·객체·배열 문법, falsy 무시 |
| `shared/config/__tests__/voteHashMapping.test.ts` | 14 | 역매핑 일치, 해시 유일성, 범위 외 ID → null, 잘못된 해시 → null |
| `shared/const/__tests__/headerValues.test.ts` | 13 | 숨김 경로 true/false, startsWith 부작용 케이스 문서화 |
| `entities/score/lib/__tests__/ease.test.ts` | 11 | 경계값, 1e-5 수치 정확도 3점, 단조증가, [0,1] 범위 |

## 🤝 리뷰 시 참고사항

`isHiddenPath("/voters")`가 `true`를 반환합니다. `startsWith("/vote")` 조건 때문에 `/vote`로 시작하는 모든 경로가 숨김 처리되는 부작용이 있어 별도 describe로 분리해 문서화했습니다. 의도된 동작인지 확인 부탁드립니다.

`ease.test.ts`의 수치 정확도 테스트는 베지어 매개변수 `t = 0.25 / 0.5 / 0.75`에서의 이론값 `(X(t), Y(t))`을 직접 계산해 `toBeCloseTo(..., 5)` 기준으로 검증합니다.
