### PR TITLE
feat: 예선 진출팀 발표 페이지 및 메인 섹션 추가

### DIFF
--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://www.광탈페.com/robots.txt</loc><lastmod>2026-06-09T01:02:02.313Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.광탈페.com/rank</loc><lastmod>2026-06-09T01:02:02.314Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.광탈페.com</loc><lastmod>2026-06-09T01:02:02.314Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.광탈페.com/apply</loc><lastmod>2026-06-09T01:02:02.314Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.광탈페.com/home</loc><lastmod>2026-06-09T01:02:02.314Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.광탈페.com/signup</loc><lastmod>2026-06-09T01:02:02.314Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.광탈페.com/result/detail</loc><lastmod>2026-06-09T01:02:02.314Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.광탈페.com/booking</loc><lastmod>2026-06-09T01:02:02.314Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.광탈페.com/booking/my</loc><lastmod>2026-06-09T01:02:02.314Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.광탈페.com/result</loc><lastmod>2026-06-09T01:02:02.314Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.광탈페.com/slogan</loc><lastmod>2026-06-09T01:02:02.314Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.광탈페.com/signin</loc><lastmod>2026-06-09T01:02:02.314Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.광탈페.com/robots.txt</loc><lastmod>2026-06-30T07:15:17.006Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.광탈페.com/rank</loc><lastmod>2026-06-30T07:15:17.010Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.광탈페.com/booking</loc><lastmod>2026-06-30T07:15:17.010Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.광탈페.com</loc><lastmod>2026-06-30T07:15:17.011Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.광탈페.com/signin</loc><lastmod>2026-06-30T07:15:17.011Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.광탈페.com/result</loc><lastmod>2026-06-30T07:15:17.011Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.광탈페.com/preliminary-result</loc><lastmod>2026-06-30T07:15:17.011Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.광탈페.com/home</loc><lastmod>2026-06-30T07:15:17.011Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.광탈페.com/booking/my</loc><lastmod>2026-06-30T07:15:17.011Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.광탈페.com/result/detail</loc><lastmod>2026-06-30T07:15:17.011Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.광탈페.com/apply</loc><lastmod>2026-06-30T07:15:17.011Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.광탈페.com/signup</loc><lastmod>2026-06-30T07:15:17.011Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.광탈페.com/slogan</loc><lastmod>2026-06-30T07:15:17.011Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/app/preliminary-result/page.tsx
+++ b/src/app/preliminary-result/page.tsx
@@ -2,7 +2,7 @@ import PreliminaryResultView from "@/views/preliminary-result/ui/PreliminaryResu
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "예선 진출팀 발표 | 광주학생탈렌트페스티벌",
+  title: "광주학생탈렌트페스티벌",
   description: "2026 광탈페 光트로 예선 진출팀 24팀을 발표합니다.",
 };
 

