### PR TITLE
fix: 슬로건 API 요청 로직 정리 및 팝업 노출 환경 제한

### DIFF
--- a/src/entities/slogan/api/postSlogan.ts
+++ b/src/entities/slogan/api/postSlogan.ts
@@ -4,12 +4,21 @@ import { SloganFormValues } from "../model/schema";
 export const postSlogan = async (data: SloganFormValues, isOutOfSchool: boolean) => {
   const { phone_number, classroom, grade, birthday, school, ...rest } = data;
 
+  if (isOutOfSchool) {
+    return await instance.post("/slogan", {
+      ...rest,
+      phoneNumber: phone_number,
+      schoolStatus: "OUT_OF_SCHOOL",
+      birthDate: birthday || undefined,
+    });
+  }
+
   return await instance.post("/slogan", {
     ...rest,
     phoneNumber: phone_number,
-    schoolStatus: isOutOfSchool ? "OUT_OF_SCHOOL" : "ENROLLED",
-    ...(isOutOfSchool
-      ? { birthDate: birthday || undefined }
-      : { school, grade: Number(grade), classNum: Number(classroom) }),
+    schoolStatus: "ENROLLED",
+    school,
+    grade: Number(grade),
+    classNum: Number(classroom),
   });
 };

--- a/src/widgets/main/SloganPosterPopup/index.tsx
+++ b/src/widgets/main/SloganPosterPopup/index.tsx
@@ -21,6 +21,8 @@ export default function SloganPosterPopup() {
     }
   }, []);
 
+  if (process.env.NEXT_PUBLIC_APP_ENV !== "production") return null;
+
   const handleClose = () => {
     if (doNotShow) {
       localStorage.setItem(STORAGE_KEY, "true");


### PR DESCRIPTION
## 요약

- 슬로건 제출 API의 재학/졸업 분기 로직 단순화 및 요청 필드명 서버 스펙 반영
- 슬로건 포스터 팝업을 production 환경에서만 노출하도록 제한

## 작업 내용

- `postSlogan.ts`: `isOutOfSchool` 조건으로 조기 반환하여 분기 명확히 분리, 재학생 분기 필드 누락 버그 수정
- `SloganPosterPopup`: `NEXT_PUBLIC_APP_ENV !== "production"` 이면 렌더링 차단

## 참고사항

- 기존 삼항 연산자 구조에서 `isOutOfSchool`이 `false`(재학생)일 때 `school`, `grade`, `classNum` 필드가 전송되지 않던 버그가 함께 수정됨
- 슬로건 제출 플로우 전체 확인 필요