### PR TITLE
refactor: 슬로건 수상작 발표 UI 구현

### DIFF
--- a/src/entities/home/ui/SloganMarquee/index.tsx
+++ b/src/entities/home/ui/SloganMarquee/index.tsx
@@ -18,21 +18,32 @@ const assignFonts = (slogans1: ReadonlyArray<string>, slogans2: ReadonlyArray<st
   return [fonts1, fonts2] as const;
 };
 
-const SloganMarquee = (): React.ReactElement => {
+type SloganMarqueeProps = Readonly<{
+  extraSlogans?: ReadonlyArray<string>;
+}>;
+
+const SloganMarquee = ({ extraSlogans }: SloganMarqueeProps): React.ReactElement => {
   const [slogans1, setSlogans1] = useState<ReadonlyArray<string>>([]);
   const [slogans2, setSlogans2] = useState<ReadonlyArray<string>>([]);
   const [fonts1, setFonts1] = useState<ReadonlyArray<FontType>>([]);
   const [fonts2, setFonts2] = useState<ReadonlyArray<FontType>>([]);
 
   const initializeSlogans = useCallback(() => {
-    let firstSlogans: ReadonlyArray<string>;
-    let secondSlogans: ReadonlyArray<string>;
+    let firstSlogans: string[];
+    let secondSlogans: string[];
 
     try {
-      [firstSlogans, secondSlogans] = getRandomSubset(slogansMock, 8);
+      const [s1, s2] = getRandomSubset(slogansMock, 8);
+      firstSlogans = [...s1];
+      secondSlogans = [...s2];
     } catch {
-      firstSlogans = slogansMock.slice(0, 4);
-      secondSlogans = slogansMock.slice(4, 8);
+      firstSlogans = [...slogansMock.slice(0, 4)];
+      secondSlogans = [...slogansMock.slice(4, 8)];
+    }
+
+    if (extraSlogans && extraSlogans.length > 0) {
+      firstSlogans = [...firstSlogans, ...extraSlogans].sort(() => Math.random() - 0.5);
+      secondSlogans = [...secondSlogans, ...extraSlogans].sort(() => Math.random() - 0.5);
     }
 
     const [f1, f2] = assignFonts(firstSlogans, secondSlogans);
@@ -40,7 +51,7 @@ const SloganMarquee = (): React.ReactElement => {
     setSlogans2(secondSlogans);
     setFonts1(f1);
     setFonts2(f2);
-  }, []);
+  }, [extraSlogans]);
 
   useEffect(() => {
     initializeSlogans();

--- a/src/shared/config/dateConfig.ts
+++ b/src/shared/config/dateConfig.ts
@@ -12,6 +12,8 @@ export const isSloganPeriod = () => {
   return now >= sloganStartDate && now <= sloganEndDate;
 };
 export const isSloganEnded = () => new Date() > sloganEndDate;
+export const sloganAwardDate = new Date("2026-06-09T08:00:00+09:00");
+export const isSloganAwardReleased = () => new Date() >= sloganAwardDate;
 
 export const applyStartDate = new Date(
   process.env.NEXT_PUBLIC_APPLY_START_DATE ?? "2026-06-15T00:00:00+09:00",

--- a/src/widgets/main/SloganSecondSection/index.tsx
+++ b/src/widgets/main/SloganSecondSection/index.tsx
@@ -5,13 +5,26 @@ import SloganMarquee from "@/entities/home/ui/SloganMarquee";
 import PrizeItem from "@/entities/home/ui/PrizeItem";
 import { cn } from "@/shared/utils/cn";
 import { SectionTitle } from "@/shared/ui/SectionTitle";
-import { sloganStartDate, sloganEndDate } from "@/shared/config/dateConfig";
+import { sloganStartDate, sloganEndDate, isSloganAwardReleased } from "@/shared/config/dateConfig";
 
 const PRIZE_LIST = [
   { rank: "2등", bg: "bg-gray-400", emoji: "🍗", desc: "치킨 세트" },
   { rank: "1등", bg: "bg-[#E8B84B]", emoji: "🎁", desc: "수상자 해당 학습 간식" },
   { rank: "3등", bg: "bg-[#9B5E3B]", emoji: "🍔", desc: "햄버거 세트" },
 ];
+
+const AWARD_LIST = [
+  { rank: "2등", bg: "bg-gray-400", school: "광주송원여자고등학교", name: "주*서" },
+  { rank: "1등", bg: "bg-[#E8B84B]", school: "광주소프트웨어마이스터고", name: "김*솔" },
+  { rank: "3등", bg: "bg-[#9B5E3B]", school: "광주소프트웨어마이스터고", name: "이*" },
+] as const;
+
+const FIRST_PLACE_SLOGAN = "빛고을에 울려 퍼지는 우리의 끼, 광탈페에서!";
+const MARQUEE_EXTRA_SLOGANS = [
+  "빛고을에 울려 퍼지는 우리의 끼, 광탈페에서!",
+  "우리가 만드는 가장 찬란한 순간, 청춘의 에너지를 무한한 가능성으로!",
+  "너의 재능을 ON, 광주의 미래를 ON!",
+] as const;
 
 // import { formatDate } from "@/shared/utils/formatDate";
 // import Button from "@/shared/ui/Button";
@@ -22,15 +35,16 @@ const SLOGAN_YEAR = sloganStartDate.getFullYear();
 // const submissionPeriodText = `공모기간 : ${SLOGAN_YEAR}.${formatDate(sloganStartDate)}~${formatDate(sloganEndDate)}`;
 
 const SloganSecondSection = () => {
-  // const router = useRouter();
-
   const [isSloganPeriod, setIsSloganPeriod] = useState(false);
   const [sloganEnded, setSloganEnded] = useState(false);
+  const [awardReleased, setAwardReleased] = useState(() => isSloganAwardReleased());
+
   useEffect(() => {
     const updateSloganStatus = () => {
       const now = new Date();
       setIsSloganPeriod(now >= sloganStartDate && now <= sloganEndDate);
       setSloganEnded(now > sloganEndDate);
+      setAwardReleased(isSloganAwardReleased());
     };
 
     updateSloganStatus();
@@ -46,50 +60,73 @@ const SloganSecondSection = () => {
     >
       <SectionTitle
         title={
-          sloganEnded
-            ? `${SLOGAN_YEAR} 광탈페 슬로건 접수마감 되었습니다`
-            : `${SLOGAN_YEAR} 광탈페 슬로건 ${isSloganPeriod ? "공모중" : "공모예정"}`
+          awardReleased
+            ? `${SLOGAN_YEAR} 광탈페 슬로건`
+            : sloganEnded
+              ? `${SLOGAN_YEAR} 광탈페 슬로건 접수마감 되었습니다`
+              : `${SLOGAN_YEAR} 광탈페 슬로건 ${isSloganPeriod ? "공모중" : "공모예정"}`
         }
         description={
-          <>
-            <span className="text-black text-body2b mobile:text-body3b">
-              세상의 무대 위, 광탈페! 너의 꿈이 시작되는 순간!
-            </span>
-            <span className={cn("block")}>
-              {SLOGAN_YEAR}년 모두가 주인공이 되는 광주학생탈렌트페스티벌의 꿈의 무대가 펼쳐집니다.
-            </span>
-          </>
+          awardReleased ? (
+            <>
+              <span className="inline-block text-black text-body2b mobile:text-body3b mb-[8px]">
+                {FIRST_PLACE_SLOGAN}
+              </span>
+              <span className={cn("block")}>
+                {SLOGAN_YEAR}년 모두가 주인공이 되는 광주학생탈렌트페스티벌의 꿈의 무대가
+                펼쳐집니다.
+              </span>
+            </>
+          ) : (
+            <>
+              <span className="text-black text-body2b mobile:text-body3b">
+                세상의 무대 위, 광탈페! 너의 꿈이 시작되는 순간!
+              </span>
+              <span className={cn("block")}>
+                {SLOGAN_YEAR}년 모두가 주인공이 되는 광주학생탈렌트페스티벌의 꿈의 무대가
+                펼쳐집니다.
+              </span>
+            </>
+          )
         }
       />
 
-      <SloganMarquee />
-
-      {/* <Button
-        type="button"
-        onClick={() => router.push("/slogan")}
-        className={cn("mobile:mb-[12px] px-28 mt-[54px] mb-[10px] rounded-lg")}
-        disabled={!isSloganPeriod}
-      >
-        <span className={cn("text-body3b px-[60px] mobile:text-body3b flex items-center gap-10")}>
-          {isSloganPeriod ? "슬로건 공모하러가기" : "공모기간이 아닙니다"}{" "}
-          <ArrowBack color={isSloganPeriod ? "white" : "#1F2937"} />
-        </span>
-      </Button>
-
-      <div className={cn("text-caption1r mobile:text-caption2r text-gray-400")}>
-        {submissionPeriodText}
-      </div> */}
+      <SloganMarquee extraSlogans={awardReleased ? MARQUEE_EXTRA_SLOGANS : undefined} />
 
       <div className={cn("mt-[54px] mb-[10px] flex flex-col items-center gap-8")}>
-        <div className={cn("w-full flex justify-center gap-[60px] mobile:gap-[24px] mb-[24px]")}>
-          {PRIZE_LIST.map((item) => (
-            <PrizeItem key={item.rank} {...item} />
-          ))}
-        </div>
-        <p className={cn("text-body2b mobile:text-body3b text-gray-700")}>
-          공모 접수내용에 대해 심사중입니다.
-        </p>
-        <p className={cn("text-body3r text-gray-700")}>결과발표 : 2026. 6. 9.(예정)</p>
+        {awardReleased ? (
+          <div className="relative w-full flex justify-center">
+            <div className={cn("flex justify-center gap-[60px] mobile:gap-[24px]")}>
+              {AWARD_LIST.map(item => (
+                <div key={item.rank} className="flex flex-col items-center gap-[16px]">
+                  <div
+                    className={`w-[60px] h-[60px] mobile:w-[36px] mobile:h-[36px] flex justify-center items-center rounded-full text-white text-body1r mobile:text-caption2r ${item.bg}`}
+                  >
+                    {item.rank}
+                  </div>
+                  <div className="flex flex-col items-center gap-[4px] text-body3r mobile:text-caption2r text-gray-700">
+                    <span>{item.school}</span>
+                    <span>{item.name}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <>
+            <div
+              className={cn("w-full flex justify-center gap-[60px] mobile:gap-[24px] mb-[24px]")}
+            >
+              {PRIZE_LIST.map(item => (
+                <PrizeItem key={item.rank} {...item} />
+              ))}
+            </div>
+            <p className={cn("text-body2b mobile:text-body3b text-gray-700")}>
+              공모 접수내용에 대해 심사중입니다.
+            </p>
+            <p className={cn("text-body3r text-gray-700")}>결과발표 : 2026. 6. 9.(예정)</p>
+          </>
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
## 💡 PR 요약

- 슬로건 수상 발표일(`2026-06-09 08:00 KST`) 기준으로 UI가 자동 전환되는 수상작 발표 기능을 구현합니다.

## 📋 작업 내용

- **`dateConfig.ts`**: `sloganAwardDate` 상수 및 `isSloganAwardReleased()` 함수 추가
- **`SloganMarquee`**: `extraSlogans` prop 추가 — 수상작 3개(1등/2등/3등)를 마퀴 양쪽 row에 랜덤으로 섞어서 표시
- **`SloganSecondSection`**: `awardReleased` 상태 추가 및 날짜 도달 시 UI 자동 전환
  - 섹션 제목: `"2026 광탈페 슬로건"`으로 변경
  - 1등 슬로건 텍스트(`빛고을에 울려 퍼지는 우리의 끼, 광탈페에서!`) 표시
  - 수상자 정보(등수 배지 + 학교명 + 이름) 표시
  - 기존 "심사중" / "결과발표 예정" 문구 제거

## 🤝 리뷰 시 참고사항

- `sloganAwardDate`는 `2026-06-09T08:00:00+09:00`으로 설정되어 있으며, 해당 시각 이후 자동으로 수상 발표 UI로 전환됩니다.
- 수상자 정보(`AWARD_LIST`)는 컴포넌트 상단 상수로 관리하고 있습니다.
- `extraSlogans`는 수상 발표 전에는 전달하지 않아(`undefined`) 기존 마퀴 동작을 유지합니다.