### PR TITLE
fix: 회원가입 요청 필드명 통일 및 인증 API 응답 처리 단순화

### DIFF
--- a/src/entities/user/api/signup.ts
+++ b/src/entities/user/api/signup.ts
@@ -1,4 +1,4 @@
-import { SignUpRequest } from "../model/schema";
+import { SignUpRequest, ApiError } from "../model/schema";
 
 export const signUp = async (data: SignUpRequest): Promise<void> => {
   const response = await fetch("/api/signup", {
@@ -8,7 +8,7 @@ export const signUp = async (data: SignUpRequest): Promise<void> => {
   });
 
   if (!response.ok) {
-    const result = await response.json().catch(() => ({}));
+    const result = (await response.json().catch(() => ({}))) as Partial<ApiError>;
     throw new Error(result.message || "회원가입에 실패했습니다.");
   }
 };

--- a/src/entities/user/api/signup.ts
+++ b/src/entities/user/api/signup.ts
@@ -1,17 +1,14 @@
-import { SignUpRequest, SignUpResponse } from "../model/schema";
+import { SignUpRequest } from "../model/schema";
 
-export const signUp = async (data: SignUpRequest): Promise<SignUpResponse> => {
+export const signUp = async (data: SignUpRequest): Promise<void> => {
   const response = await fetch("/api/signup", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   });
 
-  const result = await response.json();
-
   if (!response.ok) {
+    const result = await response.json().catch(() => ({}));
     throw new Error(result.message || "회원가입에 실패했습니다.");
   }
-
-  return result;
 };

--- a/src/entities/user/api/verify.ts
+++ b/src/entities/user/api/verify.ts
@@ -1,23 +1,14 @@
-import { PhoneVerificationRequest, PhoneVerificationResponse } from "../model/schema";
+import { PhoneVerificationRequest } from "../model/schema";
 
-export const sendVerificationCode = async (
-  data: PhoneVerificationRequest,
-): Promise<PhoneVerificationResponse> => {
+export const sendVerificationCode = async (data: PhoneVerificationRequest): Promise<void> => {
   const response = await fetch("/api/verify", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   });
 
-  const result = await response.json();
-
   if (!response.ok) {
+    const result = await response.json().catch(() => ({}));
     throw new Error(result.message || "인증번호 전송에 실패했습니다.");
   }
-
-  if (!result || Object.keys(result).length === 0) {
-    return { success: true, message: "인증번호가 전송되었습니다." };
-  }
-
-  return result;
 };

--- a/src/entities/user/api/verify.ts
+++ b/src/entities/user/api/verify.ts
@@ -1,4 +1,4 @@
-import { PhoneVerificationRequest } from "../model/schema";
+import { PhoneVerificationRequest, ApiError } from "../model/schema";
 
 export const sendVerificationCode = async (data: PhoneVerificationRequest): Promise<void> => {
   const response = await fetch("/api/verify", {
@@ -8,7 +8,7 @@ export const sendVerificationCode = async (data: PhoneVerificationRequest): Prom
   });
 
   if (!response.ok) {
-    const result = await response.json().catch(() => ({}));
+    const result = (await response.json().catch(() => ({}))) as Partial<ApiError>;
     throw new Error(result.message || "인증번호 전송에 실패했습니다.");
   }
 };

--- a/src/entities/user/model/schema.ts
+++ b/src/entities/user/model/schema.ts
@@ -46,24 +46,10 @@ export interface PhoneVerificationRequest {
   phoneNumber: string;
 }
 
-export interface PhoneVerificationResponse {
-  success?: boolean;
-  message?: string;
-}
-
 export interface SignUpRequest {
   phoneNumber: string;
   code: string;
   password: string;
-}
-
-export interface SignUpResponse {
-  success: boolean;
-  message: string;
-  user?: {
-    id: string;
-    phone_number: string;
-  };
 }
 
 export interface ApiError {

--- a/src/entities/user/model/schema.ts
+++ b/src/entities/user/model/schema.ts
@@ -52,7 +52,7 @@ export interface PhoneVerificationResponse {
 }
 
 export interface SignUpRequest {
-  phone_number: string;
+  phoneNumber: string;
   code: string;
   password: string;
 }

--- a/src/widgets/signup/lib/__tests__/handleSignupFormSubmit.test.ts
+++ b/src/widgets/signup/lib/__tests__/handleSignupFormSubmit.test.ts
@@ -72,7 +72,7 @@ describe("handleSignupFormSubmit - 비밀번호 확인", () => {
 
 describe("handleSignupFormSubmit - 회원가입 성공", () => {
   it("/signin으로 리다이렉트한다", async () => {
-    mockSignUp.mockResolvedValue({ success: true, message: "가입 완료" });
+    mockSignUp.mockResolvedValue(undefined);
     const result = await handleSignupFormSubmit(INITIAL_STATE, makeFormData(VALID_FORM));
     expect(result.isValid).toBe(true);
     expect(result.shouldRedirect).toBe(true);
@@ -80,10 +80,10 @@ describe("handleSignupFormSubmit - 회원가입 성공", () => {
   });
 
   it("signUp API에 올바른 데이터를 전달한다", async () => {
-    mockSignUp.mockResolvedValue({ success: true, message: "가입 완료" });
+    mockSignUp.mockResolvedValue(undefined);
     await handleSignupFormSubmit(INITIAL_STATE, makeFormData(VALID_FORM));
     expect(mockSignUp).toHaveBeenCalledWith({
-      phone_number: "01012345678",
+      phoneNumber: "01012345678",
       code: "123456",
       password: "pass1234",
     });

--- a/src/widgets/signup/lib/handleSignupFormSubmit.ts
+++ b/src/widgets/signup/lib/handleSignupFormSubmit.ts
@@ -35,7 +35,7 @@ export const handleSignupFormSubmit = async (
 
   try {
     const requestData = {
-      phone_number: values.phoneNumber,
+      phoneNumber: values.phoneNumber,
       code: values.verificationCode,
       password: values.password,
     };

--- a/src/widgets/signup/ui/SignupFormContainer/index.tsx
+++ b/src/widgets/signup/ui/SignupFormContainer/index.tsx
@@ -55,16 +55,9 @@ const SignupFormContainer = () => {
     setIsCodeSending(true);
 
     try {
-      const response = await sendVerificationCode({
-        phoneNumber: phoneNumber,
-      });
-
-      if (response.success) {
-        toast.success("인증번호가 전송되었습니다.");
-        setCodeSent(true);
-      } else {
-        throw new Error(response.message);
-      }
+      await sendVerificationCode({ phoneNumber });
+      toast.success("인증번호가 전송되었습니다.");
+      setCodeSent(true);
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "인증번호 전송에 실패했습니다.");
     } finally {


### PR DESCRIPTION
## 💡 PR 요약

> 해당 PR의 변경사항, 해당 이슈 등에 대한 간략한 설명을 작성해주세요.

- 회원가입 요청 필드명을 `phone_number`에서 `phoneNumber`로 통일
- 인증 관련 API(`signUp`, `sendVerificationCode`)의 응답 타입을 제거하고 `void` 반환으로 단순화
- 응답 본문에 의존하던 성공 판정 로직을 HTTP 상태 기반으로 정리

## 📋 작업 내용

> 해당 PR에서 작업한 내용을 자세히 설명해주세요.

- `SignUpRequest`의 `phone_number` 필드를 `phoneNumber`로 변경하여 요청 페이로드 네이밍을 카멜케이스로 통일했습니다. `handleSignupFormSubmit`의 요청 데이터 구성도 함께 수정했습니다.
- `signUp`, `sendVerificationCode` API에서 더 이상 사용하지 않는 `SignUpResponse`, `PhoneVerificationResponse` 타입을 제거하고 반환 타입을 `void`로 단순화했습니다.
- 성공 시 응답 본문을 파싱하지 않고, 실패(`!response.ok`)인 경우에만 메시지를 파싱하도록 변경했습니다. 본문 파싱 실패에 대비해 `.catch(() => ({}))`로 폴백을 두었습니다.
- `SignupFormContainer`에서 응답의 `success` 필드로 성공을 판정하던 분기를 제거하고, 예외가 발생하지 않으면 성공으로 처리하도록 정리했습니다.
- 위 변경에 맞춰 회원가입 폼 제출 테스트의 mock 반환값(`undefined`)과 기대 필드명(`phoneNumber`)을 갱신했습니다.