### PR TITLE
refactor: NCP Object Storage에서 Cloudflare R2로 스토리지 마이그레이션 대응

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -48,12 +48,6 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: "https",
-        hostname: "kr.object.ncloudstorage.com",
-        port: "",
-        pathname: "/gwangju-talent-festival-bucket/**",
-      },
-      {
-        protocol: "https",
         hostname: "avatars.githubusercontent.com",
         port: "",
         pathname: "/u/**",

--- a/src/entities/apply/api/postApply.ts
+++ b/src/entities/apply/api/postApply.ts
@@ -9,7 +9,7 @@ export interface ApplyFormData {
   videoFile: File;
 }
 
-const uploadToS3WithProgress = (
+const uploadVideoWithProgress = (
   uploadUrl: string,
   file: File,
   onProgress?: (percent: number) => void
@@ -55,8 +55,8 @@ export const postApply = async (
   }
   const { key, uploadUrl } = (await uploadUrlRes.json()) as { key: string; uploadUrl: string };
 
-  // 2단계: S3 직접 업로드 (presigned PUT)
-  await uploadToS3WithProgress(uploadUrl, data.videoFile, onProgress);
+  // 2단계: R2 직접 업로드 (presigned PUT)
+  await uploadVideoWithProgress(uploadUrl, data.videoFile, onProgress);
 
   // 3단계: 백엔드에 업로드 확정
   const videoFileName = `${data.field}_${data.teamName}_${data.school}_${data.representative}_${data.contact}.mp4`;

--- a/src/entities/home/ui/Video/index.tsx
+++ b/src/entities/home/ui/Video/index.tsx
@@ -10,7 +10,7 @@ export interface VideoProps {
 }
 
 const Video = ({
-  link = "https://kr.object.ncloudstorage.com/gwangju-talent-festival-bucket/video%20(2).mp4",
+  link = process.env.NEXT_PUBLIC_HOME_VIDEO_URL ?? "",
   className,
   visibleCaption = true,
 }: VideoProps) => {


### PR DESCRIPTION
## 💡 PR 요약

- 백엔드 PR #140(NCP → Cloudflare R2 마이그레이션) 완료에 따른 프론트엔드 대응 작업
- API 계약 변경은 없으며, 코드 표현 및 설정 파일의 인프라 참조를 R2 기준으로 정리

## 📋 작업 내용

- `postApply.ts`: 함수명 `uploadToS3WithProgress` → `uploadVideoWithProgress` 변경 및 주석 "R2 직접 업로드"로 수정
- `Video/index.tsx`: 하드코딩된 NCP 영상 URL을 `NEXT_PUBLIC_HOME_VIDEO_URL` 환경변수로 분리
- `next.config.ts`: 미사용 NCP 도메인(`kr.object.ncloudstorage.com`) remotePatterns 항목 제거

## 🤝 리뷰 시 참고사항

- `.env`의 `NEXT_PUBLIC_HOME_VIDEO_URL` 값은 현재 NCP URL로 세팅되어 있으며, R2 마이그레이션 완료 후 R2 URL로 교체 필요
- `Video` 컴포넌트의 `link` prop 기본값이 환경변수를 참조하므로, 환경변수 누락 시 빈 문자열로 폴백됨
