### PR TITLE
refactor: 슬로건 폼 기간 검사 통합 및 유효성 검사 개선

### DIFF
--- a/src/app/api/server/[...path]/route.ts
+++ b/src/app/api/server/[...path]/route.ts
@@ -33,23 +33,13 @@ async function handleRequest(request: NextRequest): Promise<NextResponse> {
 
     const response = await fetch(url, options);
 
-    // TODO: 테스트용 — 슬로건 기간 제한 우회 (테스트 완료 후 아래 블록 제거)
-    if (path === "slogan" && method === "POST") {
-      return NextResponse.json({ message: "슬로건이 제출되었습니다." }, { status: 201 });
-    }
-    // 기존 코드
-    // const contentLength = response.headers.get("content-length");
-    // const hasBody = contentLength !== "0" && response.status !== 204;
-    // const data = hasBody ? await response.json().catch(() => null) : null;
-    // return NextResponse.json(data, { status: response.status });
-
     const contentLength = response.headers.get("content-length");
     const hasBody = contentLength !== "0" && response.status !== 204;
     const data = hasBody ? await response.json().catch(() => null) : null;
     return NextResponse.json(data, { status: response.status });
   } catch (error) {
     console.error(`${method} ${url}:`, error);
-    return NextResponse.json({ status: 500 });
+    return NextResponse.json({ message: "Internal Server Error" }, { status: 500 });
   }
 }
 

--- a/src/entities/slogan/lib/types.ts
+++ b/src/entities/slogan/lib/types.ts
@@ -24,6 +24,7 @@ export interface SloganFormSchoolData {
 export interface UseSloganFormReturn {
   state: FormState;
   isValid: boolean;
+  isSloganPeriod: boolean;
   isOutOfSchool: boolean;
   fieldErrors: Partial<Record<keyof SloganFormValues, string>>;
   handlers: SloganFormHandlers;

--- a/src/entities/slogan/lib/useSloganForm.ts
+++ b/src/entities/slogan/lib/useSloganForm.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useReducer, useCallback, useMemo } from "react";
+import { useReducer, useCallback, useMemo, useState, useEffect } from "react";
 import { formReducer, initialFormState } from "./formReducer";
 import { sloganSchema, SloganFormValues } from "../model/schema";
 import { handleSloganFormSubmit } from "./handleSloganFormSubmit";
@@ -18,8 +18,18 @@ const parseSchoolApiResponse = (data: SchoolInfoResponse | undefined) => {
   return data.schoolInfo[1].row ?? [];
 };
 
+const SLOGAN_PERIOD_CHECK_INTERVAL = 60000;
+
 export const useSloganForm = (): UseSloganFormReturn => {
   const [state, dispatch] = useReducer(formReducer, initialFormState);
+  const [isSloganPeriod, setIsSloganPeriod] = useState(checkSloganPeriod);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setIsSloganPeriod(checkSloganPeriod());
+    }, SLOGAN_PERIOD_CHECK_INTERVAL);
+    return () => clearInterval(timer);
+  }, []);
 
   const schema = state.isOutOfSchool ? outOfSchoolSloganSchema : sloganSchema;
 
