### PR TITLE
fix: 헤더 네비게이션 링크를 참여 신청으로 변경

### DIFF
--- a/src/shared/const/headerValues.ts
+++ b/src/shared/const/headerValues.ts
@@ -11,7 +11,7 @@ export const isHiddenPath = (pathname: string): boolean => {
 export const links = [
   { section: "SloganSecondSection", label: "2026 광탈페 슬로건" },
   // { section: "section3", label: "FaQ" },
-  { section: "PreliminaryFourthSection", label: "2025 광탈페 예선 다시보기" },
+  { section: "ApplyThirdSection", label: "참여 신청" },
   { section: "FinalsSixthSection", label: "2025 광탈페 본선 다시보기" },
   // { section: "ReservationFifthSection", label: "본선 수상팀 명단" },
 ];

--- a/src/shared/const/headerValues.ts
+++ b/src/shared/const/headerValues.ts
@@ -8,7 +8,17 @@ export const isHiddenPath = (pathname: string): boolean => {
   return HIDDEN_PREFIXES.some(prefix => matchesSegment(pathname, prefix));
 };
 
-export const links = [
+export type SectionId =
+  | "SloganSecondSection"
+  | "ApplyThirdSection"
+  | "FinalsSixthSection";
+
+export interface HeaderLink {
+  section: SectionId;
+  label: string;
+}
+
+export const links: HeaderLink[] = [
   { section: "SloganSecondSection", label: "2026 광탈페 슬로건" },
   // { section: "section3", label: "FaQ" },
   { section: "ApplyThirdSection", label: "참여 신청" },


### PR DESCRIPTION
## 💡 PR 요약

- 헤더 네비게이션에서 "2025 광탈페 예선 다시보기" 항목을 "참여 신청"으로 변경

## 📋 작업 내용

- `src/shared/const/headerValues.ts`의 links 배열에서 `PreliminaryFourthSection` 항목을 `ApplyThirdSection`으로 교체
- 레이블: "2025 광탈페 예선 다시보기" → "참여 신청"
- 현재 홈페이지에서 PreliminaryFourthSection이 주석 처리되어 있어 해당 링크가 동작하지 않는 상태였음

## 🤝 리뷰 시 참고사항

- PreliminaryFourthSection은 홈페이지에서 주석 처리된 상태로, 링크가 아무 섹션도 가리키지 않는 문제가 있었습니다.
- ApplyThirdSection은 현재 홈페이지에 실제로 렌더링되어 있어 정상 동작합니다.