### PR TITLE
chore: 메인 페이지 섹션 텍스트 및 구성 업데이트

### DIFF
--- a/src/entities/home/ui/PrizeItem/index.tsx
+++ b/src/entities/home/ui/PrizeItem/index.tsx
@@ -3,10 +3,9 @@ type PrizeItemProps = Readonly<{
   bg: string;
   emoji: string;
   desc: string;
-  slogan: string;
 }>;
 
-const PrizeItem: React.FC<PrizeItemProps> = ({ rank, bg, emoji, desc, slogan }) => {
+const PrizeItem: React.FC<PrizeItemProps> = ({ rank, bg, emoji, desc }) => {
   return (
     <div key={rank} className="flex flex-col items-center gap-[16px]">
       <div
@@ -14,10 +13,9 @@ const PrizeItem: React.FC<PrizeItemProps> = ({ rank, bg, emoji, desc, slogan }) 
       >
         {rank}
       </div>
-      <div className="flex flex-col gap-[2px]">
-        <div className="text-lg mobile:text-caption1b text-gray-400">{emoji}</div>
-        <div className="text-lg mobile:text-caption1b">{desc}</div>
-        <div className={`text-lg mobile:text-caption1b `}>{slogan}</div>
+      <div className="flex items-center gap-[6px] text-lg mobile:text-caption1b font-semibold">
+        <span>{emoji}</span>
+        <span>{desc}</span>
       </div>
     </div>
   );

--- a/src/shared/const/headerValues.ts
+++ b/src/shared/const/headerValues.ts
@@ -11,6 +11,7 @@ export const isHiddenPath = (pathname: string): boolean => {
 export type SectionId =
   | "SloganSecondSection"
   | "ApplyThirdSection"
+  | "PreliminaryFourthSection"
   | "FinalsSixthSection";
 
 export interface HeaderLink {
@@ -21,7 +22,7 @@ export interface HeaderLink {
 export const links: HeaderLink[] = [
   { section: "SloganSecondSection", label: "2026 광탈페 슬로건" },
   // { section: "section3", label: "FaQ" },
-  { section: "ApplyThirdSection", label: "참여 신청" },
-  { section: "FinalsSixthSection", label: "2025 광탈페 본선 다시보기" },
+  { section: "ApplyThirdSection", label: "2026 광탈페 참가신청" },
+  { section: "PreliminaryFourthSection", label: "2025 광탈페 다시보기" },
   // { section: "ReservationFifthSection", label: "본선 수상팀 명단" },
 ];

--- a/src/views/home/ui/HomePage/index.tsx
+++ b/src/views/home/ui/HomePage/index.tsx
@@ -7,10 +7,10 @@ import ApplyThirdSection from "@/widgets/main/ApplyThirdSection";
 import LazySection from "@/shared/ui/LazySection";
 import SloganPosterPopup from "@/widgets/main/SloganPosterPopup";
 
-// const PreliminaryFourthSection = dynamic(() => import("@/widgets/main/PreliminaryFourthSection"), {
-//   loading: () => <SectionPlaceholder />,
-//   ssr: false,
-// });
+const PreliminaryFourthSection = dynamic(() => import("@/widgets/main/PreliminaryFourthSection"), {
+  loading: () => <SectionPlaceholder />,
+  ssr: false,
+});
 
 // const ReservationFifthSection = dynamic(() => import("@/widgets/main/ReservationFifthSection"), {
 //   loading: () => <SectionPlaceholder />,
@@ -54,9 +54,9 @@ const HomePage = () => {
 
       <ApplyThirdSection />
 
-      {/* <LazySection fallback={<SectionPlaceholder height="600px" />} rootMargin="200px">
+      <LazySection fallback={<SectionPlaceholder height="600px" />} rootMargin="200px">
         <PreliminaryFourthSection />
-      </LazySection> */}
+      </LazySection>
 
       <LazySection fallback={<SectionPlaceholder height="500px" />} rootMargin="300px">
         <FinalsSixthSection />

--- a/src/widgets/main/ApplyThirdSection/index.tsx
+++ b/src/widgets/main/ApplyThirdSection/index.tsx
@@ -86,7 +86,7 @@ const ApplyThirdSection = () => {
 
       {/* 본문 */}
       <div className="relative z-10 flex flex-col items-center text-center py-[80px] mobile:py-[52px] px-[80px] tablet:px-[40px] mobile:px-16 gap-24 mobile:gap-16">
-        <h2 className="text-title2b tablet:text-title4b mobile:text-h4b text-black">참여 신청</h2>
+        <h2 className="text-title2b tablet:text-title4b mobile:text-h4b text-black">2026 광탈페 참가신청</h2>
 
         <p className="text-body3r tablet:text-body3r mobile:text-body3r text-gray-700">
           신청기간 : 2026.6.15(월) ~ 6.22(월) 18:00

--- a/src/widgets/main/SloganSecondSection/index.tsx
+++ b/src/widgets/main/SloganSecondSection/index.tsx
@@ -1,20 +1,21 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
 import SloganMarquee from "@/entities/home/ui/SloganMarquee";
-import Button from "@/shared/ui/Button";
 import { cn } from "@/shared/utils/cn";
 import { SectionTitle } from "@/shared/ui/SectionTitle";
-import { formatDate } from "@/shared/utils/formatDate";
 import { sloganStartDate, sloganEndDate, isSloganEnded } from "@/shared/config/dateConfig";
-import { ArrowBack } from "@/shared/asset/svg/ArrowBack";
+
+// import { formatDate } from "@/shared/utils/formatDate";
+// import Button from "@/shared/ui/Button";
+// import { useRouter } from "next/navigation";
+// import { ArrowBack } from "@/shared/asset/svg/ArrowBack";
 
 const SLOGAN_YEAR = sloganStartDate.getFullYear();
-const submissionPeriodText = `공모기간 : ${SLOGAN_YEAR}.${formatDate(sloganStartDate)}~${formatDate(sloganEndDate)}`;
+// const submissionPeriodText = `공모기간 : ${SLOGAN_YEAR}.${formatDate(sloganStartDate)}~${formatDate(sloganEndDate)}`;
 
 const SloganSecondSection = () => {
-  const router = useRouter();
+  // const router = useRouter();
 
   const [isSloganPeriod, setIsSloganPeriod] = useState(() => {
     const now = new Date();
@@ -32,7 +33,10 @@ const SloganSecondSection = () => {
   }, []);
 
   return (
-    <section id="SloganSecondSection" className={cn("w-full mt-[3.5rem] mobile:mt-20 pb-[40px] mobile:pb-[24px] text-center")}>
+    <section
+      id="SloganSecondSection"
+      className={cn("w-full mt-[3.5rem] mobile:mt-20 pb-[40px] mobile:pb-[24px] text-center")}
+    >
       <SectionTitle
         title={
           sloganEnded
@@ -53,7 +57,7 @@ const SloganSecondSection = () => {
 
       <SloganMarquee />
 
-      <Button
+      {/* <Button
         type="button"
         onClick={() => router.push("/slogan")}
         className={cn("mobile:mb-[12px] px-28 mt-[54px] mb-[10px] rounded-lg")}
@@ -67,6 +71,13 @@ const SloganSecondSection = () => {
 
       <div className={cn("text-caption1r mobile:text-caption2r text-gray-400")}>
         {submissionPeriodText}
+      </div> */}
+
+      <div className={cn("mt-[54px] mb-[10px] flex flex-col items-center gap-8")}>
+        <p className={cn("text-body2b mobile:text-body3b text-gray-700")}>
+          공모 접수내용에 대해 심사중입니다.
+        </p>
+        <p className={cn("text-body3r text-gray-700")}>결과발표 : 2026. 6. 9.(예정)</p>
       </div>
     </section>
   );

--- a/src/widgets/main/SloganSecondSection/index.tsx
+++ b/src/widgets/main/SloganSecondSection/index.tsx
@@ -2,9 +2,16 @@
 
 import { useState, useEffect } from "react";
 import SloganMarquee from "@/entities/home/ui/SloganMarquee";
+import PrizeItem from "@/entities/home/ui/PrizeItem";
 import { cn } from "@/shared/utils/cn";
 import { SectionTitle } from "@/shared/ui/SectionTitle";
 import { sloganStartDate, sloganEndDate, isSloganEnded } from "@/shared/config/dateConfig";
+
+const PRIZE_LIST = [
+  { rank: "2등", bg: "bg-gray-400", emoji: "🍗", desc: "치킨 세트" },
+  { rank: "1등", bg: "bg-[#E8B84B]", emoji: "🎁", desc: "수상자 해당 학습 간식" },
+  { rank: "3등", bg: "bg-[#9B5E3B]", emoji: "🍔", desc: "햄버거 세트" },
+];
 
 // import { formatDate } from "@/shared/utils/formatDate";
 // import Button from "@/shared/ui/Button";
@@ -74,6 +81,11 @@ const SloganSecondSection = () => {
       </div> */}
 
       <div className={cn("mt-[54px] mb-[10px] flex flex-col items-center gap-8")}>
+        <div className={cn("w-full flex justify-center gap-[60px] mobile:gap-[24px] mb-[24px]")}>
+          {PRIZE_LIST.map((item) => (
+            <PrizeItem key={item.rank} {...item} />
+          ))}
+        </div>
         <p className={cn("text-body2b mobile:text-body3b text-gray-700")}>
           공모 접수내용에 대해 심사중입니다.
         </p>


### PR DESCRIPTION
## 💡 PR 요약

> 광탈페 진행 상황에 맞게 메인 페이지 섹션 텍스트 및 노출 구성을 변경합니다.

- 헤더 및 섹션 텍스트를 현재 진행 상황에 맞게 수정
- 예선 다시보기 섹션 메인 페이지에 노출
- 슬로건 공모 종료에 따른 심사중 안내 문구로 교체

## 📋 작업 내용

- `headerValues.ts`: 헤더 링크 "참여 신청" → "2026 광탈페 참가신청", "2025 광탈페 본선 다시보기" → "2025 광탈페 다시보기"로 변경 / 헤더 클릭 시 예선 섹션으로 스크롤되어 예선·본선 모두 노출
- `HomePage`: 주석 처리되어 있던 `PreliminaryFourthSection`(예선 다시보기) 노출 처리
- `ApplyThirdSection`: 섹션 제목 "참여 신청" → "2026 광탈페 참가신청"으로 변경
- `SloganSecondSection`: 공모 버튼·기간 텍스트 주석 처리, "공모 접수내용에 대해 심사중입니다." / "결과발표 : 2026. 6. 9.(예정)" 안내 문구로 교체
