### PR TITLE
feat: 참가신청서와 동의서 파일 크기 제한 추가

### DIFF
--- a/src/widgets/apply/model/useApplyForm.ts
+++ b/src/widgets/apply/model/useApplyForm.ts
@@ -137,6 +137,12 @@ export const useApplyForm = () => {
       return;
     }
 
+    const totalPdfSize = (applicationFile.file?.size ?? 0) + (privacyFile.file?.size ?? 0);
+    if (totalPdfSize > 4 * 1024 * 1024) {
+      toast.error("참가신청서와 동의서 합계는 4MB 이하여야 합니다.");
+      return;
+    }
+
     try {
       setIsSubmitting(true);
       await postApply(


### PR DESCRIPTION
## 💡 PR 요약

- Vercel 서버리스 한도(4.5MB) 초과 시 제네릭 오류만 노출되던 문제 수정
- 제출 전 클라이언트에서 PDF 두 파일 합계를 사전 검사해 명확한 안내 메시지 표시

## 📋 작업 내용

- `useApplyForm.ts` — 파일 존재 확인 이후, API 호출 이전에 합계 크기 검사 추가
- 합계 4MB 초과 시 `"참가신청서와 동의서 합계는 4MB 이하여야 합니다."` 토스트 표시 후 제출 중단

## 🤝 리뷰 시 참고사항

기존 코드는 파일별 개별 4MB 검사만 존재했고, 합계가 Vercel 한도를 넘으면 413 응답을 JSON 파싱 실패로 처리해 `"전송 중 오류가 발생했습니다."` 만 노출됐습니다.
합계 상한을 4MB로 설정해 멀티파트 폼 오버헤드 포함 여유분을 확보했는데, 수치가 적절한지 확인 부탁드립니다.
