### PR TITLE
fix: 좌석 그리드 인라인 콜백으로 무력화된 memo 복구

### DIFF
--- a/src/entities/booking/ui/LotterySeatGrid/index.tsx
+++ b/src/entities/booking/ui/LotterySeatGrid/index.tsx
@@ -8,6 +8,8 @@ import { Seat, SeatLayout, SECTIONS } from "@/entities/booking/model/types";
 import { getSeatPattern, getSeatLayout } from "@/entities/booking/model/seatLayouts";
 import { SeatItem } from "../SeatItem";
 
+const NOOP_SEAT_SELECT = () => {};
+
 export interface LotterySeatGridProps {
   layout: SeatLayout | null;
   lotterySeats: Seat[];
@@ -163,7 +165,7 @@ export const LotterySeatGrid = memo<LotterySeatGridProps>(
                   <SeatItem
                     seat={{ ...seat, status: getSeatStatus(seat) }}
                     isSelected={isSeatSelected(seat)}
-                    onSelect={() => {}}
+                    onSelect={NOOP_SEAT_SELECT}
                     className={cn(
                       "w-5 h-5 border-2 bg-gray-500",
                       disabledSet.has(keyOf(seat)) && "pointer-events-none opacity-40",
@@ -221,7 +223,7 @@ export const LotterySeatGrid = memo<LotterySeatGridProps>(
                       <SeatItem
                         seat={{ ...seat, status }}
                         isSelected={isRevealedSeat || isAnimatingSeat}
-                        onSelect={() => {}}
+                        onSelect={NOOP_SEAT_SELECT}
                         className={cn(
                           "w-20 h-20 text-sm",
                           disabled && "pointer-events-none opacity-40",

--- a/src/entities/booking/ui/SeatGrid/index.tsx
+++ b/src/entities/booking/ui/SeatGrid/index.tsx
@@ -128,11 +128,21 @@ export const SeatGrid = memo<SeatGridProps>(
     );
 
     const sectionSeatMaps = useMemo(() => {
+      const seatsBySection = new Map<(typeof SECTIONS)[number], Seat[]>();
+      allSeats?.forEach(seat => {
+        const bucket = seatsBySection.get(seat.section);
+        if (bucket) {
+          bucket.push(seat);
+        } else {
+          seatsBySection.set(seat.section, [seat]);
+        }
+      });
+
       const maps = new Map<(typeof SECTIONS)[number], Map<string, Seat>>();
 
       SECTIONS.forEach(section => {
         const cachedSeats = queryClient.getQueryData<Seat[]>(seatQueryKeys.seatState(section));
-        const allSectionSeats = allSeats?.filter(seat => seat.section === section);
+        const allSectionSeats = seatsBySection.get(section);
         const sectionLayout = getSeatLayout(section);
         const seatsToUse =
           allSectionSeats && allSectionSeats.length > 0

--- a/src/entities/booking/ui/SeatGrid/index.tsx
+++ b/src/entities/booking/ui/SeatGrid/index.tsx
@@ -8,6 +8,8 @@ import { Seat, SeatLayout, SECTIONS } from "@/entities/booking/model/types";
 import { SeatItem } from "../SeatItem";
 import { getSeatPattern, getSeatLayout } from "@/entities/booking/model/seatLayouts";
 
+const NOOP_SEAT_SELECT = () => {};
+
 export interface SeatGridProps {
   layout: SeatLayout | null;
   selectedSeat: Seat | null;
@@ -113,7 +115,7 @@ export const SeatGrid = memo<SeatGridProps>(
                   <SeatItem
                     seat={seat}
                     isSelected={getSeatSelectedState(seat)}
-                    onSelect={mySeat ? () => {} : handleSeatSelect}
+                    onSelect={mySeat ? NOOP_SEAT_SELECT : handleSeatSelect}
                   />
                 ) : (
                   <div className="w-5 h-5" />
@@ -125,21 +127,31 @@ export const SeatGrid = memo<SeatGridProps>(
       </div>
     );
 
-    const renderSectionMiniGrid = (section: (typeof SECTIONS)[number]) => {
-      const cachedSeats = queryClient.getQueryData<Seat[]>(seatQueryKeys.seatState(section));
-      const allSectionSeats = allSeats?.filter(seat => seat.section === section);
-      const sectionLayout = getSeatLayout(section);
-      const pattern = getSeatPattern(section);
+    const sectionSeatMaps = useMemo(() => {
+      const maps = new Map<(typeof SECTIONS)[number], Map<string, Seat>>();
 
-      const seatMap = new Map<string, Seat>();
-      const seatsToUse =
-        allSectionSeats && allSectionSeats.length > 0
-          ? allSectionSeats
-          : cachedSeats || sectionLayout.seats;
+      SECTIONS.forEach(section => {
+        const cachedSeats = queryClient.getQueryData<Seat[]>(seatQueryKeys.seatState(section));
+        const allSectionSeats = allSeats?.filter(seat => seat.section === section);
+        const sectionLayout = getSeatLayout(section);
+        const seatsToUse =
+          allSectionSeats && allSectionSeats.length > 0
+            ? allSectionSeats
+            : cachedSeats || sectionLayout.seats;
 
-      seatsToUse.forEach(seat => {
-        seatMap.set(seat.seatNumber, seat);
+        const seatMap = new Map<string, Seat>();
+        seatsToUse.forEach(seat => {
+          seatMap.set(seat.seatNumber, seat);
+        });
+        maps.set(section, seatMap);
       });
+
+      return maps;
+    }, [allSeats, queryClient]);
+
+    const renderSectionMiniGrid = (section: (typeof SECTIONS)[number]) => {
+      const pattern = getSeatPattern(section);
+      const seatMap = sectionSeatMaps.get(section)!;
 
       return (
         <div className="flex flex-col items-center border rounded-lg mb-28">
@@ -158,7 +170,7 @@ export const SeatGrid = memo<SeatGridProps>(
                         <SeatItem
                           seat={seat}
                           isSelected={getSeatSelectedState(seat)}
-                          onSelect={mySeat ? () => {} : handleSeatSelect}
+                          onSelect={mySeat ? NOOP_SEAT_SELECT : handleSeatSelect}
                           className="w-6 h-6 text-transparent"
                         />
                       ) : (

--- a/src/widgets/booking/ui/SeatSection/index.tsx
+++ b/src/widgets/booking/ui/SeatSection/index.tsx
@@ -14,6 +14,8 @@ import { useSeatChangeSSE } from "@/entities/booking/lib/useSeatChangeSSE";
 import { getSeatLayout } from "@/entities/booking/model/seatLayouts";
 import { useQueryClient } from "@tanstack/react-query";
 
+const NOOP_SEAT_SELECT = () => {};
+
 interface SeatSectionProps {
   selectedSection: Section | null;
   selectedSeat: Seat | null;
@@ -162,7 +164,7 @@ export const SeatSection = memo<SeatSectionProps>(
           <SeatGrid
             layout={layout}
             selectedSeat={selectedSeat}
-            onSeatSelect={isLoading || !!error ? () => {} : onSeatSelect}
+            onSeatSelect={isLoading || !!error ? NOOP_SEAT_SELECT : onSeatSelect}
             allSeats={realTimeSeats}
             selectedSeats={selectedSeats}
             isSeatSelected={isSeatSelected}


### PR DESCRIPTION
## 💡 PR 요약

> 해당 PR의 변경사항, 해당 이슈 등에 대한 간략한 설명을 작성해주세요.

- `SeatGrid`, `SeatSection`, `LotterySeatGrid`에서 `memo()`/`useCallback` 적용해놓고 인라인 화살표 함수(`() => {}`)를 prop으로 넘겨 매 렌더마다 새 참조가 생성되던 문제 수정
- 좌석 SSE 이벤트(`useSeatChangeSSE`)로 좌석 하나 상태만 바뀌어도 최대 995석 전체가 리렌더/재조정되던 것을 방지

## 📋 작업 내용

- `SeatGrid/index.tsx`: `mySeat ? () => {} : handleSeatSelect` → 모듈 스코프 상수 `NOOP_SEAT_SELECT`로 교체 (2곳). `SeatItem`에 준 `memo()`가 매 렌더마다 무력화되던 문제 복구
- `SeatGrid/index.tsx`: `renderSectionMiniGrid`에서 렌더마다 재계산되던 구역별 좌석 Map 빌드 로직을 `useMemo`(`sectionSeatMaps`)로 이동, `allSeats` 참조가 바뀔 때만 재계산
- `SeatSection/index.tsx`: `SeatGrid`로 넘기는 `onSeatSelect`의 인라인 no-op도 동일하게 상수로 교체
- `LotterySeatGrid/index.tsx`: 동일한 인라인 `onSelect={() => {}}` 2곳을 동일한 상수로 교체
- 동작 변화 없음 (순수 렌더 최적화)

## 🤝 리뷰 시 참고사항

- 측정 기반 최적화라기보단 이미 붙어있던 `memo`/`useCallback`을 인라인 함수가 스스로 무력화하던 버그성 코드라 `fix`로 분류함
- `LotterySeatGrid`는 `seat={{ ...seat, status }}` 부분에서 매 렌더 새 객체를 만들어 `SeatItem` prop이 여전히 매번 바뀌긴 하지만, 애니메이션 중 상태가 실제로 자주 바뀌는 화면이라 이번 범위에서는 손대지 않음