### PR TITLE
fix: 인증 API 응답 타입 정규화 및 Role 값 통일

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -83,31 +83,31 @@ describe("middleware - /signin 리다이렉트", () => {
 });
 
 describe("middleware - 어드민 접근 제어", () => {
-  it("ROLE_ADMIN이 아니면 /admin 접근 시 /home으로 리다이렉트한다", () => {
+  it("ADMIN이 아니면 /admin 접근 시 /home으로 리다이렉트한다", () => {
     const res = middleware(
-      makeRequest("/admin/dashboard", { accessToken: "abc", refreshToken: "xyz", role: "ROLE_USER" }),
+      makeRequest("/admin/dashboard", { accessToken: "abc", refreshToken: "xyz", role: "USER" }),
     );
     expect(res.status).toBe(307);
     expect(getLocation(res)).toContain("/home");
   });
 
-  it("ROLE_ADMIN이면 /admin 접근이 허용된다", () => {
+  it("ADMIN이면 /admin 접근이 허용된다", () => {
     const res = middleware(
-      makeRequest("/admin/dashboard", { accessToken: "abc", refreshToken: "xyz", role: "ROLE_ADMIN" }),
+      makeRequest("/admin/dashboard", { accessToken: "abc", refreshToken: "xyz", role: "ADMIN" }),
     );
     expect(res.status).toBe(200);
   });
 
   it("/admin/lottery/:id는 비어드민도 접근 가능하다", () => {
     const res = middleware(
-      makeRequest("/admin/lottery/123", { accessToken: "abc", refreshToken: "xyz", role: "ROLE_USER" }),
+      makeRequest("/admin/lottery/123", { accessToken: "abc", refreshToken: "xyz", role: "USER" }),
     );
     expect(res.status).toBe(200);
   });
 
   it("/admin/score/:id는 비어드민도 접근 가능하다", () => {
     const res = middleware(
-      makeRequest("/admin/score/456", { accessToken: "abc", refreshToken: "xyz", role: "ROLE_USER" }),
+      makeRequest("/admin/score/456", { accessToken: "abc", refreshToken: "xyz", role: "USER" }),
     );
     expect(res.status).toBe(200);
   });
@@ -120,20 +120,20 @@ describe("middleware - publicIn27 (축제 날짜 접근 제한)", () => {
 
   it("축제 이전에는 비어드민의 /vote 접근을 /home으로 리다이렉트한다", () => {
     vi.setSystemTime(new Date("2025-09-20T00:00:00"));
-    const res = middleware(makeRequest("/vote", { role: "ROLE_USER" }));
+    const res = middleware(makeRequest("/vote", { role: "USER" }));
     expect(res.status).toBe(307);
     expect(getLocation(res)).toContain("/home");
   });
 
   it("축제 이후에는 비어드민도 /vote 접근이 허용된다", () => {
     vi.setSystemTime(new Date("2025-09-28T00:00:00"));
-    const res = middleware(makeRequest("/vote", { role: "ROLE_USER" }));
+    const res = middleware(makeRequest("/vote", { role: "USER" }));
     expect(res.status).toBe(200);
   });
 
   it("어드민은 축제 이전에도 /vote 접근이 허용된다", () => {
     vi.setSystemTime(new Date("2025-09-20T00:00:00"));
-    const res = middleware(makeRequest("/vote", { accessToken: "abc", refreshToken: "xyz", role: "ROLE_ADMIN" }));
+    const res = middleware(makeRequest("/vote", { accessToken: "abc", refreshToken: "xyz", role: "ADMIN" }));
     expect(res.status).toBe(200);
   });
 });

--- a/src/entities/booking/api/getMySeat.ts
+++ b/src/entities/booking/api/getMySeat.ts
@@ -35,11 +35,11 @@ export const getMySeat = async (): Promise<Seat | null> => {
   try {
     const role = getTokenFromCookie("role");
 
-    const endpoint = role === "ROLE_PERFORMER" ? "/api/seat/myself/performer" : "/api/seat/myself";
+    const endpoint = role === "PERFORMER" ? "/api/seat/myself/performer" : "/api/seat/myself";
 
     const response = await axios.get<MySeatApiResponse | PerformerSeatsApiResponse>(endpoint);
 
-    if (role === "ROLE_PERFORMER") {
+    if (role === "PERFORMER") {
       const data = response.data as PerformerSeatsApiResponse;
       if (data.length === 0) {
         return null;

--- a/src/entities/booking/lib/useMySeat.ts
+++ b/src/entities/booking/lib/useMySeat.ts
@@ -91,7 +91,7 @@ export const useMyBookedSeats = () => {
     queryFn: () => getMySeat(),
     staleTime: 0,
     gcTime: 1000 * 60 * 10,
-    enabled: isClient && !isPerformer,
+    enabled: isClient && !!role && !isPerformer,
   });
 
   const multiSeatsQueryWithCondition = useQuery<Seat[], Error, Seat[]>({
@@ -99,7 +99,7 @@ export const useMyBookedSeats = () => {
     queryFn: () => getMySeats(),
     staleTime: 0,
     gcTime: 1000 * 60 * 10,
-    enabled: isClient && isPerformer,
+    enabled: isClient && !!role && isPerformer,
   });
 
   if (!isClient) {

--- a/src/entities/booking/lib/useMySeat.ts
+++ b/src/entities/booking/lib/useMySeat.ts
@@ -84,7 +84,7 @@ export const useMyBookedSeats = () => {
     }
   }, []);
 
-  const isPerformer = role === "ROLE_PERFORMER";
+  const isPerformer = role === "PERFORMER";
 
   const singleSeatQueryWithCondition = useQuery<Seat | null, Error, Seat | null>({
     queryKey: ["mySeat"],

--- a/src/entities/user/model/schema.ts
+++ b/src/entities/user/model/schema.ts
@@ -28,17 +28,17 @@ export const phoneVerificationRequestSchema = z.object({
 });
 
 export interface SignInRequest {
-  phone_number: string;
+  phoneNumber: string;
   password: string;
 }
 
-export type Role = "ROLE_USER" | "ROLE_ADMIN" | "ROLE_PERFORMER";
+export type Role = "USER" | "ADMIN" | "PERFORMER";
 
 export interface SignInResponse {
-  access_token: string;
-  access_token_expired_at: string;
-  refresh_token: string;
-  refresh_token_expired_at: string;
+  accessToken: string;
+  accessTokenExpiresAt: string;
+  refreshToken: string;
+  refreshTokenExpiresAt: string;
   role: Role;
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,7 +18,7 @@ export function middleware(request: NextRequest) {
     pathname.match(/^\/admin\/lottery\/[^/]+$/) ||
     pathname.match(/^\/admin\/score\/[^/]+$/) ||
     pathname.match(/^\/admin\/apply\/[^/]+$/);
-  if (role !== "ROLE_ADMIN" && pathname.startsWith("/admin") && !isPublicAdminPath) {
+  if (role !== "ADMIN" && pathname.startsWith("/admin") && !isPublicAdminPath) {
     return NextResponse.redirect(new URL("/home", request.url));
   }
 
@@ -53,7 +53,7 @@ export function middleware(request: NextRequest) {
   }
 
   if (publicIn27.includes(pathname)) {
-    if (role !== "ROLE_ADMIN" && new Date() < festivalDate) {
+    if (role !== "ADMIN" && new Date() < festivalDate) {
       return NextResponse.redirect(new URL("/home", request.url));
     }
   }

--- a/src/views/booking/ui/BookingPage/index.tsx
+++ b/src/views/booking/ui/BookingPage/index.tsx
@@ -47,7 +47,7 @@ const BookingPage = () => {
     setUserRole(role);
   }, []);
 
-  const isPerformer = userRole === "ROLE_PERFORMER";
+  const isPerformer = userRole === "PERFORMER";
   const handleSectionSelect = useCallback(
     (section: SectionType) => {
       if (isPerformer) {

--- a/src/widgets/main/ReservationFifthSection/index.tsx
+++ b/src/widgets/main/ReservationFifthSection/index.tsx
@@ -66,7 +66,7 @@ const ReservationFifthSection = () => {
   //   const calculateTimeLeft = () => {
   //     const now = new Date();
   //     const relevantTicketOpenDate =
-  //       userRole === "ROLE_PERFORMER" ? performerTicketOpenDate : ticketOpenDate;
+  //       userRole === "PERFORMER" ? performerTicketOpenDate : ticketOpenDate;
   //     const difference = relevantTicketOpenDate.getTime() - now.getTime();
   //     setTimeLeft(difference > 0 ? difference : 0);
   //   };
@@ -118,7 +118,7 @@ const ReservationFifthSection = () => {
           {/* <div className={cn("text-title1b text-main-600 mobile:text-body1b")}>
             {/* {timeLeft > 0 ? (
               formatDateLeft(timeLeft)
-            ) : mySeat && userRole === "ROLE_PERFORMER" ? (
+            ) : mySeat && userRole === "PERFORMER" ? (
               <div className="flex gap-2 w-full">
                 <Button
                   className="flex-1"
@@ -153,7 +153,7 @@ const ReservationFifthSection = () => {
           {/* <div className={cn("flex justify-center gap-4 items-center")}>
             <span className={cn("text-body2r mobile:text-caption2r")}>티켓오픈</span>
             <span className={cn("text-body2r text-gray-500 mobile:text-caption2r")}>
-              {(userRole === "ROLE_PERFORMER"
+              {(userRole === "PERFORMER"
                 ? performerTicketOpenDate
                 : ticketOpenDate
               ).toLocaleString("ko-KR", {

--- a/src/widgets/signin/lib/__tests__/handleSigninFormSubmit.test.ts
+++ b/src/widgets/signin/lib/__tests__/handleSigninFormSubmit.test.ts
@@ -12,11 +12,11 @@ const mockSetTokens = vi.mocked(setTokens);
 const mockSetRole = vi.mocked(setRole);
 
 const MOCK_RESPONSE = {
-  access_token: "access-abc",
-  access_token_expired_at: new Date(Date.now() + 3_600_000).toISOString(),
-  refresh_token: "refresh-xyz",
-  refresh_token_expired_at: new Date(Date.now() + 86_400_000).toISOString(),
-  role: "ROLE_USER" as const,
+  accessToken: "access-abc",
+  accessTokenExpiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+  refreshToken: "refresh-xyz",
+  refreshTokenExpiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+  role: "USER" as const,
 };
 
 const INITIAL_STATE = { values: {}, isValid: false, submitted: false };
@@ -77,10 +77,10 @@ describe("handleSigninFormSubmit - 로그인 성공", () => {
       makeFormData({ phoneNumber: "01012345678", password: "pass1234" }),
     );
     expect(mockSetTokens).toHaveBeenCalledWith(
-      MOCK_RESPONSE.access_token,
-      MOCK_RESPONSE.access_token_expired_at,
-      MOCK_RESPONSE.refresh_token,
-      MOCK_RESPONSE.refresh_token_expired_at,
+      MOCK_RESPONSE.accessToken,
+      MOCK_RESPONSE.accessTokenExpiresAt,
+      MOCK_RESPONSE.refreshToken,
+      MOCK_RESPONSE.refreshTokenExpiresAt,
     );
     expect(mockSetRole).toHaveBeenCalledWith(MOCK_RESPONSE.role);
   });

--- a/src/widgets/signin/lib/handleSigninFormSubmit.ts
+++ b/src/widgets/signin/lib/handleSigninFormSubmit.ts
@@ -23,18 +23,13 @@ export const handleSigninFormSubmit = async (
   }
 
   try {
-    const requestData = {
-      phone_number: values.phoneNumber,
-      password: values.password,
-    };
-
-    const response = await signin(requestData);
+    const response = await signin(values);
 
     setTokens(
-      response.access_token,
-      response.access_token_expired_at,
-      response.refresh_token,
-      response.refresh_token_expired_at,
+      response.accessToken,
+      response.accessTokenExpiresAt,
+      response.refreshToken,
+      response.refreshTokenExpiresAt,
     );
 
     setRole(response.role);


### PR DESCRIPTION
## 💡 PR 요약

- 백엔드 API 명세와의 불일치 해결
- API 응답/요청 타입을 camelCase로 정규화
- Role 값을 `ROLE_*` → `*` 형식으로 통일

## 📋 작업 내용

### 타입 정의 수정 (schema.ts)
- `SignInRequest.phone_number` → `phoneNumber`
- `SignInResponse` 필드명 정규화:
  - `access_token` → `accessToken`
  - `access_token_expired_at` → `accessTokenExpiresAt`
  - `refresh_token` → `refreshToken`
  - `refresh_token_expired_at` → `refreshTokenExpiresAt`
- Role 타입값: `ROLE_USER` → `USER`, `ROLE_ADMIN` → `ADMIN`, `ROLE_PERFORMER` → `PERFORMER`

### API 함수 및 핸들러 업데이트
- `handleSigninFormSubmit.ts`: 응답 필드명 적용
- 불필요한 요청 데이터 변환 제거

### 테스트 및 컴포넌트 업데이트
- 모의 응답 데이터 형식 수정
- middleware, BookingPage, getMySeat, useMySeat, ReservationFifthSection에서 Role 값 정규화
- 모든 테스트 통과 (262 tests passed)

## 🤝 리뷰 시 참고사항

- 로컬 API 라우트(`/api/signin`, `/api/signup`)를 통해 백엔드로 프록시하는 구조로, 클라이언트는 로컬 라우트를 호출합니다
- Role 값 정규화로 인해 관련 코드가 여러 파일에 분산되어 있으니 전체적인 일관성을 확인해주세요