### PR TITLE
feat: 예선 결과 페이지 확정 데이터 및 사전 협의회 안내 반영

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -44,7 +44,7 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(new URL("/home", request.url));
   }
 
-  if (pathname === "/preliminary-result" && (!preliminaryResultOpenDate || now < preliminaryResultOpenDate)) {
+  if (pathname === "/preliminary-result" && now < preliminaryResultOpenDate) {
     return NextResponse.redirect(new URL("/home", request.url));
   }
 

--- a/src/shared/config/dateConfig.ts
+++ b/src/shared/config/dateConfig.ts
@@ -27,8 +27,7 @@ export const isApplyPeriod = () => {
 };
 export const isApplyEnded = () => new Date() > applyEndDate;
 
-export const preliminaryResultOpenDate = process.env.NEXT_PUBLIC_PRELIMINARY_RESULT_OPEN_DATE
-  ? new Date(process.env.NEXT_PUBLIC_PRELIMINARY_RESULT_OPEN_DATE)
-  : null;
-export const isPreliminaryResultOpen = () =>
-  preliminaryResultOpenDate !== null && new Date() >= preliminaryResultOpenDate;
+export const preliminaryResultOpenDate = new Date(
+  process.env.NEXT_PUBLIC_PRELIMINARY_RESULT_OPEN_DATE ?? "2026-07-03T10:00:00+09:00",
+);
+export const isPreliminaryResultOpen = () => new Date() >= preliminaryResultOpenDate;

--- a/src/shared/config/dateConfig.ts
+++ b/src/shared/config/dateConfig.ts
@@ -27,7 +27,11 @@ export const isApplyPeriod = () => {
 };
 export const isApplyEnded = () => new Date() > applyEndDate;
 
-export const preliminaryResultOpenDate = new Date(
-  process.env.NEXT_PUBLIC_PRELIMINARY_RESULT_OPEN_DATE ?? "2026-07-03T10:00:00+09:00",
+const PRELIMINARY_RESULT_OPEN_DATE_FALLBACK = "2026-07-03T10:00:00+09:00";
+const parsedPreliminaryResultOpenDate = new Date(
+  process.env.NEXT_PUBLIC_PRELIMINARY_RESULT_OPEN_DATE ?? PRELIMINARY_RESULT_OPEN_DATE_FALLBACK,
 );
+export const preliminaryResultOpenDate = Number.isNaN(parsedPreliminaryResultOpenDate.getTime())
+  ? new Date(PRELIMINARY_RESULT_OPEN_DATE_FALLBACK)
+  : parsedPreliminaryResultOpenDate;
 export const isPreliminaryResultOpen = () => new Date() >= preliminaryResultOpenDate;

--- a/src/views/preliminary-result/ui/PreliminaryResultView/index.tsx
+++ b/src/views/preliminary-result/ui/PreliminaryResultView/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef } from "react";
 import { cn } from "@/shared/utils/cn";
 import BackHeader from "@/shared/ui/BackHeader";
 
@@ -63,6 +64,8 @@ const MEETING_AGENDA = [
 ];
 
 const PreliminaryResultView = () => {
+  const meetingGuideRef = useRef<HTMLElement>(null);
+
   return (
     <main className={cn("min-h-screen bg-white")}>
       <div className={cn("max-w-[900px] mx-auto px-[5%] pb-80 mobile:pb-52")}>
@@ -82,7 +85,7 @@ const PreliminaryResultView = () => {
             href="#meeting-guide"
             onClick={(e) => {
               e.preventDefault();
-              document.getElementById("meeting-guide")?.scrollIntoView({ behavior: "smooth" });
+              meetingGuideRef.current?.scrollIntoView({ behavior: "smooth" });
             }}
             className={cn(
               "inline-flex items-center gap-4 text-body3b mobile:text-caption1b text-orange-500",
@@ -140,7 +143,11 @@ const PreliminaryResultView = () => {
         <div className="w-full h-[1px] bg-gray-100 my-40 mobile:my-28" />
 
         {/* 사전 협의회 참석 안내 */}
-        <section id="meeting-guide" className={cn("flex flex-col gap-24 mobile:gap-16 scroll-mt-80")}>
+        <section
+          id="meeting-guide"
+          ref={meetingGuideRef}
+          className={cn("flex flex-col gap-24 mobile:gap-16 scroll-mt-80")}
+        >
           <h2 className={cn("text-title4b mobile:text-body1b text-black")}>
             예선진출팀 사전 협의회 참석 안내
           </h2>

--- a/src/views/preliminary-result/ui/PreliminaryResultView/index.tsx
+++ b/src/views/preliminary-result/ui/PreliminaryResultView/index.tsx
@@ -5,43 +5,62 @@ import BackHeader from "@/shared/ui/BackHeader";
 
 type Team = {
   id: number;
+  field: string;
   name: string;
-  representative: string;
   school: string;
+  representative: string;
 };
 
 const PRELIMINARY_TEAMS: Team[] = [
-  { id: 1, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 2, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 3, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 4, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 5, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 6, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 7, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 8, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 9, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 10, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 11, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 12, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 13, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 14, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 15, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 16, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 17, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 18, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 19, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 20, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 21, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 22, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 23, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
-  { id: 24, name: "스타트업", representative: "박준민", school: "광주소프트웨어마이스터고" },
+  { id: 1, field: "국악", name: "살레시오초", school: "", representative: "김현*" },
+  { id: 2, field: "보컬", name: "Blas", school: "대촌중", representative: "박서*" },
+  { id: 3, field: "보컬", name: "전남여자고", school: "", representative: "김민*" },
+  { id: 4, field: "보컬", name: "영천초", school: "", representative: "김시*" },
+  { id: 5, field: "보컬", name: "이음", school: "문정여자고 외", representative: "염민*" },
+  { id: 6, field: "보컬", name: "광주석산고", school: "", representative: "임준*" },
+  { id: 7, field: "보컬", name: "광주화정중", school: "", representative: "전람*" },
+  { id: 8, field: "보컬", name: "쿠쿠다쓰", school: "하백초", representative: "장연*" },
+  { id: 9, field: "댄스", name: "Ate", school: "수완고 외", representative: "유현*" },
+  { id: 10, field: "댄스", name: "Luna.X", school: "살레시오중", representative: "박시*" },
+  { id: 11, field: "댄스", name: "ON:BEAT", school: "문산중 외", representative: "강도*" },
+  { id: 12, field: "댄스", name: "PLAY", school: "성덕중", representative: "임수*" },
+  { id: 13, field: "댄스", name: "베아트리스. Beat", school: "동일미래과학고", representative: "이준*" },
+  { id: 14, field: "밴드", name: "B.O.D", school: "서강중", representative: "임도*" },
+  { id: 15, field: "밴드", name: "Be 정상", school: "문정여고 외", representative: "박지*" },
+  { id: 16, field: "밴드", name: "EVA밴드", school: "고려고 외", representative: "박지*" },
+  { id: 17, field: "밴드", name: "Made in stop", school: "광주예술고 외", representative: "양윤*" },
+  { id: 18, field: "밴드", name: "권오건 밴드", school: "광주고 외", representative: "권오*" },
+  { id: 19, field: "밴드", name: "플로우", school: "금호중", representative: "전다*" },
+  { id: 20, field: "밴드", name: "밴드유아이어스", school: "숭덕고", representative: "박준*" },
+  { id: 21, field: "밴드", name: "수피아밴드", school: "광주수피아여고", representative: "진단*" },
+  { id: 22, field: "밴드", name: "신가밴드", school: "신가중", representative: "신지*" },
+  { id: 23, field: "밴드", name: "원미동사람들", school: "광주숭일중", representative: "배서*" },
+  { id: 24, field: "밴드", name: "일퍼센", school: "광주여고 외", representative: "최사*" },
 ];
 
-const maskName = (name: string) => {
-  if (name.length <= 1) return name;
-  if (name.length === 2) return name[0] + "*";
-  return name[0] + "*" + name[name.length - 1];
+const MEETING_INFO = [
+  { label: "일시", value: "2026. 7. 15.(수) 17:00~18:00 (등록 ~16:50)" },
+  {
+    label: "대상",
+    value:
+      "예선(오디션) 선정 팀 대표(24개 팀, 팀당 1명 필참, 사진학생증(신분증, 여권, 청소년증, 주민등록증, 생기부 1면 등))",
+  },
+  { label: "장소", value: "광주학생예술누리터 꿈이룸관(2층)" },
+];
+
+const VENUE = {
+  name: "광주학생예술누리터",
+  address: "광주광역시 동구 제봉로 167 광주학생예술누리터",
+  phone: "운영실 222-7301,2,4,5 / 관리실 222-7306",
 };
+
+const MEETING_AGENDA = [
+  "2026 光탈페(광주학생탈렌트페스티벌) 예선(오디션) 운영 전반 사항 안내",
+  "예선일정 확정(7. 24.(금) / 7. 25.(토) 경연장르 확정)",
+  "예선 경연 순서 추첨",
+  "예선 참여 곡명 및 무대 지원 필요 사항 점검 등",
+  "홍보자료 제작용 팀 소개 관련 자료 수합 안내(사진, 팀 소개, 연주곡 소개 등)",
+];
 
 const PreliminaryResultView = () => {
   return (
@@ -60,7 +79,11 @@ const PreliminaryResultView = () => {
             <p>진출하신 모든 팀을 진심으로 축하드립니다.</p>
           </div>
           <a
-            href="#"
+            href="#meeting-guide"
+            onClick={(e) => {
+              e.preventDefault();
+              document.getElementById("meeting-guide")?.scrollIntoView({ behavior: "smooth" });
+            }}
             className={cn(
               "inline-flex items-center gap-4 text-body3b mobile:text-caption1b text-orange-500",
               "underline underline-offset-4 hover:text-orange-400 transition-colors duration-200",
@@ -95,21 +118,86 @@ const PreliminaryResultView = () => {
               {/* 콘텐츠 */}
               <div className={cn("relative z-10 flex flex-col gap-10 mobile:gap-8")}>
                 <span className={cn("text-caption2b text-orange-400")}>
-                  {String(team.id).padStart(2, "0")}
+                  {String(team.id).padStart(2, "0")} · {team.field}
                 </span>
                 <div className={cn("flex flex-col gap-4")}>
                   <p className={cn("text-body3b mobile:text-caption1b text-black break-keep leading-snug")}>
                     {team.name}
                     <span className={cn("ml-6 text-caption1r mobile:text-caption2r text-gray-400 font-normal")}>
-                      ({maskName(team.representative)})
+                      ({team.representative})
                     </span>
                   </p>
-                  <p className={cn("text-caption2r text-gray-400 break-keep")}>{team.school}</p>
+                  {team.school && (
+                    <p className={cn("text-caption2r text-gray-400 break-keep")}>{team.school}</p>
+                  )}
                 </div>
               </div>
             </div>
           ))}
         </div>
+
+        {/* 구분선 */}
+        <div className="w-full h-[1px] bg-gray-100 my-40 mobile:my-28" />
+
+        {/* 사전 협의회 참석 안내 */}
+        <section id="meeting-guide" className={cn("flex flex-col gap-24 mobile:gap-16 scroll-mt-80")}>
+          <h2 className={cn("text-title4b mobile:text-body1b text-black")}>
+            예선진출팀 사전 협의회 참석 안내
+          </h2>
+
+          <div className={cn("flex flex-col gap-16 mobile:gap-12")}>
+            {MEETING_INFO.map((item) => (
+              <div key={item.label} className={cn("flex gap-12 mobile:gap-8")}>
+                <span className={cn("shrink-0 text-body3b mobile:text-caption1b text-orange-500")}>
+                  {item.label}
+                </span>
+                <p className={cn("text-body3r mobile:text-caption1r text-gray-700 break-keep")}>
+                  {item.value}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          <div className={cn("flex flex-col gap-8 rounded-xl bg-gray-50 p-20 mobile:p-16")}>
+            <p className={cn("text-body3b mobile:text-caption1b text-black")}>{VENUE.name}</p>
+            <p className={cn("text-caption1r mobile:text-caption2r text-gray-600")}>{VENUE.address}</p>
+            <p className={cn("text-caption1r mobile:text-caption2r text-gray-600")}>{VENUE.phone}</p>
+            <a
+              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(VENUE.address)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={cn(
+                "mt-4 inline-flex w-fit items-center gap-4 text-caption1b mobile:text-caption2b text-orange-500",
+                "underline underline-offset-4 hover:text-orange-400 transition-colors duration-200",
+              )}
+            >
+              지도에서 보기 →
+            </a>
+          </div>
+        </section>
+
+        {/* 구분선 */}
+        <div className="w-full h-[1px] bg-gray-100 my-40 mobile:my-28" />
+
+        {/* 사전 협의회 주요 내용 */}
+        <section className={cn("flex flex-col gap-24 mobile:gap-16")}>
+          <h2 className={cn("text-title4b mobile:text-body1b text-black")}>
+            예선팀 대표 사전 협의회 주요 내용
+          </h2>
+          <ul className={cn("flex flex-col gap-10 mobile:gap-8")}>
+            {MEETING_AGENDA.map((content) => (
+              <li
+                key={content}
+                className={cn("flex gap-8 text-body3r mobile:text-caption1r text-gray-700 break-keep")}
+              >
+                <span className="text-orange-400" aria-hidden="true">
+                  ○
+                </span>
+                {content}
+              </li>
+            ))}
+          </ul>
+        </section>
 
       </div>
     </main>


### PR DESCRIPTION
## 💡 PR 요약

- 예선 진출 24팀 확정 명단 반영 (분야/소속/팀명/대표자)
- 예선 결과 공개 날짜 게이팅 버그 수정 (env 미설정 시 영구 차단되던 문제)
- 예선진출팀 사전 협의회 참석 안내 섹션을 결과 페이지 하단에 추가

## 📋 작업 내용

- `src/views/preliminary-result/ui/PreliminaryResultView/index.tsx`
  - 더미 데이터(24개 항목 모두 동일)를 실제 확정된 24팀 데이터로 교체, `Team` 타입에 `field`(분야) 필드 추가
  - 대표자명이 이미 마스킹된 형태로 제공되어 기존 런타임 `maskName` 함수 제거 (이중 마스킹 방지)
  - 페이지 하단에 "예선진출팀 사전 협의회 참석 안내" 섹션 추가 (일시/대상/장소, 장소 카드 및 지도 링크, 협의회 주요 내용 리스트)
  - 상단 "협의회 참석 관련 안내 →" 링크를 해당 섹션으로 부드럽게 스크롤 이동하도록 연결
- `src/shared/config/dateConfig.ts`, `src/middleware.ts`
  - `NEXT_PUBLIC_PRELIMINARY_RESULT_OPEN_DATE`가 비어있으면 `preliminaryResultOpenDate`가 `null`이 되어 미들웨어가 날짜와 무관하게 영구적으로 `/preliminary-result`를 차단하던 문제 수정
  - 다른 날짜 변수들(`sloganStartDate`, `applyStartDate`)과 동일하게 `env ?? 하드코딩 폴백값(2026-07-03T10:00:00+09:00)` 패턴으로 통일
- `.env`
  - 로컬 값도 홈 화면 공개 문구(7월 3일)에 맞춰 수정

## 🤝 리뷰 시 참고사항

- Vercel에 `NEXT_PUBLIC_PRELIMINARY_RESULT_OPEN_DATE`를 별도로 설정하지 않아도 하드코딩 폴백값으로 7/3 10시에 정상 공개됩니다. 날짜를 코드 배포 없이 바꾸고 싶으면 Vercel 대시보드에 해당 env var를 추가 후 재배포하면 됩니다.
- "지도에서 보기" 링크는 별도 지도 API 연동 없이 구글맵 검색 URL로 연결했습니다.