--- a/src/app/preliminary-result/page.tsx
+++ b/src/app/preliminary-result/page.tsx
@@ -1,0 +1,11 @@
+import PreliminaryResultView from "@/views/preliminary-result/ui/PreliminaryResultView";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "예선 진출팀 발표 | 광주학생탈렌트페스티벌",
+  description: "2026 광탈페 光트로 예선 진출팀 24팀을 발표합니다.",
+};
+
+export default function PreliminaryResultPage() {
+  return <PreliminaryResultView />;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { publicPages, publicIn27 } from "@/shared/config/authConfig";
-import { festivalDate, sloganStartDate, sloganEndDate, applyStartDate, applyEndDate } from "@/shared/config/dateConfig";
+import { festivalDate, sloganStartDate, sloganEndDate, applyStartDate, applyEndDate, preliminaryResultOpenDate } from "@/shared/config/dateConfig";
 
 export const config = {
   matcher: [
@@ -41,6 +41,10 @@ export function middleware(request: NextRequest) {
   }
 
   if (pathname === "/apply" && (now < applyStartDate || now > applyEndDate)) {
+    return NextResponse.redirect(new URL("/home", request.url));
+  }
+
+  if (pathname === "/preliminary-result" && (!preliminaryResultOpenDate || now < preliminaryResultOpenDate)) {
     return NextResponse.redirect(new URL("/home", request.url));
   }
 

--- a/src/shared/config/authConfig.ts
+++ b/src/shared/config/authConfig.ts
@@ -1,4 +1,4 @@
-export const publicPages = ["/home", "/signin", "/signup", "/admin", "/vote", "/slogan", "/apply"];
+export const publicPages = ["/home", "/signin", "/signup", "/admin", "/vote", "/slogan", "/apply", "/preliminary-result"];
 
 export const publicIn18 = ["/booking"];
 

--- a/src/shared/config/dateConfig.ts
+++ b/src/shared/config/dateConfig.ts
@@ -26,3 +26,9 @@ export const isApplyPeriod = () => {
   return now >= applyStartDate && now <= applyEndDate;
 };
 export const isApplyEnded = () => new Date() > applyEndDate;
+
+export const preliminaryResultOpenDate = process.env.NEXT_PUBLIC_PRELIMINARY_RESULT_OPEN_DATE
+  ? new Date(process.env.NEXT_PUBLIC_PRELIMINARY_RESULT_OPEN_DATE)
+  : null;
+export const isPreliminaryResultOpen = () =>
+  preliminaryResultOpenDate !== null && new Date() >= preliminaryResultOpenDate;

--- a/src/shared/const/headerValues.ts
+++ b/src/shared/const/headerValues.ts
@@ -11,7 +11,7 @@ export const isHiddenPath = (pathname: string): boolean => {
 
 export type SectionId =
   | "SloganSecondSection"
-  | "ApplyThirdSection"
+  | "PreliminaryResultSection"
   | "PreliminaryFourthSection"
   | "FinalsSixthSection";
 
@@ -22,8 +22,6 @@ export interface HeaderLink {
 
 export const links: HeaderLink[] = [
   { section: "SloganSecondSection", label: "2026 광탈페 슬로건" },
-  // { section: "section3", label: "FaQ" },
-  { section: "ApplyThirdSection", label: "2026 광탈페 참가신청" },
+  { section: "PreliminaryResultSection", label: "2026 광탈페 예선 결과" },
   { section: "PreliminaryFourthSection", label: "2025 광탈페 다시보기" },
-  // { section: "ReservationFifthSection", label: "본선 수상팀 명단" },
 ];

--- a/src/views/home/ui/HomePage/index.tsx
+++ b/src/views/home/ui/HomePage/index.tsx
@@ -3,9 +3,14 @@
 import dynamic from "next/dynamic";
 import IntroFirstSection from "@/widgets/main/IntroFirstSection";
 import SloganSecondSection from "@/widgets/main/SloganSecondSection";
-import ApplyThirdSection from "@/widgets/main/ApplyThirdSection";
+
 import LazySection from "@/shared/ui/LazySection";
 import SloganPosterPopup from "@/widgets/main/SloganPosterPopup";
+
+const PreliminaryResultSection = dynamic(
+  () => import("@/widgets/main/PreliminaryResultSection"),
+  { loading: () => <SectionPlaceholder height="400px" />, ssr: false },
+);
 
 const PreliminaryFourthSection = dynamic(() => import("@/widgets/main/PreliminaryFourthSection"), {
   loading: () => <SectionPlaceholder />,
@@ -52,7 +57,9 @@ const HomePage = () => {
       <IntroFirstSection />
       <SloganSecondSection />
 
-      <ApplyThirdSection />
+      <LazySection fallback={<SectionPlaceholder height="400px" />} rootMargin="200px">
+        <PreliminaryResultSection />
+      </LazySection>
 
       <LazySection fallback={<SectionPlaceholder height="600px" />} rootMargin="200px">
         <PreliminaryFourthSection />

--- a/src/views/preliminary-result/ui/PreliminaryResultView/index.tsx
+++ b/src/views/preliminary-result/ui/PreliminaryResultView/index.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { cn } from "@/shared/utils/cn";
+import BackHeader from "@/shared/ui/BackHeader";
+
+type Team = {
+  id: number;
+  name: string;
+  representative: string;
+  school: string;
+};
+
+const PRELIMINARY_TEAMS: Team[] = [
+  { id: 1, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 2, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 3, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 4, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 5, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 6, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 7, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 8, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 9, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 10, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 11, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 12, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 13, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 14, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 15, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 16, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 17, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 18, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 19, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 20, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 21, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 22, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 23, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 24, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+];
+
+const maskName = (name: string) => {
+  if (name.length <= 1) return name;
+  if (name.length === 2) return name[0] + "*";
+  return name[0] + "*" + name[name.length - 1];
+};
+
+const PreliminaryResultView = () => {
+  return (
+    <main className={cn("min-h-screen bg-white")}>
+      <div className={cn("max-w-[900px] mx-auto px-[5%] pb-80 mobile:pb-52")}>
+        <BackHeader text="예선 진출팀" goto="/home" />
+
+        {/* 헤더 */}
+        <div className={cn("flex flex-col items-center text-center gap-16 py-40 mobile:py-28")}>
+          <h1 className={cn("text-title2b mobile:text-h4b text-black")}>
+            2026 광탈페 예선 진출팀
+          </h1>
+          <div className={cn("flex flex-col gap-6 text-body3r mobile:text-caption1r text-gray-600")}>
+            <p>오디션에 선정되신 <strong className="text-orange-500">24개 팀</strong>의 대표는 신분증을 지참하여 협의회에 참석해주세요.</p>
+            <p>각 팀의 대표는 사전 협의회 참석 명단을 이메일로 제출해주세요.</p>
+            <p>진출하신 모든 팀을 진심으로 축하드립니다.</p>
+          </div>
+          <a
+            href="#"
+            className={cn(
+              "inline-flex items-center gap-4 text-body3b mobile:text-caption1b text-orange-500",
+              "underline underline-offset-4 hover:text-orange-400 transition-colors duration-200",
+            )}
+          >
+            협의회 참석 관련 안내 →
+          </a>
+        </div>
+
+        {/* 구분선 */}
+        <div className="w-full h-[1px] bg-gray-100 mb-40 mobile:mb-28" />
+
+        {/* 팀 카드 그리드 */}
+        <div className={cn("grid grid-cols-3 tablet:grid-cols-2 mobile:grid-cols-2 gap-14 mobile:gap-8")}>
+          {PRELIMINARY_TEAMS.map((team) => (
+            <div
+              key={team.id}
+              className={cn(
+                "relative overflow-hidden rounded-2xl p-24 mobile:p-16",
+                "bg-gradient-to-br from-orange-50 to-white",
+                "border border-orange-100",
+              )}
+            >
+              {/* 배경 워터마크 번호 */}
+              <span
+                className="absolute -bottom-10 -right-4 text-[80px] mobile:text-[60px] font-bold text-orange-200 leading-none select-none pointer-events-none"
+                aria-hidden="true"
+              >
+                {String(team.id).padStart(2, "0")}
+              </span>
+
+              {/* 콘텐츠 */}
+              <div className={cn("relative z-10 flex flex-col gap-10 mobile:gap-8")}>
+                <span className={cn("text-caption2b text-orange-400")}>
+                  {String(team.id).padStart(2, "0")}
+                </span>
+                <div className={cn("flex flex-col gap-4")}>
+                  <p className={cn("text-body3b mobile:text-caption1b text-black break-keep leading-snug")}>
+                    {team.name}
+                    <span className={cn("ml-6 text-caption1r mobile:text-caption2r text-gray-400 font-normal")}>
+                      ({maskName(team.representative)})
+                    </span>
+                  </p>
+                  <p className={cn("text-caption2r text-gray-400 break-keep")}>{team.school}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+      </div>
+    </main>
+  );
+};
+
+export default PreliminaryResultView;

--- a/src/widgets/main/PreliminaryResultSection/index.tsx
+++ b/src/widgets/main/PreliminaryResultSection/index.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Link from "next/link";
+import { cn } from "@/shared/utils/cn";
+import { isPreliminaryResultOpen } from "@/shared/config/dateConfig";
+
+const PreliminaryResultSection = () => {
+  const isOpen = isPreliminaryResultOpen();
+  return (
+    <section
+      id="PreliminaryResultSection"
+      className={cn("relative w-full overflow-hidden bg-white py-[80px] mobile:py-[52px]")}
+    >
+      {/* 좌측 데코 — 와이드 데스크탑에서만 표시 */}
+      <div className="absolute left-[5%] top-0 pointer-events-none select-none mobile:hidden tablet:hidden">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src="/images/apply-deco-left.png" alt="" width={300} height={300} className="w-full h-auto" />
+      </div>
+
+      {/* 우측 데코 — 와이드 데스크탑에서만 표시 */}
+      <div className="absolute right-[5%] top-1/2 -translate-y-1/2 pointer-events-none select-none mobile:hidden tablet:hidden">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src="/images/apply-deco-right.png" alt="" width={300} height={300} className="w-full h-auto" />
+      </div>
+
+      {/* 모바일 좌상단 데코 */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src="/images/apply-deco-left.png" alt="" width={120} height={120} className="absolute left-0 top-0 pointer-events-none select-none hidden mobile:block w-[120px] h-auto" />
+
+      {/* 모바일 우하단 데코 */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src="/images/apply-deco-right.png" alt="" width={120} height={120} className="absolute right-0 bottom-0 pointer-events-none select-none hidden mobile:block w-[120px] h-auto" />
+
+      {/* 블러 원 데코 */}
+      <div className="absolute top-[-60px] left-[-80px] w-[320px] h-[320px] rounded-full bg-orange-300 opacity-60 blur-[80px] pointer-events-none" aria-hidden="true" />
+      <div className="absolute bottom-[-60px] right-[-80px] w-[280px] h-[280px] rounded-full bg-orange-400 opacity-50 blur-[80px] pointer-events-none" aria-hidden="true" />
+      <div className="absolute top-[40%] left-[55%] w-[200px] h-[200px] rounded-full bg-orange-200 opacity-60 blur-[60px] pointer-events-none" aria-hidden="true" />
+
+      <div className="relative z-10 flex flex-col items-center text-center px-[80px] tablet:px-[40px] mobile:px-16 gap-24 mobile:gap-16">
+        {/* 제목 */}
+        <div className="flex flex-col gap-12 mobile:gap-8">
+          <h2 className="text-title2b mobile:text-body1b text-black">
+            2026 광탈페 光트로 예선 진출팀
+          </h2>
+          <p className="text-body3r mobile:text-caption1r text-gray-700">
+            총 <strong className="text-orange-500 text-body2b mobile:text-body3b">24팀</strong>이 본선에 진출합니다
+          </p>
+          <p className="text-body3r mobile:text-caption1r text-gray-500">
+            7월 3일(금) 오전 10시 공개 예정
+          </p>
+        </div>
+
+        {/* CTA 버튼 */}
+        {isOpen ? (
+          <Link
+            href="/preliminary-result"
+            className={cn(
+              "inline-flex items-center justify-center gap-10",
+              "h-[50px] rounded-lg",
+              "bg-orange-500 text-white text-body3b font-bold",
+              "hover:bg-orange-400 transition-colors duration-200",
+              "px-28 mobile:w-full",
+            )}
+          >
+            <span className="flex items-center justify-center px-[60px] mobile:px-0 mobile:w-full">
+              결과 보러가기
+            </span>
+          </Link>
+        ) : (
+          <button
+            disabled
+            className={cn(
+              "inline-flex items-center justify-center",
+              "h-[50px] rounded-lg cursor-not-allowed",
+              "bg-gray-100 text-gray-400 text-body3b font-bold border border-gray-200",
+              "px-28 mobile:w-full",
+            )}
+          >
+            <span className="flex items-center justify-center px-[60px] mobile:px-0 mobile:w-full">
+              7월 3일(금) 10시에 공개됩니다
+            </span>
+          </button>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default PreliminaryResultSection;


### PR DESCRIPTION
## 💡 PR 요약

> 2026 광탈페 光트로 예선 진출팀 발표를 위한 페이지 및 메인 섹션을 추가합니다.

- 메인 페이지에 예선 결과 발표 섹션 추가
- `/preliminary-result` 예선 진출팀 결과 페이지 추가
- 공개 날짜 전 URL 직접 접근 차단 (미들웨어)
- 헤더 네비게이션 업데이트 (참가신청 → 예선 결과)
- 참가신청 섹션 메인 페이지에서 제거
- 
<img width="2846" height="892" alt="image" src="https://github.com/user-attachments/assets/78bdd5d4-a6b8-4f50-bf8d-0d9d49a7e2ea" />
<img width="2848" height="1458" alt="image" src="https://github.com/user-attachments/assets/2e261fb3-1065-49a0-acaf-b3ccf38c3e3b" />


## 📋 작업 내용

**메인 페이지 섹션 (`PreliminaryResultSection`)**
- 예선 결과 발표 안내 문구 및 CTA 버튼 표시
- `NEXT_PUBLIC_PRELIMINARY_RESULT_OPEN_DATE` 기준으로 공개 전 버튼 비활성화
- 공개 전: "7월 3일(금) 10시에 공개됩니다" 비활성 버튼 표시

**결과 페이지 (`/preliminary-result`)**
- 24팀 진출팀 목록 표시 (팀명, 대표자 마스킹, 학교명)
- 협의회 참석 관련 안내 링크 포함

**접근 제어**
- 미들웨어에서 `NEXT_PUBLIC_PRELIMINARY_RESULT_OPEN_DATE` env 기준 차단
- env 미설정 시 무조건 차단

## 🤝 리뷰 시 참고사항

- 팀 데이터는 현재 목데이터이며 실제 데이터로 교체 필요
- 협의회 안내 링크(`href="#"`)는 실제 URL로 교체 필요
- `.env`에 `NEXT_PUBLIC_PRELIMINARY_RESULT_OPEN_DATE=2026-07-03T10:00:00+09:00` 추가 필요
