### PR TITLE
fix: 예선 결과 페이지 중복 참석 명단 제출 버튼 제거

### DIFF
--- a/src/views/preliminary-result/ui/PreliminaryResultView/index.tsx
+++ b/src/views/preliminary-result/ui/PreliminaryResultView/index.tsx
@@ -3,7 +3,6 @@
 import { useRef } from "react";
 import { cn } from "@/shared/utils/cn";
 import BackHeader from "@/shared/ui/BackHeader";
-import Button from "@/shared/ui/Button";
 
 type Team = {
   id: number;
@@ -69,8 +68,6 @@ const MEETING_AGENDA = [
   "홍보자료 제작용 팀 소개 관련 자료 수합 안내(사진, 팀 소개, 연주곡 소개 등)",
 ];
 
-const PRELIMINARY_FORM_URL = "https://form.naver.com/response/lmQTiRvKRFYiVKnSeLieRg";
-
 const PreliminaryResultView = () => {
   const meetingGuideRef = useRef<HTMLElement>(null);
 
@@ -93,12 +90,6 @@ const PreliminaryResultView = () => {
           </div>
 
           <div className={cn("flex flex-col items-center gap-12 mobile:gap-10 mobile:w-full")}>
-            <Button
-              className="px-48 mobile:w-full"
-              onClick={() => window.open(PRELIMINARY_FORM_URL, "_blank")}
-            >
-              사전 협의회 참석 명단 제출하기
-            </Button>
             <a
               href="#meeting-guide"
               onClick={e => {
@@ -212,23 +203,6 @@ const PreliminaryResultView = () => {
             >
               지도에서 보기 →
             </a>
-          </div>
-
-          <div
-            className={cn(
-              "flex flex-col items-center gap-12 mobile:gap-10 rounded-xl p-24 mobile:p-16",
-              "bg-gradient-to-br from-orange-50 to-white border border-orange-100 text-center",
-            )}
-          >
-            <p className={cn("text-body3b mobile:text-caption1b text-black")}>
-              사전 협의회 참석 명단은 아래 폼으로 제출해주세요
-            </p>
-            <Button
-              className="px-48 mobile:w-full"
-              onClick={() => window.open(PRELIMINARY_FORM_URL, "_blank")}
-            >
-              참석 명단 제출 폼 바로가기
-            </Button>
           </div>
         </section>
 


### PR DESCRIPTION
## 💡 PR 요약

> 해당 PR의 변경사항, 해당 이슈 등에 대한 간략한 설명을 작성해주세요.

- 예선 결과 페이지에 동일한 역할(폼 제출)을 하는 버튼이 상단과 협의회 안내 섹션 2곳에 중복 노출되던 문제 수정
- "사전 협의회 참석 명단 제출하기" 버튼 2개 모두 제거

## 📋 작업 내용

> 해당 PR에서 작업한 내용을 자세히 설명해주세요.

- `PreliminaryResultView`에서 헤더 영역의 참석 명단 제출 버튼 제거 (하단 "협의회 참석 관련 안내 →" 스크롤 링크는 유지)
- 협의회 안내 섹션(`#meeting-guide`) 내 "참석 명단 제출 폼 바로가기" 버튼 및 안내 문구 블록 제거
- 버튼 제거로 미사용 처리된 `PRELIMINARY_FORM_URL` 상수, `Button` import 함께 정리

## 🤝 리뷰 시 참고사항

- 폼 제출 링크 자체를 완전히 없앤 것으로, 추후 폼 제출이 다시 필요하면 별도 버튼을 재도입해야 합니다
