### PR TITLE
fix: 예선 진출팀 헤더 스크롤 동작 수정 및 안내 문구 업데이트

### DIFF
--- a/src/shared/const/headerValues.ts
+++ b/src/shared/const/headerValues.ts
@@ -22,6 +22,6 @@ export interface HeaderLink {
 
 export const links: HeaderLink[] = [
   { section: "SloganSecondSection", label: "2026 광탈페 슬로건" },
-  { section: "PreliminaryResultSection", label: "2026 광탈페 예선 결과" },
+  { section: "PreliminaryResultSection", label: "2026 예선 진출팀" },
   { section: "PreliminaryFourthSection", label: "2025 광탈페 다시보기" },
 ];

--- a/src/shared/ui/LazySection/index.tsx
+++ b/src/shared/ui/LazySection/index.tsx
@@ -8,6 +8,7 @@ interface LazySectionProps {
   rootMargin?: string;
   threshold?: number;
   className?: string;
+  id?: string;
 }
 
 const LazySection = ({
@@ -16,6 +17,7 @@ const LazySection = ({
   rootMargin = "200px",
   threshold = 0.1,
   className = "",
+  id,
 }: LazySectionProps) => {
   const [isInView, setIsInView] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -42,7 +44,7 @@ const LazySection = ({
   }, [rootMargin, threshold]);
 
   return (
-    <div ref={ref} className={className}>
+    <div ref={ref} id={id} className={className}>
       {isInView ? children : fallback}
     </div>
   );

--- a/src/views/home/ui/HomePage/index.tsx
+++ b/src/views/home/ui/HomePage/index.tsx
@@ -57,11 +57,19 @@ const HomePage = () => {
       <IntroFirstSection />
       <SloganSecondSection />
 
-      <LazySection fallback={<SectionPlaceholder height="400px" />} rootMargin="200px">
+      <LazySection
+        id="PreliminaryResultSection"
+        fallback={<SectionPlaceholder height="400px" />}
+        rootMargin="200px"
+      >
         <PreliminaryResultSection />
       </LazySection>
 
-      <LazySection fallback={<SectionPlaceholder height="600px" />} rootMargin="200px">
+      <LazySection
+        id="PreliminaryFourthSection"
+        fallback={<SectionPlaceholder height="600px" />}
+        rootMargin="200px"
+      >
         <PreliminaryFourthSection />
       </LazySection>
 

--- a/src/widgets/main/PreliminaryFourthSection/index.tsx
+++ b/src/widgets/main/PreliminaryFourthSection/index.tsx
@@ -22,7 +22,7 @@ const PRELIMINARY_VIDEOS = [
 
 const PreliminaryFourthSection = () => {
   return (
-    <section id="PreliminaryFourthSection" className={cn("flex flex-col items-center")}>
+    <section className={cn("flex flex-col items-center")}>
       <div className={cn("w-[70%] mobile:w-full")}>
         <SectionTitle
           title="2025 광탈페 예선 다시보기"

--- a/src/widgets/main/PreliminaryResultSection/index.tsx
+++ b/src/widgets/main/PreliminaryResultSection/index.tsx
@@ -45,9 +45,6 @@ const PreliminaryResultSection = () => {
           <p className="text-body3r mobile:text-caption1r text-gray-700">
             총 <strong className="text-orange-500 text-body2b mobile:text-body3b">24팀</strong>이 본선에 진출합니다
           </p>
-          <p className="text-body3r mobile:text-caption1r text-gray-500">
-            7월 3일(금) 오전 10시 공개 예정
-          </p>
         </div>
 
         {/* CTA 버튼 */}

--- a/src/widgets/main/PreliminaryResultSection/index.tsx
+++ b/src/widgets/main/PreliminaryResultSection/index.tsx
@@ -8,7 +8,6 @@ const PreliminaryResultSection = () => {
   const isOpen = isPreliminaryResultOpen();
   return (
     <section
-      id="PreliminaryResultSection"
       className={cn("relative w-full overflow-hidden bg-white py-[80px] mobile:py-[52px]")}
     >
       {/* 좌측 데코 — 와이드 데스크탑에서만 표시 */}


### PR DESCRIPTION
## 💡 PR 요약

> 해당 PR의 변경사항, 해당 이슈 등에 대한 간략한 설명을 작성해주세요.

- 헤더 네비게이션 라벨 `2026 광탈페 예선 결과` → `2026 예선 진출팀`으로 변경
- 메인 화면 예선 진출팀 섹션의 `7월 3일(금) 오전 10시 공개 예정` 안내 문구 삭제
- 헤더에서 `2026 예선 진출팀`·`2025 광탈페 다시보기` 클릭 시 스크롤이 동작하지 않던 버그 수정

## 📋 작업 내용

> 해당 PR에서 작업한 내용을 자세히 설명해주세요.

### 문구 수정 (design)

- `headerValues.ts`의 헤더 링크 라벨 변경
- `PreliminaryResultSection`의 공개 예정 안내 문단 제거 (예선 결과 공개 완료로 불필요)

### 헤더 앵커 스크롤 버그 수정 (fix)

- **원인**: 헤더 링크는 `scrollToElement` → `getElementById(id)`로 동작하는데, 대상 섹션이 `LazySection`(+`ssr:false` dynamic import)으로 감싸여 있어 뷰포트에 들어오기 전에는 placeholder만 렌더링됩니다. 실제 `id`를 가진 `<section>`이 DOM에 없어 페이지 상단에서 클릭하면 스크롤 대상을 찾지 못했습니다.
- **해결**: `LazySection`에 `id` prop을 추가해 **항상 렌더링되는 래퍼 `<div>`**에 부여. `HomePage`에서 각 섹션 id를 전달하고, 내부 `<section>`의 중복 id는 제거했습니다.
- 정적 렌더링되는 `2026 광탈페 슬로건` 링크는 원래 정상 동작했고, 지연 로딩되는 `PreliminaryResultSection`·`PreliminaryFourthSection` 두 섹션만 문제였습니다. 둘 다 함께 수정했습니다.

## 🤝 리뷰 시 참고사항

- 로컬 dev 서버에서 `/home` 200 정상 렌더링 확인, ESLint 통과했습니다.
- `문의하기`(채널톡)는 코드상 정상 연동 상태입니다. 다만 플러그인 키(`NEXT_PUBLIC_CHANNEL_PLUGIN_KEY`)가 `.env.local`(git-ignore)에만 있으므로, 배포 환경에도 동일 키가 설정돼 있는지 확인이 필요합니다.
- `npm run build`는 미설치 의존성(`react-day-picker`·`nodemailer`)으로 실패하나 이번 변경과 무관하며, 로컬에서 `npm install`이 필요한 별개 이슈입니다.