@@ -131,7 +141,7 @@ export const useSloganForm = (): UseSloganFormReturn => {
   return {
     state,
     isValid,
-    isSloganPeriod: checkSloganPeriod(),
+    isSloganPeriod,
     isOutOfSchool: state.isOutOfSchool,
     fieldErrors,
     handlers: {

--- a/src/entities/slogan/lib/useSloganForm.ts
+++ b/src/entities/slogan/lib/useSloganForm.ts
@@ -9,6 +9,7 @@ import { useGetSchool } from "../api/useGetSchool";
 import { SchoolInfoResponse } from "../model/school";
 import { UseSloganFormReturn } from "./types";
 import { outOfSchoolSloganSchema } from "../model/schema";
+import { isSloganPeriod as checkSloganPeriod } from "@/shared/config/dateConfig";
 
 const SCHOOL_SEARCH_DELAY = 200;
 
@@ -21,8 +22,6 @@ export const useSloganForm = (): UseSloganFormReturn => {
   const [state, dispatch] = useReducer(formReducer, initialFormState);
 
   const schema = state.isOutOfSchool ? outOfSchoolSloganSchema : sloganSchema;
-
-  const debouncedFormValues = useDebounce(state.formValues, 500);
 
   const normalizedSchoolName = useMemo(
     () => state.formValues.school.replace(/\s+/g, ""),
@@ -44,8 +43,8 @@ export const useSloganForm = (): UseSloganFormReturn => {
     schema.safeParse(state.formValues).success &&
     (state.isOutOfSchool || isSchoolValid);
 
-  const fieldErrors = useMemo(() => {
-    const result = schema.safeParse(debouncedFormValues);
+  const rawErrors = useMemo(() => {
+    const result = schema.safeParse(state.formValues);
     const errors: Partial<Record<keyof SloganFormValues, string>> = {};
     if (!result.success) {
       for (const issue of result.error.issues) {
@@ -59,12 +58,14 @@ export const useSloganForm = (): UseSloganFormReturn => {
       !state.isOutOfSchool &&
       !isSchoolValid &&
       state.touchedFields.school &&
-      debouncedFormValues.school
+      state.formValues.school
     ) {
       errors.school = "학교를 목록에서 선택해주세요.";
     }
     return errors;
-  }, [debouncedFormValues, state.touchedFields, isSchoolValid, state.isOutOfSchool, schema]);
+  }, [state.formValues, state.touchedFields, isSchoolValid, state.isOutOfSchool, schema]);
+
+  const fieldErrors = useDebounce(rawErrors, 500);
 
   const filteredSchools = useMemo(
     () => schoolList.filter(school => school.SCHUL_NM !== normalizedSchoolName),
@@ -130,6 +131,7 @@ export const useSloganForm = (): UseSloganFormReturn => {
   return {
     state,
     isValid,
+    isSloganPeriod: checkSloganPeriod(),
     isOutOfSchool: state.isOutOfSchool,
     fieldErrors,
     handlers: {

--- a/src/entities/slogan/model/__tests__/schema.test.ts
+++ b/src/entities/slogan/model/__tests__/schema.test.ts
@@ -60,8 +60,15 @@ describe("gradeSchema", () => {
     expect(result.error?.errors[0].message).toBe("학년은 1학년 이상 입력해주세요.");
   });
 
-  it("4 이상이면 실패한다", () => {
-    expect(gradeSchema.safeParse("4").success).toBe(false);
+  it("4~6이면 유효하다", () => {
+    expect(gradeSchema.safeParse("4").success).toBe(true);
+    expect(gradeSchema.safeParse("6").success).toBe(true);
+  });
+
+  it("7 이상이면 실패한다", () => {
+    const result = gradeSchema.safeParse("7");
+    expect(result.success).toBe(false);
+    expect(result.error?.errors[0].message).toBe("학년은 6학년까지 입력할 수 있습니다.");
   });
 });
 
@@ -121,4 +128,39 @@ describe("sloganSchema", () => {
   it("전화번호 형식이 잘못되면 실패한다", () => {
     expect(sloganSchema.safeParse({ ...valid, phone_number: "010-1234-5678" }).success).toBe(false);
   });
+
+  it("초등학교이고 4학년 이상이면 유효하다", () => {
+    expect(sloganSchema.safeParse({ ...valid, school: "광주초등학교", grade: "4" }).success).toBe(true);
+    expect(sloganSchema.safeParse({ ...valid, school: "광주초등학교", grade: "6" }).success).toBe(true);
+  });
+
+  it("초등학교이고 3학년 이하면 실패한다", () => {
+    const result = sloganSchema.safeParse({ ...valid, school: "광주초등학교", grade: "3" });
+    expect(result.success).toBe(false);
+    const gradeError = result.error?.issues.find(i => i.path[0] === "grade");
+    expect(gradeError?.message).toBe("초등학생은 4학년 이상만 참가 가능합니다.");
+  });
+
+  it("중학교이고 3학년 이하면 유효하다", () => {
+    expect(sloganSchema.safeParse({ ...valid, school: "광주중학교", grade: "3" }).success).toBe(true);
+  });
+
+  it("중학교이고 4학년 이상이면 실패한다", () => {
+    const result = sloganSchema.safeParse({ ...valid, school: "광주중학교", grade: "4" });
+    expect(result.success).toBe(false);
+    const gradeError = result.error?.issues.find(i => i.path[0] === "grade");
+    expect(gradeError?.message).toBe("학년은 3학년까지 입력할 수 있습니다.");
+  });
+
+  it("고등학교이고 3학년 이하면 유효하다", () => {
+    expect(sloganSchema.safeParse({ ...valid, school: "광주고등학교", grade: "3" }).success).toBe(true);
+  });
+
+  it("고등학교이고 4학년 이상이면 실패한다", () => {
+    const result = sloganSchema.safeParse({ ...valid, school: "광주고등학교", grade: "4" });
+    expect(result.success).toBe(false);
+    const gradeError = result.error?.issues.find(i => i.path[0] === "grade");
+    expect(gradeError?.message).toBe("학년은 3학년까지 입력할 수 있습니다.");
+  });
 });
+

--- a/src/entities/slogan/model/__tests__/schema.test.ts
+++ b/src/entities/slogan/model/__tests__/schema.test.ts
@@ -53,6 +53,16 @@ describe("gradeSchema", () => {
     expect(result.success).toBe(false);
     expect(result.error?.errors[0].message).toBe("학년은 숫자만 입력할 수 있습니다.");
   });
+
+  it("0이면 실패한다", () => {
+    const result = gradeSchema.safeParse("0");
+    expect(result.success).toBe(false);
+    expect(result.error?.errors[0].message).toBe("학년은 1학년 이상 입력해주세요.");
+  });
+
+  it("4 이상이면 실패한다", () => {
+    expect(gradeSchema.safeParse("4").success).toBe(false);
+  });
 });
 
 describe("classroomSchema", () => {
@@ -68,6 +78,16 @@ describe("classroomSchema", () => {
     const result = classroomSchema.safeParse("5반");
     expect(result.success).toBe(false);
     expect(result.error?.errors[0].message).toBe("반은 숫자만 입력할 수 있습니다.");
+  });
+
+  it("0이면 실패한다", () => {
+    const result = classroomSchema.safeParse("0");
+    expect(result.success).toBe(false);
+    expect(result.error?.errors[0].message).toBe("반은 1반 이상 입력해주세요.");
+  });
+
+  it("100 이상이면 실패한다", () => {
+    expect(classroomSchema.safeParse("100").success).toBe(false);
   });
 });
 

--- a/src/entities/slogan/model/schema.ts
+++ b/src/entities/slogan/model/schema.ts
@@ -9,12 +9,14 @@ export const gradeSchema = z
   .string()
   .min(1, "학년을 입력해주세요.")
   .refine(val => /^\d+$/.test(val), "학년은 숫자만 입력할 수 있습니다.")
+  .refine(val => Number(val) >= 1, "학년은 1학년 이상 입력해주세요.")
   .refine(val => Number(val) <= 3, "학년은 3학년까지 입력할 수 있습니다.");
 
 export const classroomSchema = z
   .string()
   .min(1, "반을 입력해주세요.")
   .refine(val => /^\d+$/.test(val), "반은 숫자만 입력할 수 있습니다.")
+  .refine(val => Number(val) >= 1, "반은 1반 이상 입력해주세요.")
   .refine(val => Number(val) <= 99, "반은 두자릿수 이내로 입력 해주세요.");
 
 const sharedSloganFields = {

--- a/src/entities/slogan/model/schema.ts
+++ b/src/entities/slogan/model/schema.ts
@@ -10,7 +10,7 @@ export const gradeSchema = z
   .min(1, "학년을 입력해주세요.")
   .refine(val => /^\d+$/.test(val), "학년은 숫자만 입력할 수 있습니다.")
   .refine(val => Number(val) >= 1, "학년은 1학년 이상 입력해주세요.")
-  .refine(val => Number(val) <= 3, "학년은 3학년까지 입력할 수 있습니다.");
+  .refine(val => Number(val) <= 6, "학년은 6학년까지 입력할 수 있습니다.");
 
 export const classroomSchema = z
   .string()
@@ -29,12 +29,30 @@ const sharedSloganFields = {
   phone_number: phoneNumberSchema,
 };
 
-export const sloganSchema = z.object({
-  ...sharedSloganFields,
-  school: z.string().min(1, "학교를 입력해주세요."),
-  grade: gradeSchema,
-  classroom: classroomSchema,
-});
+export const sloganSchema = z
+  .object({
+    ...sharedSloganFields,
+    school: z.string().min(1, "학교를 입력해주세요."),
+    grade: gradeSchema,
+    classroom: classroomSchema,
+  })
+  .superRefine((data, ctx) => {
+    const grade = Number(data.grade);
+    if (data.school.includes("초등학교") && grade < 4) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["grade"],
+        message: "초등학생은 4학년 이상만 참가 가능합니다.",
+      });
+    }
+    if ((data.school.includes("중학교") || data.school.includes("고등학교")) && grade > 3) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["grade"],
+        message: "학년은 3학년까지 입력할 수 있습니다.",
+      });
+    }
+  });
 
 export const outOfSchoolSloganSchema = z.object({
   ...sharedSloganFields,

--- a/src/entities/slogan/ui/BirthdayPicker/index.tsx
+++ b/src/entities/slogan/ui/BirthdayPicker/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { DayPicker } from "react-day-picker";
 import { ko } from "react-day-picker/locale";
 import "react-day-picker/style.css";
@@ -25,6 +25,14 @@ const BirthdayPicker = ({ value, onSelect, onBlur, error }: BirthdayPickerProps)
   }, [open]);
 
   const selectedDate = value ? new Date(value) : undefined;
+
+  const { fromDate, toDate } = useMemo(() => {
+    const today = new Date();
+    return {
+      fromDate: new Date(today.getFullYear() - 19, today.getMonth(), today.getDate() + 1),
+      toDate: new Date(today.getFullYear() - 10, today.getMonth(), today.getDate()),
+    };
+  }, []);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -67,7 +75,10 @@ const BirthdayPicker = ({ value, onSelect, onBlur, error }: BirthdayPickerProps)
             onSelect={handleSelect}
             locale={ko}
             captionLayout="dropdown"
-            defaultMonth={selectedDate ?? new Date()}
+            defaultMonth={selectedDate ?? toDate}
+            startMonth={fromDate}
+            endMonth={toDate}
+            disabled={[{ before: fromDate }, { after: toDate }]}
             style={{ "--rdp-accent-color": "#FF9644" } as React.CSSProperties}
           />
         </div>

--- a/src/entities/slogan/ui/PersonalInfoInputs/index.tsx
+++ b/src/entities/slogan/ui/PersonalInfoInputs/index.tsx
@@ -34,22 +34,22 @@ const PersonalInfoInputs = ({ formValues, onFieldChange, onFieldBlur, isOutOfSch
         <div className="flex gap-24">
           <Input
             name="grade"
-            type="number"
+            type="text"
+            inputMode="numeric"
             value={formValues.grade}
             onChange={onFieldChange("grade")}
             onBlur={onFieldBlur("grade")}
-            onKeyDown={e => ["e", "E", "+", "-", "."].includes(e.key) && e.preventDefault()}
             label="학년"
             placeholder="학년을 입력해주세요"
             error={fieldErrors.grade}
           />
           <Input
             name="class"
-            type="number"
+            type="text"
+            inputMode="numeric"
             value={formValues.classroom}
             onChange={onFieldChange("classroom")}
             onBlur={onFieldBlur("classroom")}
-            onKeyDown={e => ["e", "E", "+", "-", "."].includes(e.key) && e.preventDefault()}
             label="반"
             placeholder="반을 입력해주세요"
             error={fieldErrors.classroom}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { publicPages, publicIn27 } from "@/shared/config/authConfig";
-import { festivalDate } from "@/shared/config/dateConfig";
+import { festivalDate, sloganStartDate, sloganEndDate } from "@/shared/config/dateConfig";
 
 export const config = {
   matcher: [
@@ -32,6 +32,11 @@ export function middleware(request: NextRequest) {
 
   const accessToken = request.cookies.get("accessToken")?.value;
   const refreshToken = request.cookies.get("refreshToken")?.value;
+
+  const now = new Date();
+  if (pathname === "/slogan" && (now < sloganStartDate || now > sloganEndDate)) {
+    return NextResponse.redirect(new URL("/home", request.url));
+  }
 
   if (pathname === "/signin" && accessToken && refreshToken) {
     const nextParam = searchParams.get("next");

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { publicPages, publicIn27 } from "@/shared/config/authConfig";
-// TODO: 테스트 완료 후 sloganStartDate, sloganEndDate 주석 해제
 import { festivalDate } from "@/shared/config/dateConfig";
 
 export const config = {
@@ -33,7 +32,6 @@ export function middleware(request: NextRequest) {
 
   const accessToken = request.cookies.get("accessToken")?.value;
   const refreshToken = request.cookies.get("refreshToken")?.value;
-
 
   if (pathname === "/signin" && accessToken && refreshToken) {
     const nextParam = searchParams.get("next");

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { publicPages, publicIn27 } from "@/shared/config/authConfig";
 // TODO: 테스트 완료 후 sloganStartDate, sloganEndDate 주석 해제
-import { festivalDate /*, sloganStartDate, sloganEndDate */ } from "@/shared/config/dateConfig";
+import { festivalDate } from "@/shared/config/dateConfig";
 
 export const config = {
   matcher: [
@@ -34,11 +34,6 @@ export function middleware(request: NextRequest) {
   const accessToken = request.cookies.get("accessToken")?.value;
   const refreshToken = request.cookies.get("refreshToken")?.value;
 
-  // TODO: 테스트 완료 후 아래 슬로건 기간 체크 주석 해제
-  // const now = new Date();
-  // if (pathname === "/slogan" && (now < sloganStartDate || now > sloganEndDate)) {
-  //   return NextResponse.redirect(new URL("/home", request.url));
-  // }
 
   if (pathname === "/signin" && accessToken && refreshToken) {
     const nextParam = searchParams.get("next");

--- a/src/shared/config/dateConfig.ts
+++ b/src/shared/config/dateConfig.ts
@@ -7,3 +7,7 @@ export const sloganStartDate = new Date(
 export const sloganEndDate = new Date(
   process.env.NEXT_PUBLIC_SLOGAN_END_DATE ?? "2026-05-28T18:00:00+09:00",
 );
+export const isSloganPeriod = () => {
+  const now = new Date();
+  return now >= sloganStartDate && now <= sloganEndDate;
+};

--- a/src/widgets/main/SloganSecondSection/index.tsx
+++ b/src/widgets/main/SloganSecondSection/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-// TODO: 테스트 완료 후 useState, useEffect 주석 해제
-// import { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 // import PrizeItem from "@/entities/home/ui/PrizeItem";
 import SloganMarquee from "@/entities/home/ui/SloganMarquee";
@@ -18,18 +17,17 @@ const submissionPeriodText = `공모기간 : ${SLOGAN_YEAR}.${formatDate(sloganS
 const SloganSecondSection = () => {
   const router = useRouter();
 
-  // TODO: 테스트 완료 후 아래 슬로건 기간 체크 로직 주석 해제
-  // const [isSloganPeriod, setIsSloganPeriod] = useState(() => {
-  //   const now = new Date();
-  //   return now >= sloganStartDate && now <= sloganEndDate;
-  // });
-  // useEffect(() => {
-  //   const timer = setInterval(() => {
-  //     const now = new Date();
-  //     setIsSloganPeriod(now >= sloganStartDate && now <= sloganEndDate);
-  //   }, 60000);
-  //   return () => clearInterval(timer);
-  // }, []);
+  const [isSloganPeriod, setIsSloganPeriod] = useState(() => {
+    const now = new Date();
+    return now >= sloganStartDate && now <= sloganEndDate;
+  });
+  useEffect(() => {
+    const timer = setInterval(() => {
+      const now = new Date();
+      setIsSloganPeriod(now >= sloganStartDate && now <= sloganEndDate);
+    }, 60000);
+    return () => clearInterval(timer);
+  }, []);
 
   return (
     <section id="SloganSecondSection" className={cn("w-full mt-[3.5rem] mobile:mt-20 text-center")}>
@@ -60,11 +58,11 @@ const SloganSecondSection = () => {
         type="button"
         onClick={() => router.push("/slogan")}
         className={cn("mobile:mb-[12px] px-28 mt-[54px] mb-[10px] rounded-lg")}
-        disabled={false /* TODO: 테스트 완료 후 !isSloganPeriod 로 복구 */}
+        disabled={!isSloganPeriod}
       >
         <span className={cn("text-body3b px-[60px] mobile:text-body3b flex items-center gap-10")}>
-          {"슬로건 공모하러가기" /* TODO: 테스트 완료 후 isSloganPeriod ? "슬로건 공모하러가기" : "공모기간이 아닙니다" 로 복구 */}{" "}
-          <ArrowBack color={"white" /* TODO: 테스트 완료 후 isSloganPeriod ? "white" : "#1F2937" 로 복구 */} />
+          {isSloganPeriod ? "슬로건 공모하러가기" : "공모기간이 아닙니다"}{" "}
+          <ArrowBack color={isSloganPeriod ? "white" : "#1F2937"} />
         </span>
       </Button>
 

--- a/src/widgets/slogan/ui/SloganFormContainer/index.tsx
+++ b/src/widgets/slogan/ui/SloganFormContainer/index.tsx
@@ -11,7 +11,7 @@ import PersonalInfoInputs from "@/entities/slogan/ui/PersonalInfoInputs";
 import { useSloganForm } from "@/entities/slogan/lib/useSloganForm";
 
 export default function SloganFormContainer() {
-  const { state, isValid, isOutOfSchool, fieldErrors, handlers, schoolData } = useSloganForm();
+  const { state, isValid, isSloganPeriod, isOutOfSchool, fieldErrors, handlers, schoolData } = useSloganForm();
 
   if (state.isSubmitted) {
     return <SloganFormSuccess />;
@@ -66,7 +66,10 @@ export default function SloganFormContainer() {
           </div>
         </div>
       </div>
-      <Button type="submit" disabled={!isValid || state.isSubmitting}>
+      {!isSloganPeriod && (
+        <p className="text-center text-body3r text-gray-400">신청 기간이 아닙니다.</p>
+      )}
+      <Button type="submit" disabled={!isValid || state.isSubmitting || !isSloganPeriod}>
         응모하기
       </Button>
     </form>


### PR DESCRIPTION
## 💡 PR 요약

  - 슬로건 제출 테스트 우회 코드 제거
  - `isSloganPeriod` 유틸 추가 및 `useSloganForm` 통합
  - 학교 종류별 학년 유효성 검사 추가
  - `BirthdayPicker` 선택 날짜 범위 제한

  ## 📋 작업 내용

  **테스트 우회 코드 제거**
  - `route.ts` 슬로건 임시 블록 제거, 에러 응답 상태 코드 수정
  - `middleware.ts` 슬로건 기간 주석 정리
  - `SloganSecondSection` 기간 검사 로직 복구

  **기간 검사 통합**
  - `useSloganForm`에서 `isSloganPeriod` 반환, 폼에 연결

  **유효성 검사 개선**
  - 초등학교 4학년 이상 / 중·고등학교 3학년 이하 검증 추가
  - 학년·반 입력 `type="text" inputMode="numeric"` 변경