### PR TITLE
fix: 신청 마감 후 SloganPosterPopup 노출 방지

### DIFF
--- a/src/widgets/main/SloganPosterPopup/index.tsx
+++ b/src/widgets/main/SloganPosterPopup/index.tsx
@@ -6,7 +6,7 @@ import Modal from "@/shared/ui/Modal";
 import Button from "@/shared/ui/Button";
 import { RightArrow } from "@/shared/asset/svg/RightArrow";
 import { scrollToElement } from "@/shared/utils/scroll";
-// import { isSloganEnded } from "@/shared/config/dateConfig";
+import { isApplyEnded } from "@/shared/config/dateConfig";
 
 const STORAGE_KEY = "sloganPosterHidden";
 
@@ -15,7 +15,7 @@ export default function SloganPosterPopup() {
   const [doNotShow, setDoNotShow] = useState(false);
 
   useEffect(() => {
-    // if (isSloganEnded()) return;
+    if (isApplyEnded()) return;
     const hidden = localStorage.getItem(STORAGE_KEY);
     if (!hidden) setIsOpen(true);
   }, []);


### PR DESCRIPTION
## 💡 PR 요약

- 신청 마감 시각(applyEndDate, 오늘 18시) 이후에도 SloganPosterPopup이 계속 노출되던 문제 수정
- 주석 처리되어 있던 종료 확인 로직을 `isApplyEnded()`로 연결

## 📋 작업 내용

- `SloganPosterPopup`의 `useEffect`에서 비활성화되어 있던 종료 확인 분기를 `isApplyEnded()` 호출로 교체했습니다.
- 신청 마감 시각(`applyEndDate`)이 지난 경우 early return 하여 팝업이 열리지 않도록 했습니다.
- 기존에 잘못 참조되어 주석 처리돼 있던 `isSloganEnded` import를 제거하고, 신청 마감 기준인 `isApplyEnded`를 import 하도록 변경했습니다.

## 🤝 리뷰 시 참고사항

- `isApplyEnded()`는 `applyEndDate`(기본값 2026-06-22 18:00, 환경변수 `NEXT_PUBLIC_APPLY_END_DATE`로 오버라이드 가능) 기준으로 동작합니다.