### PR TITLE
feat: 슬로건 마감 후 팝업 숨김 및 접수마감 안내 표시

### DIFF
--- a/src/shared/config/dateConfig.ts
+++ b/src/shared/config/dateConfig.ts
@@ -11,3 +11,4 @@ export const isSloganPeriod = () => {
   const now = new Date();
   return now >= sloganStartDate && now <= sloganEndDate;
 };
+export const isSloganEnded = () => new Date() > sloganEndDate;

--- a/src/widgets/main/SloganPosterPopup/index.tsx
+++ b/src/widgets/main/SloganPosterPopup/index.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import Modal from "@/shared/ui/Modal";
 import Button from "@/shared/ui/Button";
 import { RightArrow } from "@/shared/asset/svg/RightArrow";
+import { isSloganEnded } from "@/shared/config/dateConfig";
 
 const STORAGE_KEY = "sloganPosterHidden";
 
@@ -21,7 +22,7 @@ export default function SloganPosterPopup() {
     }
   }, []);
 
-  if (process.env.NEXT_PUBLIC_APP_ENV !== "production") return null;
+  if (isSloganEnded()) return null;
 
   const handleClose = () => {
     if (doNotShow) {

--- a/src/widgets/main/SloganPosterPopup/index.tsx
+++ b/src/widgets/main/SloganPosterPopup/index.tsx
@@ -16,13 +16,10 @@ export default function SloganPosterPopup() {
   const router = useRouter();
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      const hidden = localStorage.getItem(STORAGE_KEY);
-      if (!hidden) setIsOpen(true);
-    }
+    if (isSloganEnded()) return;
+    const hidden = localStorage.getItem(STORAGE_KEY);
+    if (!hidden) setIsOpen(true);
   }, []);
-
-  if (isSloganEnded()) return null;
 
   const handleClose = () => {
     if (doNotShow) {

--- a/src/widgets/main/SloganSecondSection/index.tsx
+++ b/src/widgets/main/SloganSecondSection/index.tsx
@@ -21,11 +21,13 @@ const SloganSecondSection = () => {
     const now = new Date();
     return now >= sloganStartDate && now <= sloganEndDate;
   });
-  const sloganEnded = isSloganEnded();
+  const [sloganEnded, setSloganEnded] = useState(false);
   useEffect(() => {
+    setSloganEnded(isSloganEnded());
     const timer = setInterval(() => {
       const now = new Date();
       setIsSloganPeriod(now >= sloganStartDate && now <= sloganEndDate);
+      setSloganEnded(isSloganEnded());
     }, 60000);
     return () => clearInterval(timer);
   }, []);
@@ -33,7 +35,11 @@ const SloganSecondSection = () => {
   return (
     <section id="SloganSecondSection" className={cn("w-full mt-[3.5rem] mobile:mt-20 text-center")}>
       <SectionTitle
-        title={sloganEnded ? `${SLOGAN_YEAR} 광탈페 슬로건 접수마감 되었습니다` : `${SLOGAN_YEAR} 광탈페 슬로건 공모예정`}
+        title={
+          sloganEnded
+            ? `${SLOGAN_YEAR} 광탈페 슬로건 접수마감 되었습니다`
+            : `${SLOGAN_YEAR} 광탈페 슬로건 공모예정`
+        }
         description={
           <>
             <span className="text-black text-body2b">
@@ -62,7 +68,7 @@ const SloganSecondSection = () => {
         disabled={!isSloganPeriod}
       >
         <span className={cn("text-body3b px-[60px] mobile:text-body3b flex items-center gap-10")}>
-          {isSloganPeriod ? "슬로건 공모하러가기" : sloganEnded ? "슬로건 접수가 마감되었습니다" : "공모기간이 아닙니다"}{" "}
+          {isSloganPeriod ? "슬로건 공모하러가기" : "공모기간이 아닙니다"}{" "}
           <ArrowBack color={isSloganPeriod ? "white" : "#1F2937"} />
         </span>
       </Button>

--- a/src/widgets/main/SloganSecondSection/index.tsx
+++ b/src/widgets/main/SloganSecondSection/index.tsx
@@ -8,7 +8,7 @@ import Button from "@/shared/ui/Button";
 import { cn } from "@/shared/utils/cn";
 import { SectionTitle } from "@/shared/ui/SectionTitle";
 import { formatDate } from "@/shared/utils/formatDate";
-import { sloganStartDate, sloganEndDate } from "@/shared/config/dateConfig";
+import { sloganStartDate, sloganEndDate, isSloganEnded } from "@/shared/config/dateConfig";
 import { ArrowBack } from "@/shared/asset/svg/ArrowBack";
 
 const SLOGAN_YEAR = sloganStartDate.getFullYear();
@@ -21,6 +21,7 @@ const SloganSecondSection = () => {
     const now = new Date();
     return now >= sloganStartDate && now <= sloganEndDate;
   });
+  const sloganEnded = isSloganEnded();
   useEffect(() => {
     const timer = setInterval(() => {
       const now = new Date();
@@ -32,7 +33,7 @@ const SloganSecondSection = () => {
   return (
     <section id="SloganSecondSection" className={cn("w-full mt-[3.5rem] mobile:mt-20 text-center")}>
       <SectionTitle
-        title={`${SLOGAN_YEAR} 광탈페 슬로건 공모예정`}
+        title={sloganEnded ? `${SLOGAN_YEAR} 광탈페 슬로건 접수마감 되었습니다` : `${SLOGAN_YEAR} 광탈페 슬로건 공모예정`}
         description={
           <>
             <span className="text-black text-body2b">
@@ -61,7 +62,7 @@ const SloganSecondSection = () => {
         disabled={!isSloganPeriod}
       >
         <span className={cn("text-body3b px-[60px] mobile:text-body3b flex items-center gap-10")}>
-          {isSloganPeriod ? "슬로건 공모하러가기" : "공모기간이 아닙니다"}{" "}
+          {isSloganPeriod ? "슬로건 공모하러가기" : sloganEnded ? "슬로건 접수가 마감되었습니다" : "공모기간이 아닙니다"}{" "}
           <ArrowBack color={isSloganPeriod ? "white" : "#1F2937"} />
         </span>
       </Button>


### PR DESCRIPTION
## 💡 PR 요약

- 슬로건 마감일 기준으로 팝업 및 섹션 UI를 마감 상태로 전환하는 기능 추가

## 📋 작업 내용

- `dateConfig.ts`에 `isSloganEnded()` 헬퍼 추가 — `sloganEndDate` 기준으로 마감 여부 반환
- `SloganPosterPopup`: 마감 후 팝업이 노출되지 않도록 `isSloganEnded()` 체크 적용
- `SloganSecondSection`: 마감 후 타이틀을 "접수마감 되었습니다"로 변경, 버튼 텍스트도 "슬로건 접수가 마감되었습니다"로 변경