### PR TITLE
feat: apply 영상 업로드 멀티파트 방식 전환 및 NCP 마이그레이션 롤백

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -48,6 +48,12 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: "https",
+        hostname: "kr.object.ncloudstorage.com",
+        port: "",
+        pathname: "/gwangju-talent-festival-bucket/**",
+      },
+      {
+        protocol: "https",
         hostname: "avatars.githubusercontent.com",
         port: "",
         pathname: "/u/**",

--- a/src/entities/apply/api/postApply.ts
+++ b/src/entities/apply/api/postApply.ts
@@ -66,8 +66,8 @@ export const postApply = async (
   if (!partUrlsRes.ok) {
     throw new Error("업로드 URL 발급에 실패했습니다. 잠시 후 다시 시도해주세요.");
   }
-  const { partUrls } = (await partUrlsRes.json()) as {
-    partUrls: { partNumber: number; uploadUrl: string }[];
+  const { parts: presignedParts } = (await partUrlsRes.json()) as {
+    parts: { partNumber: number; url: string }[];
   };
 
   // 3단계: 파트별 순차 업로드 (진행률 추적)
@@ -75,12 +75,12 @@ export const postApply = async (
   let uploadedBytes = 0;
 
   try {
-    for (const { partNumber, uploadUrl } of partUrls) {
+    for (const { partNumber, url } of presignedParts) {
       const start = (partNumber - 1) * PART_SIZE;
       const end = Math.min(start + PART_SIZE, data.videoFile.size);
       const chunk = data.videoFile.slice(start, end);
 
-      const etag = await uploadPart(chunk, uploadUrl, (loaded) => {
+      const etag = await uploadPart(chunk, url, (loaded) => {
         if (onProgress) {
           onProgress(Math.round(((uploadedBytes + loaded) / data.videoFile.size) * 100));
         }

--- a/src/entities/apply/api/postApply.ts
+++ b/src/entities/apply/api/postApply.ts
@@ -9,25 +9,26 @@ export interface ApplyFormData {
   videoFile: File;
 }
 
-const uploadVideoWithProgress = (
+const PART_SIZE = 5 * 1024 * 1024; // 5MB
+
+const uploadPart = (
+  chunk: Blob,
   uploadUrl: string,
-  file: File,
-  onProgress?: (percent: number) => void
-): Promise<void> =>
+  onProgress?: (loaded: number) => void
+): Promise<string> =>
   new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
 
     if (onProgress) {
       xhr.upload.addEventListener("progress", (e) => {
-        if (e.lengthComputable) {
-          onProgress(Math.round((e.loaded / e.total) * 100));
-        }
+        if (e.lengthComputable) onProgress(e.loaded);
       });
     }
 
     xhr.addEventListener("load", () => {
       if (xhr.status >= 200 && xhr.status < 300) {
-        resolve();
+        const etag = xhr.getResponseHeader("ETag") ?? xhr.getResponseHeader("etag") ?? "";
+        resolve(etag);
       } else {
         reject(new Error("영상 업로드에 실패했습니다. 잠시 후 다시 시도해주세요."));
       }
@@ -38,8 +39,7 @@ const uploadVideoWithProgress = (
     );
 
     xhr.open("PUT", uploadUrl);
-    xhr.setRequestHeader("Content-Type", file.type || "video/mp4");
-    xhr.send(file);
+    xhr.send(chunk);
   });
 
 export const postApply = async (
@@ -48,22 +48,62 @@ export const postApply = async (
 ): Promise<void> => {
   const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
-  // 1단계: presigned upload URL 발급
-  const uploadUrlRes = await fetch(`${apiUrl}/apply/upload-url`, { method: "POST" });
-  if (!uploadUrlRes.ok) {
+  // 1단계: 멀티파트 업로드 시작
+  const initiateRes = await fetch(`${apiUrl}/apply/upload/initiate`, { method: "POST" });
+  if (!initiateRes.ok) {
+    throw new Error("업로드 초기화에 실패했습니다. 잠시 후 다시 시도해주세요.");
+  }
+  const { key, uploadId } = (await initiateRes.json()) as { key: string; uploadId: string };
+
+  const partCount = Math.max(1, Math.ceil(data.videoFile.size / PART_SIZE));
+
+  // 2단계: 파트별 presigned URL 발급
+  const partUrlsRes = await fetch(`${apiUrl}/apply/upload/part-urls`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ key, uploadId, partCount }),
+  });
+  if (!partUrlsRes.ok) {
     throw new Error("업로드 URL 발급에 실패했습니다. 잠시 후 다시 시도해주세요.");
   }
-  const { key, uploadUrl } = (await uploadUrlRes.json()) as { key: string; uploadUrl: string };
+  const { partUrls } = (await partUrlsRes.json()) as {
+    partUrls: { partNumber: number; uploadUrl: string }[];
+  };
 
-  // 2단계: R2 직접 업로드 (presigned PUT)
-  await uploadVideoWithProgress(uploadUrl, data.videoFile, onProgress);
+  // 3단계: 파트별 순차 업로드 (진행률 추적)
+  const parts: { partNumber: number; etag: string }[] = [];
+  let uploadedBytes = 0;
 
-  // 3단계: 백엔드에 업로드 확정
+  try {
+    for (const { partNumber, uploadUrl } of partUrls) {
+      const start = (partNumber - 1) * PART_SIZE;
+      const end = Math.min(start + PART_SIZE, data.videoFile.size);
+      const chunk = data.videoFile.slice(start, end);
+
+      const etag = await uploadPart(chunk, uploadUrl, (loaded) => {
+        if (onProgress) {
+          onProgress(Math.round(((uploadedBytes + loaded) / data.videoFile.size) * 100));
+        }
+      });
+
+      uploadedBytes += end - start;
+      parts.push({ partNumber, etag });
+    }
+  } catch (err) {
+    await fetch(`${apiUrl}/apply/upload/abort`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key, uploadId }),
+    }).catch(() => {});
+    throw err;
+  }
+
+  // 4단계: 업로드 완료 및 신청 확정
   const videoFileName = `${data.field}_${data.teamName}_${data.school}_${data.representative}_${data.contact}.mp4`;
   const applyRes = await fetch(`${apiUrl}/apply`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ key, filename: videoFileName }),
+    body: JSON.stringify({ key, uploadId, filename: videoFileName, parts }),
   });
   if (!applyRes.ok) {
     const err = (await applyRes.json().catch(() => ({}))) as { message?: string };
@@ -71,7 +111,7 @@ export const postApply = async (
   }
   const { applyId } = (await applyRes.json()) as { applyId: number };
 
-  // 4단계: 나머지 폼 데이터 + applyId로 이메일 전송 (SMTP는 서버에서만 가능하므로 Next.js API Route 경유)
+  // 5단계: 이메일 전송 (Next.js API Route 경유)
   const formData = new FormData();
   formData.append("applyId", String(applyId));
   formData.append("field", data.field);

--- a/src/entities/home/ui/Video/index.tsx
+++ b/src/entities/home/ui/Video/index.tsx
@@ -10,7 +10,7 @@ export interface VideoProps {
 }
 
 const Video = ({
-  link = process.env.NEXT_PUBLIC_HOME_VIDEO_URL ?? "",
+  link = "https://kr.object.ncloudstorage.com/gwangju-talent-festival-bucket/video%20(2).mp4",
   className,
   visibleCaption = true,
 }: VideoProps) => {


### PR DESCRIPTION
## 요약

- 서버 /apply 엔드포인트가 S3 Multipart Upload 방식으로 변경됨에 따라 클라이언트 업데이트
- PR #229 (NCP → R2 마이그레이션) 일부 변경사항 롤백 (홈 영상 URL, next.config)

## 작업 내용

- `postApply.ts` 파일 업로드 플로우 전면 교체
  - 기존: `POST /apply/upload-url` → 단일 presigned PUT
  - 변경: `POST /apply/upload/initiate` → `POST /apply/upload/part-urls` → 파트별 PUT → `POST /apply`
  - 5MB 단위로 파일 분할, 파트별 ETag 수집 후 완료 요청
  - 업로드 실패 시 `POST /apply/upload/abort` 자동 호출
- 홈 배경 영상 URL 환경변수 → 하드코딩 복원 (배포 서버에 env 미설정으로 영상 미표시 문제)
- next.config.ts NCP remotePatterns 복원

## 참고사항

- R2 버킷 CORS 설정 필요: `AllowedMethods: [PUT]`, `ExposeHeaders: [ETag]`
- 서버 응답: `{ parts: [{ partNumber, url }] }` 기준으로 파싱
