### PR TITLE
fix: SloganSecondSection hydration-mismatch 수정

### DIFF
--- a/src/widgets/main/SloganSecondSection/index.tsx
+++ b/src/widgets/main/SloganSecondSection/index.tsx
@@ -5,7 +5,7 @@ import SloganMarquee from "@/entities/home/ui/SloganMarquee";
 import PrizeItem from "@/entities/home/ui/PrizeItem";
 import { cn } from "@/shared/utils/cn";
 import { SectionTitle } from "@/shared/ui/SectionTitle";
-import { sloganStartDate, sloganEndDate, isSloganEnded } from "@/shared/config/dateConfig";
+import { sloganStartDate, sloganEndDate } from "@/shared/config/dateConfig";
 
 const PRIZE_LIST = [
   { rank: "2등", bg: "bg-gray-400", emoji: "🍗", desc: "치킨 세트" },
@@ -27,16 +27,15 @@ const SloganSecondSection = () => {
   const [isSloganPeriod, setIsSloganPeriod] = useState(false);
   const [sloganEnded, setSloganEnded] = useState(false);
   useEffect(() => {
-    const checkSloganPeriod = () => {
+    const updateSloganStatus = () => {
       const now = new Date();
       setIsSloganPeriod(now >= sloganStartDate && now <= sloganEndDate);
+      setSloganEnded(now > sloganEndDate);
     };
-    checkSloganPeriod();
-    setSloganEnded(isSloganEnded());
-    const timer = setInterval(() => {
-      checkSloganPeriod();
-      setSloganEnded(isSloganEnded());
-    }, 60000);
+
+    updateSloganStatus();
+
+    const timer = setInterval(updateSloganStatus, 60000);
     return () => clearInterval(timer);
   }, []);
 

--- a/src/widgets/main/SloganSecondSection/index.tsx
+++ b/src/widgets/main/SloganSecondSection/index.tsx
@@ -24,16 +24,17 @@ const SLOGAN_YEAR = sloganStartDate.getFullYear();
 const SloganSecondSection = () => {
   // const router = useRouter();
 
-  const [isSloganPeriod, setIsSloganPeriod] = useState(() => {
-    const now = new Date();
-    return now >= sloganStartDate && now <= sloganEndDate;
-  });
+  const [isSloganPeriod, setIsSloganPeriod] = useState(false);
   const [sloganEnded, setSloganEnded] = useState(false);
   useEffect(() => {
-    setSloganEnded(isSloganEnded());
-    const timer = setInterval(() => {
+    const checkSloganPeriod = () => {
       const now = new Date();
       setIsSloganPeriod(now >= sloganStartDate && now <= sloganEndDate);
+    };
+    checkSloganPeriod();
+    setSloganEnded(isSloganEnded());
+    const timer = setInterval(() => {
+      checkSloganPeriod();
       setSloganEnded(isSloganEnded());
     }, 60000);
     return () => clearInterval(timer);


### PR DESCRIPTION
## 💡 PR 요약

- `isSloganPeriod` 초기값을 `new Date()` 기반 lazy initializer에서 `false`로 변경
- 날짜 체크 로직을 `useEffect`로 이동해 클라이언트에서만 실행되도록 수정

## 📋 작업 내용

`useState`의 lazy initializer 안에서 `new Date()`를 호출하면 서버 렌더링 시점과 클라이언트 실행 시점의 시간 차이로 인해 hydration mismatch가 발생할 수 있습니다.

`isSloganPeriod` 초기값을 `false`(안정적인 기본값)로 고정하고, 기존 `useEffect` 내에 `checkSloganPeriod` 함수를 추출해 마운트 시 즉시 호출 + `setInterval`에서 재사용하는 방식으로 변경했습니다.