### PR TITLE
design: 모바일 반응형 레이아웃 조정

### DIFF
--- a/src/entities/home/ui/Footer/index.tsx
+++ b/src/entities/home/ui/Footer/index.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 export default function Footer() {
   return (
     <footer className="py-24 bg-gray-100 flex items-center justify-center gap-[5%] text-black mobile:flex-col mobile:gap-12 mobile:py-20 mobile:px-16">
-      <ul className="flex items-center sm:text-body3r text-caption2r gap-5 mobile:flex-col mobile:gap-4 mobile:items-center mobile:text-center">
+      <div className="flex items-center sm:text-body3r text-caption2r gap-5 mobile:flex-col mobile:gap-4 mobile:items-center mobile:text-center">
         <p>&copy; 2026 光탈페. All rights reserved. </p>
         <a
           className="pr-8 underline underline-offset-4"
@@ -17,7 +17,7 @@ export default function Footer() {
         <li className="pl-8 border-l border-white/40 underline underline-offset-4">
           저작권신고 및 보호규정
         </li> */}
-      </ul>
+      </div>
       <div className="flex items-center gap-10">
         <Image
           src="/images/gwanglogo.jpg"

--- a/src/entities/home/ui/Footer/index.tsx
+++ b/src/entities/home/ui/Footer/index.tsx
@@ -2,8 +2,8 @@ import Image from "next/image";
 
 export default function Footer() {
   return (
-    <footer className="py-24 bg-gray-100 flex items-center justify-center gap-[5%] text-black mobile:pr-[70px]">
-      <ul className="flex items-center sm:text-body3r text-caption2r gap-5 mobile:flex-col mobile:gap-0">
+    <footer className="py-24 bg-gray-100 flex items-center justify-center gap-[5%] text-black mobile:flex-col mobile:gap-12 mobile:py-20 mobile:px-16">
+      <ul className="flex items-center sm:text-body3r text-caption2r gap-5 mobile:flex-col mobile:gap-4 mobile:items-center mobile:text-center">
         <p>&copy; 2026 光탈페. All rights reserved. </p>
         <a
           className="pr-8 underline underline-offset-4"

--- a/src/shared/ui/SectionTitle/index.tsx
+++ b/src/shared/ui/SectionTitle/index.tsx
@@ -10,7 +10,7 @@ type SectionTitleProps = Readonly<{
 export const SectionTitle = ({ title, description, className }: SectionTitleProps) => {
   return (
     <div className={cn("w-full text-center", className)}>
-      <p className={cn("text-title1b mobile:text-body1b ")}>{title}</p>
+      <p className={cn("text-title1b mobile:text-body2b break-keep")}>{title}</p>
       {description && (
         <p
           className={cn(

--- a/src/shared/ui/SectionTitle/index.tsx
+++ b/src/shared/ui/SectionTitle/index.tsx
@@ -10,7 +10,7 @@ type SectionTitleProps = Readonly<{
 export const SectionTitle = ({ title, description, className }: SectionTitleProps) => {
   return (
     <div className={cn("w-full text-center", className)}>
-      <p className={cn("text-title1b mobile:text-body2b break-keep")}>{title}</p>
+      <h2 className={cn("text-title1b mobile:text-body2b break-keep")}>{title}</h2>
       {description && (
         <p
           className={cn(

--- a/src/widgets/main/ApplyThirdSection/index.tsx
+++ b/src/widgets/main/ApplyThirdSection/index.tsx
@@ -86,7 +86,7 @@ const ApplyThirdSection = () => {
 
       {/* 본문 */}
       <div className="relative z-10 flex flex-col items-center text-center py-[80px] mobile:py-[52px] px-[80px] tablet:px-[40px] mobile:px-16 gap-24 mobile:gap-16">
-        <h2 className="text-title2b tablet:text-title4b mobile:text-h4b text-black">2026 광탈페 참가신청</h2>
+        <h2 className="text-title2b tablet:text-title4b mobile:text-body1b text-black">2026 광탈페 참가신청</h2>
 
         <p className="text-body3r tablet:text-body3r mobile:text-body3r text-gray-700">
           신청기간 : 2026.6.15(월) ~ 6.22(월) 18:00

--- a/src/widgets/main/IntroFirstSection/index.tsx
+++ b/src/widgets/main/IntroFirstSection/index.tsx
@@ -32,7 +32,7 @@ const IntroFirstSection = () => {
         )}
       >
         <div className={cn("w-full", "max-w-[1060px]", "mx-auto", "px-4", "text-white", "tablet:px-8", "mobile:px-6")}>
-          <h1 className={cn("text-[clamp(0.875rem,calc(-1.982rem+7.14vw),2.75rem)]", "tablet:text-[clamp(0.875rem,calc(-1.5rem+6vw),2rem)]", "mobile:text-[clamp(0.875rem,calc(-1.5rem+6vw),2rem)]", "font-bold", "leading-[120%]")}>
+          <h1 className={cn("text-[clamp(0.875rem,calc(-1.982rem+7.14vw),2.75rem)]", "tablet:text-[clamp(0.875rem,calc(-1.5rem+6vw),2rem)]", "mobile:text-[clamp(1.125rem,5.3vw,2rem)]", "font-bold", "leading-[120%]")}>
             光탈페 (광주학생탈렌트페스티벌)
           </h1>
           <p
@@ -40,7 +40,7 @@ const IntroFirstSection = () => {
               "mt-[clamp(0.5rem,calc(-0.5rem+2.5vw),1.5rem)]",
               "text-[clamp(0.6875rem,calc(-1.3125rem+5vw),2rem)]",
               "tablet:text-[clamp(0.6875rem,calc(-0.8125rem+4vw),1.5rem)]",
-              "mobile:text-[clamp(0.6875rem,calc(-0.8125rem+4vw),1.5rem)]",
+              "mobile:text-[clamp(0.875rem,3.8vw,1.5rem)]",
               "leading-[130%]",
               "break-keep",
             )}

--- a/src/widgets/main/PreliminaryFourthSection/index.tsx
+++ b/src/widgets/main/PreliminaryFourthSection/index.tsx
@@ -37,13 +37,13 @@ const PreliminaryFourthSection = () => {
                 "flex w-full flex-col items-start gap-10 justify-between mb-90 mobile:mb-38 mobile:px-16",
               )}
             >
-              <h2
+              <h3
                 className={cn(
                   "text-body2b mobile:text-body3b place-self-start mb-8 mobile:mb-0",
                 )}
               >
                 {title}
-              </h2>
+              </h3>
               <div className={cn("w-full mobile:mt-16")}>
                 <YouTubeLazyEmbed videoId={videoId} title={title} />
               </div>

--- a/src/widgets/main/PreliminaryFourthSection/index.tsx
+++ b/src/widgets/main/PreliminaryFourthSection/index.tsx
@@ -34,17 +34,17 @@ const PreliminaryFourthSection = () => {
             <div
               key={videoId}
               className={cn(
-                "flex w-full flex-col items-start gap-10 justify-between mb-90 mobile:mb-38",
+                "flex w-full flex-col items-start gap-10 justify-between mb-90 mobile:mb-38 mobile:px-16",
               )}
             >
               <h2
                 className={cn(
-                  "text-body2b mobile:text-body3b place-self-start mb-8 mobile:mb-0 mobile:ml-12",
+                  "text-body2b mobile:text-body3b place-self-start mb-8 mobile:mb-0",
                 )}
               >
                 {title}
               </h2>
-              <div className={cn("w-full mobile:mt-16 mobile:px-16")}>
+              <div className={cn("w-full mobile:mt-16")}>
                 <YouTubeLazyEmbed videoId={videoId} title={title} />
               </div>
             </div>

--- a/src/widgets/main/SevenSection/index.tsx
+++ b/src/widgets/main/SevenSection/index.tsx
@@ -9,7 +9,7 @@ export default function SevenSection() {
   // const totalWidth = 18.4375 * GITHUB_ID.length;
   return (
     <section id="SevenSection" className={cn("flex flex-col items-center mt-20 mb-120 mobile:mb-60")}>
-      <div className={cn("w-[75%] mobile:w-full mobile:px-10")}>
+      <div className={cn("w-[75%] mobile:w-full mobile:px-16")}>
         <SectionTitle
           title="광탈페 운영진 소개"
           description="로고 클릭 시 인스타로 이동합니다"

--- a/src/widgets/main/SloganSecondSection/index.tsx
+++ b/src/widgets/main/SloganSecondSection/index.tsx
@@ -52,7 +52,7 @@ const SloganSecondSection = () => {
         }
         description={
           <>
-            <span className="text-black text-body2b">
+            <span className="text-black text-body2b mobile:text-body3b">
               세상의 무대 위, 광탈페! 너의 꿈이 시작되는 순간!
             </span>
             <span className={cn("block")}>


### PR DESCRIPTION
## 💡 PR 요약

- 모바일 환경에서 각 섹션의 레이아웃, 폰트 사이즈, 패딩이 깨지는 문제를 수정합니다.

## 📋 작업 내용

- **Footer**: 모바일에서 `flex-col` 방향으로 변경, 로고/텍스트 간격 및 패딩 조정
- **SectionTitle**: 모바일 타이틀 폰트를 `body1b` → `body2b`로 축소, `break-keep` 추가
- **IntroFirstSection**: 모바일 `clamp` 값 조정으로 소형 화면에서 텍스트 가독성 개선
- **SloganSecondSection**: 모바일에서 설명 텍스트 `body2b` → `body3b`로 축소
- **ApplyThirdSection**: 모바일 섹션 제목 `h4b` → `body1b`로 축소
- **PreliminaryFourthSection**: 모바일 패딩을 내부 요소에서 컨테이너로 이동해 일관성 통일
- **SevenSection**: 모바일 좌우 패딩 `px-10` → `px-16`으로 통일

## 🤝 리뷰 시 참고사항

- 데스크탑/태블릿 레이아웃 변경 없이 모바일(`max: 640px`)만 수정했습니다.
- 폰트 사이즈는 디자인 시스템 토큰 범위 내에서 조정했습니다.
