### PR TITLE
fix: 슬로건 포스터 팝업 환경 가드 제거 및 기간 조건으로 대체

### DIFF
--- a/src/widgets/main/SloganPosterPopup/index.tsx
+++ b/src/widgets/main/SloganPosterPopup/index.tsx
@@ -24,8 +24,6 @@ export default function SloganPosterPopup() {
     }
   }, []);
 
-  if (process.env.NEXT_PUBLIC_APP_ENV !== "production") return null;
-
   const handleClose = () => {
     if (doNotShow) {
       localStorage.setItem(STORAGE_KEY, "true");


### PR DESCRIPTION
## 💡 PR 요약

- `NEXT_PUBLIC_APP_ENV !== "production"` 가드로 인해 배포 환경에서도 슬로건 포스터 팝업이 표시되지 않던 문제 수정
- 날짜 기간 조건(`sloganStartDate ~ sloganEndDate`)으로 팝업 표시 여부를 제어하도록 변경
- 슬로건 섹션 타이틀을 공모 기간 여부에 따라 동적으로 표시

## 📋 작업 내용

- `SloganPosterPopup`: 환경 가드 제거, `useEffect` 내부에서 날짜 범위 체크 후 팝업 노출
- `SloganSecondSection`: 공모 기간 중이면 "공모중", 아니면 "공모예정" 텍스트 표시
- `SloganSecondSection`: 주석 처리된 `PrizeItem` 관련 코드 제거