### PR TITLE
chore: 참가 신청 흐름 텍스트에서 이메일 신청 단계 제거

### DIFF
--- a/src/widgets/main/ApplyThirdSection/index.tsx
+++ b/src/widgets/main/ApplyThirdSection/index.tsx
@@ -10,7 +10,7 @@ import { colors } from "@/shared/utils/color";
 import { isApplyPeriod } from "@/shared/config/dateConfig";
 
 const FLOW_TEXT =
-  "온·오프라인 참여 홍보 및 신청 접수 → 1차 영상 심사 및 光트로(예선) 참가팀 선정 → 光트로 참가팀 사전 협의 및 안내 → 이메일 신청";
+  "온·오프라인 참여 홍보 및 신청 접수 → 1차 영상 심사 및 光트로(예선) 참가팀 선정 → 光트로 참가팀 사전 협의 및 안내";
 
 const ApplyThirdSection = () => {
   const router = useRouter();


### PR DESCRIPTION
## 💡 PR 요약

- 메인 페이지 참가 신청 흐름 안내 텍스트에서 이메일 신청 단계 제거
<img width="881" height="41" alt="image" src="https://github.com/user-attachments/assets/08d801b7-3af3-4378-8c2c-eea2ba9195a8" />

<img width="696" height="44" alt="image" src="https://github.com/user-attachments/assets/d6a63e5a-0eb4-417e-a3bc-8ede11cbeb3d" />


## 📋 작업 내용

- `ApplyThirdSection`의 `FLOW_TEXT` 상수에서 `→ 이메일 신청` 문구 삭제

## 🤝 리뷰 시 참고사항

- 이메일 신청 단계가 흐름 텍스트에서 제거되었는데, 실제 참가신청 페이지 자체는 어떻게 처리하면 좋을지 의견 부탁드립니다. (유지 / 비공개 / 제거 등)
<img width="805" height="1126" alt="image" src="https://github.com/user-attachments/assets/3a6e4800-8391-4518-aee5-b36a23f2a711" />

