### PR TITLE
fix: 메인 팝업 포스터 및 버튼을 신청 화면으로 변경

### DIFF
--- a/src/widgets/main/SloganPosterPopup/index.tsx
+++ b/src/widgets/main/SloganPosterPopup/index.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import Modal from "@/shared/ui/Modal";
 import Button from "@/shared/ui/Button";
 import { RightArrow } from "@/shared/asset/svg/RightArrow";
-import { isSloganEnded } from "@/shared/config/dateConfig";
+// import { isSloganEnded } from "@/shared/config/dateConfig";
 
 const STORAGE_KEY = "sloganPosterHidden";
 
@@ -16,7 +16,7 @@ export default function SloganPosterPopup() {
   const router = useRouter();
 
   useEffect(() => {
-    if (isSloganEnded()) return;
+    // if (isSloganEnded()) return;
     const hidden = localStorage.getItem(STORAGE_KEY);
     if (!hidden) setIsOpen(true);
   }, []);
@@ -30,7 +30,7 @@ export default function SloganPosterPopup() {
 
   const handleGoSlogan = () => {
     handleClose();
-    router.push("/slogan");
+    router.push("/apply");
   };
 
   return (
@@ -48,7 +48,7 @@ export default function SloganPosterPopup() {
             onClick={handleGoSlogan}
           >
             <span className="text-body3b flex items-center justify-center gap-10">
-              슬로건 공모하러가기
+              신청하러 가기
               <RightArrow color="white" width={16} height={16} />
             </span>
           </Button>
@@ -71,7 +71,7 @@ export default function SloganPosterPopup() {
       }
     >
       <Image
-        src="/images/slogan-poster.png"
+        src="/images/신청.png"
         alt="2026 광탈페 슬로건 공모전 안내"
         width={485}
         height={708}


### PR DESCRIPTION
## 💡 PR 요약

- 메인 팝업 포스터 이미지를 신청 포스터로 교체하고 버튼 경로·텍스트를 신청 화면 기준으로 수정

## 📋 작업 내용

- `public/images/신청.png` 추가
- `SloganPosterPopup`: 팝업 상시 노출을 위해 `isSloganEnded()` 체크 주석 처리
- 버튼 경로 `/slogan` → `/apply`, 텍스트 "슬로건 공모하러가기" → "신청하러 가기"
- 포스터 이미지 `slogan-poster.png` → `신청.png`

## 🤝 리뷰 시 참고사항

- `isSloganEnded()` 체크는 신청 기간 종료 시 재활성화 필요