### PR TITLE
feat: 심사 페이지 팀 순서 드래그 앤 드롭 및 UX 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "gwangju-talent-festival-client",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@tanstack/react-query": "^5.74.4",
         "@tsparticles/preset-confetti": "^3.2.0",
         "@tsparticles/preset-fire": "^3.2.0",
@@ -584,10 +587,86 @@
       "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
       "license": "MIT"
     },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1760,6 +1839,17 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@tanstack/react-query": "^5.74.4",
     "@tsparticles/preset-confetti": "^3.2.0",
     "@tsparticles/preset-fire": "^3.2.0",

--- a/src/entities/judging/api/__tests__/downloadJudgingSummary.test.ts
+++ b/src/entities/judging/api/__tests__/downloadJudgingSummary.test.ts
@@ -83,6 +83,27 @@ describe("downloadJudgingSummary - 성공", () => {
     expect(appendedLink?.download).toBe("심사결과.xlsx");
   });
 
+  it("RFC 2047 MIME 인코디드 워드(=?UTF-8?Q?...?=) 파일명을 디코딩한다", async () => {
+    const response = createResponse({
+      ok: true,
+      headers: {
+        "content-disposition":
+          'attachment; filename="=?UTF-8?Q?=EC=8B=AC=EC=82=AC=EC=A7=91=EA=B3=84=ED=91=9C?=.xlsx"',
+      },
+    });
+    vi.mocked(fetch).mockResolvedValueOnce(response);
+
+    let appendedLink: HTMLAnchorElement | undefined;
+    appendChildSpy.mockImplementation(node => {
+      appendedLink = node as HTMLAnchorElement;
+      return node;
+    });
+
+    await downloadJudgingSummary();
+
+    expect(appendedLink?.download).toBe("심사집계표.xlsx");
+  });
+
   it("Content-Disposition 헤더가 없으면 기본 파일명을 사용한다", async () => {
     const response = createResponse({ ok: true });
     vi.mocked(fetch).mockResolvedValueOnce(response);

--- a/src/entities/judging/api/__tests__/downloadJudgingSummary.test.ts
+++ b/src/entities/judging/api/__tests__/downloadJudgingSummary.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { downloadJudgingSummary } from "../downloadJudgingSummary";
+
+const createResponse = ({
+  ok,
+  blob,
+  headers,
+  json,
+  jsonRejects,
+}: {
+  ok: boolean;
+  blob?: Blob;
+  headers?: Record<string, string>;
+  json?: unknown;
+  jsonRejects?: boolean;
+}): Response => {
+  return {
+    ok,
+    blob: vi.fn().mockResolvedValue(blob ?? new Blob(["dummy"])),
+    json: jsonRejects
+      ? vi.fn().mockRejectedValue(new Error("invalid json"))
+      : vi.fn().mockResolvedValue(json ?? {}),
+    headers: {
+      get: vi.fn((key: string) => headers?.[key] ?? null),
+    },
+  } as unknown as Response;
+};
+
+let createObjectURLMock: ReturnType<typeof vi.fn>;
+let revokeObjectURLMock: ReturnType<typeof vi.fn>;
+let clickMock: ReturnType<typeof vi.fn>;
+let appendChildSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  createObjectURLMock = vi.fn().mockReturnValue("blob:mock-url");
+  revokeObjectURLMock = vi.fn();
+  URL.createObjectURL = createObjectURLMock;
+  URL.revokeObjectURL = revokeObjectURLMock;
+
+  clickMock = vi.fn();
+  vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(clickMock);
+  appendChildSpy = vi.spyOn(document.body, "appendChild");
+
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("downloadJudgingSummary - 성공", () => {
+  it("/api/excel/summary를 호출하고 blob으로 다운로드 링크를 생성해 클릭한다", async () => {
+    const response = createResponse({ ok: true });
+    vi.mocked(fetch).mockResolvedValueOnce(response);
+
+    await downloadJudgingSummary();
+
+    expect(fetch).toHaveBeenCalledWith("/api/excel/summary");
+    expect(createObjectURLMock).toHaveBeenCalled();
+    expect(appendChildSpy).toHaveBeenCalled();
+    expect(clickMock).toHaveBeenCalled();
+    expect(revokeObjectURLMock).toHaveBeenCalledWith("blob:mock-url");
+  });
+
+  it("Content-Disposition 헤더에서 파일명을 추출해 link.download에 설정한다", async () => {
+    const response = createResponse({
+      ok: true,
+      headers: { "content-disposition": 'attachment; filename="심사결과.xlsx"' },
+    });
+    vi.mocked(fetch).mockResolvedValueOnce(response);
+
+    let appendedLink: HTMLAnchorElement | undefined;
+    appendChildSpy.mockImplementation(node => {
+      appendedLink = node as HTMLAnchorElement;
+      return node;
+    });
+
+    await downloadJudgingSummary();
+
+    expect(appendedLink?.download).toBe("심사결과.xlsx");
+  });
+
+  it("Content-Disposition 헤더가 없으면 기본 파일명을 사용한다", async () => {
+    const response = createResponse({ ok: true });
+    vi.mocked(fetch).mockResolvedValueOnce(response);
+
+    let appendedLink: HTMLAnchorElement | undefined;
+    appendChildSpy.mockImplementation(node => {
+      appendedLink = node as HTMLAnchorElement;
+      return node;
+    });
+
+    await downloadJudgingSummary();
+
+    expect(appendedLink?.download).toBe("judging-summary.xlsx");
+  });
+});
+
+describe("downloadJudgingSummary - 실패", () => {
+  it("응답이 실패면 서버 메시지를 담은 에러를 던진다", async () => {
+    const response = createResponse({ ok: false, json: { message: "권한이 없습니다." } });
+    vi.mocked(fetch).mockResolvedValueOnce(response);
+
+    await expect(downloadJudgingSummary()).rejects.toThrow("권한이 없습니다.");
+  });
+
+  it("실패 응답의 JSON 파싱도 실패하면 기본 메시지로 대체한다", async () => {
+    const response = createResponse({ ok: false, jsonRejects: true });
+    vi.mocked(fetch).mockResolvedValueOnce(response);
+
+    await expect(downloadJudgingSummary()).rejects.toThrow("심사 집계표를 다운로드하지 못했습니다.");
+  });
+});

--- a/src/entities/judging/api/__tests__/downloadJudgingSummary.test.ts
+++ b/src/entities/judging/api/__tests__/downloadJudgingSummary.test.ts
@@ -62,7 +62,9 @@ describe("downloadJudgingSummary - 성공", () => {
     expect(createObjectURLMock).toHaveBeenCalled();
     expect(appendChildSpy).toHaveBeenCalled();
     expect(clickMock).toHaveBeenCalled();
-    expect(revokeObjectURLMock).toHaveBeenCalledWith("blob:mock-url");
+    await vi.waitFor(() => {
+      expect(revokeObjectURLMock).toHaveBeenCalledWith("blob:mock-url");
+    });
   });
 
   it("Content-Disposition 헤더에서 파일명을 추출해 link.download에 설정한다", async () => {
@@ -102,6 +104,24 @@ describe("downloadJudgingSummary - 성공", () => {
     await downloadJudgingSummary();
 
     expect(appendedLink?.download).toBe("심사집계표.xlsx");
+  });
+
+  it("따옴표로 감싼 파일명 안에 세미콜론이 있어도 전체를 추출한다", async () => {
+    const response = createResponse({
+      ok: true,
+      headers: { "content-disposition": 'attachment; filename="심사;결과.xlsx"' },
+    });
+    vi.mocked(fetch).mockResolvedValueOnce(response);
+
+    let appendedLink: HTMLAnchorElement | undefined;
+    appendChildSpy.mockImplementation(node => {
+      appendedLink = node as HTMLAnchorElement;
+      return node;
+    });
+
+    await downloadJudgingSummary();
+
+    expect(appendedLink?.download).toBe("심사;결과.xlsx");
   });
 
   it("Content-Disposition 헤더가 없으면 기본 파일명을 사용한다", async () => {

--- a/src/entities/judging/api/downloadJudgingSummary.ts
+++ b/src/entities/judging/api/downloadJudgingSummary.ts
@@ -1,0 +1,23 @@
+const extractFilename = (contentDisposition: string | null): string => {
+  const match = contentDisposition?.match(/filename="?([^"]+)"?/);
+  return match?.[1] ?? "judging-summary.xlsx";
+};
+
+export const downloadJudgingSummary = async (): Promise<void> => {
+  const response = await fetch("/api/excel/summary");
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => null);
+    throw new Error(data?.message ?? "심사 집계표를 다운로드하지 못했습니다.");
+  }
+
+  const blob = await response.blob();
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = extractFilename(response.headers.get("content-disposition"));
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+};

--- a/src/entities/judging/api/downloadJudgingSummary.ts
+++ b/src/entities/judging/api/downloadJudgingSummary.ts
@@ -45,8 +45,11 @@ const extractFilename = (contentDisposition: string | null): string => {
     }
   }
 
-  const match = contentDisposition.match(/filename="?([^";]+)"?/i);
-  return match ? decodeMimeEncodedWords(match[1]) : DEFAULT_FILENAME;
+  const quotedMatch = contentDisposition.match(/filename="([^"]+)"/i);
+  if (quotedMatch) return decodeMimeEncodedWords(quotedMatch[1]);
+
+  const unquotedMatch = contentDisposition.match(/filename=([^;]+)/i);
+  return unquotedMatch ? decodeMimeEncodedWords(unquotedMatch[1]) : DEFAULT_FILENAME;
 };
 
 export const downloadJudgingSummary = async (): Promise<void> => {
@@ -65,5 +68,6 @@ export const downloadJudgingSummary = async (): Promise<void> => {
   document.body.appendChild(link);
   link.click();
   link.remove();
-  URL.revokeObjectURL(url);
+  // 일부 브라우저는 다운로드 트리거가 비동기로 처리돼 즉시 revoke하면 다운로드가 실패할 수 있다
+  setTimeout(() => URL.revokeObjectURL(url), 100);
 };

--- a/src/entities/judging/api/downloadJudgingSummary.ts
+++ b/src/entities/judging/api/downloadJudgingSummary.ts
@@ -1,6 +1,52 @@
+const DEFAULT_FILENAME = "judging-summary.xlsx";
+
+const decodeQEncodedWord = (text: string): string => {
+  const bytes: number[] = [];
+  for (let i = 0; i < text.length; ) {
+    if (text[i] === "=" && i + 2 < text.length) {
+      bytes.push(parseInt(text.slice(i + 1, i + 3), 16));
+      i += 3;
+    } else if (text[i] === "_") {
+      bytes.push(0x20);
+      i += 1;
+    } else {
+      bytes.push(text.charCodeAt(i));
+      i += 1;
+    }
+  }
+  return new TextDecoder("utf-8").decode(Uint8Array.from(bytes));
+};
+
+const decodeBase64EncodedWord = (text: string): string => {
+  const binary = atob(text);
+  return new TextDecoder("utf-8").decode(Uint8Array.from(binary, char => char.charCodeAt(0)));
+};
+
+// 백엔드가 Content-Disposition의 filename에 RFC 2047 MIME 인코디드 워드(=?UTF-8?Q?...?=)를
+// 그대로 내려주는 경우가 있어, 브라우저가 기본 다운로드로 처리할 때와 동일하게 직접 디코딩한다.
+const decodeMimeEncodedWords = (value: string): string =>
+  value.replace(/=\?[^?]+\?([BbQq])\?([^?]*)\?=/g, (match, encoding: string, text: string) => {
+    try {
+      return encoding.toUpperCase() === "Q" ? decodeQEncodedWord(text) : decodeBase64EncodedWord(text);
+    } catch {
+      return match;
+    }
+  });
+
 const extractFilename = (contentDisposition: string | null): string => {
-  const match = contentDisposition?.match(/filename="?([^"]+)"?/);
-  return match?.[1] ?? "judging-summary.xlsx";
+  if (!contentDisposition) return DEFAULT_FILENAME;
+
+  const extendedMatch = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i);
+  if (extendedMatch) {
+    try {
+      return decodeURIComponent(extendedMatch[1]);
+    } catch {
+      // 잘못된 percent-encoding이면 아래 일반 filename 파싱으로 대체
+    }
+  }
+
+  const match = contentDisposition.match(/filename="?([^";]+)"?/i);
+  return match ? decodeMimeEncodedWords(match[1]) : DEFAULT_FILENAME;
 };
 
 export const downloadJudgingSummary = async (): Promise<void> => {

--- a/src/entities/judging/model/teams.ts
+++ b/src/entities/judging/model/teams.ts
@@ -1,4 +1,0 @@
-import { Score } from "./score";
-
-export const getVisibleTeams = (scores: Score[]): Score[] =>
-  [...scores].sort((a, b) => a.teamId - b.teamId);

--- a/src/entities/team/api/__tests__/updateTeamOrder.test.ts
+++ b/src/entities/team/api/__tests__/updateTeamOrder.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AxiosError } from "axios";
+import { updateTeamOrder } from "../updateTeamOrder";
+import instance from "@/shared/lib/axios";
+
+vi.mock("@/shared/lib/axios", () => ({
+  default: {
+    patch: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("updateTeamOrder - 성공", () => {
+  it("orderItems로 팀 순서 변경 API를 호출한다", async () => {
+    vi.mocked(instance.patch).mockResolvedValueOnce({ data: null });
+    const orderItems = [
+      { teamId: 1, order: 1 },
+      { teamId: 2, order: 2 },
+    ];
+
+    await updateTeamOrder(orderItems);
+
+    expect(instance.patch).toHaveBeenCalledWith("/team/order", { orderItems });
+  });
+});
+
+describe("updateTeamOrder - 실패", () => {
+  it("서버 에러 메시지가 있으면 해당 메시지로 Error를 throw한다", async () => {
+    const axiosError = new AxiosError("Request failed");
+    axiosError.response = {
+      data: { message: "이미 확정된 순서입니다." },
+      status: 400,
+      statusText: "Bad Request",
+      headers: {},
+      config: {} as never,
+    };
+    vi.mocked(instance.patch).mockRejectedValueOnce(axiosError);
+
+    await expect(updateTeamOrder([{ teamId: 1, order: 1 }])).rejects.toThrow(
+      "이미 확정된 순서입니다.",
+    );
+  });
+
+  it("서버 에러 메시지가 없으면 기본 메시지로 Error를 throw한다", async () => {
+    const axiosError = new AxiosError("Request failed");
+    axiosError.response = {
+      data: {},
+      status: 500,
+      statusText: "Internal Server Error",
+      headers: {},
+      config: {} as never,
+    };
+    vi.mocked(instance.patch).mockRejectedValueOnce(axiosError);
+
+    await expect(updateTeamOrder([{ teamId: 1, order: 1 }])).rejects.toThrow(
+      "팀 순서 변경에 실패했습니다.",
+    );
+  });
+});

--- a/src/entities/team/api/getAllTeams.ts
+++ b/src/entities/team/api/getAllTeams.ts
@@ -1,0 +1,7 @@
+import instance from "@/shared/lib/axios";
+import { Team } from "../model/types";
+
+export const getAllTeams = async (): Promise<Team[]> => {
+  const res = await instance.get<Team[]>("/team");
+  return res.data;
+};

--- a/src/entities/team/api/updateTeamOrder.ts
+++ b/src/entities/team/api/updateTeamOrder.ts
@@ -1,0 +1,18 @@
+import instance from "@/shared/lib/axios";
+import { AxiosError } from "axios";
+import { TeamOrderItem } from "../model/types";
+
+export const updateTeamOrder = async (orderItems: TeamOrderItem[]) => {
+  try {
+    return await instance.patch("/team/order", { orderItems });
+  } catch (error) {
+    const axiosError = error as AxiosError;
+    const errorMessage =
+      axiosError?.response?.data &&
+      typeof axiosError.response.data === "object" &&
+      "message" in axiosError.response.data
+        ? (axiosError.response.data as { message: string }).message
+        : "팀 순서 변경에 실패했습니다.";
+    throw new Error(errorMessage);
+  }
+};

--- a/src/entities/team/model/types.ts
+++ b/src/entities/team/model/types.ts
@@ -1,0 +1,14 @@
+export type TeamStatus = "PENDING" | "ONGOING" | "FINISHED";
+
+export type Team = {
+  teamId: number;
+  teamName: string;
+  school: string;
+  performOrder: number;
+  status: TeamStatus;
+};
+
+export type TeamOrderItem = {
+  teamId: number;
+  order: number;
+};

--- a/src/views/judging/model/__tests__/useReorderTeams.test.tsx
+++ b/src/views/judging/model/__tests__/useReorderTeams.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { useReorderTeams } from "../useReorderTeams";
+import { updateTeamOrder } from "@/entities/team/api/updateTeamOrder";
+import { teamOrderQueryKey } from "../queryKeys";
+import { Team } from "@/entities/team/model/types";
+
+vi.mock("@/entities/team/api/updateTeamOrder", () => ({
+  updateTeamOrder: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const makeTeam = (teamId: number, performOrder: number): Team => ({
+  teamId,
+  teamName: `팀${teamId}`,
+  school: "광주고",
+  performOrder,
+  status: "PENDING",
+});
+
+const createWrapper = (queryClient: QueryClient) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+let queryClient: QueryClient;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+});
+
+describe("useReorderTeams - order 변환", () => {
+  it("orderedTeamIds를 1부터 시작하는 order로 변환해 API를 호출한다", async () => {
+    vi.mocked(updateTeamOrder).mockResolvedValueOnce({ data: null } as never);
+    const { result } = renderHook(() => useReorderTeams(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.reorderTeams([3, 1, 2]);
+
+    await waitFor(() => {
+      expect(updateTeamOrder).toHaveBeenCalledWith([
+        { teamId: 3, order: 1 },
+        { teamId: 1, order: 2 },
+        { teamId: 2, order: 3 },
+      ]);
+    });
+  });
+});
+
+describe("useReorderTeams - 낙관적 업데이트", () => {
+  it("성공 시 캐시가 새 순서로 갱신된 상태로 유지된다", async () => {
+    const initialTeams = [makeTeam(1, 1), makeTeam(2, 2), makeTeam(3, 3)];
+    queryClient.setQueryData(teamOrderQueryKey, initialTeams);
+    vi.mocked(updateTeamOrder).mockResolvedValueOnce({ data: null } as never);
+
+    const { result } = renderHook(() => useReorderTeams(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.reorderTeams([2, 1, 3]);
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<Team[]>(teamOrderQueryKey)?.map(team => team.teamId),
+      ).toEqual([2, 1, 3]);
+    });
+
+    await waitFor(() => {
+      expect(updateTeamOrder).toHaveBeenCalled();
+    });
+  });
+
+  it("실패 시 이전 캐시로 롤백된다", async () => {
+    const initialTeams = [makeTeam(1, 1), makeTeam(2, 2), makeTeam(3, 3)];
+    queryClient.setQueryData(teamOrderQueryKey, initialTeams);
+    vi.mocked(updateTeamOrder).mockRejectedValueOnce(new Error("팀 순서 변경에 실패했습니다."));
+
+    const { result } = renderHook(() => useReorderTeams(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.reorderTeams([2, 1, 3]);
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData<Team[]>(teamOrderQueryKey)?.map(team => team.teamId)).toEqual(
+        [1, 2, 3],
+      );
+    });
+  });
+});

--- a/src/views/judging/model/__tests__/useTeamGridData.test.ts
+++ b/src/views/judging/model/__tests__/useTeamGridData.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useTeamGridData } from "../useTeamGridData";
+import { useGetJudgeList } from "../useGetJudgeList";
+import { useGetTeamOrder } from "../useGetTeamOrder";
+import { Score } from "@/entities/judging/model/score";
+import { Team } from "@/entities/team/model/types";
+
+vi.mock("../useGetJudgeList", () => ({
+  useGetJudgeList: vi.fn(),
+}));
+
+vi.mock("../useGetTeamOrder", () => ({
+  useGetTeamOrder: vi.fn(),
+}));
+
+const makeScore = (teamId: number): Score => ({
+  judgementId: null,
+  teamId,
+  teamName: `팀${teamId}`,
+  completenessExpressionScore: 0,
+  creativityCompositionScore: 0,
+  stagePerformanceTeamworkScore: 0,
+  totalScore: 0,
+  isPerformed: false,
+  isJudged: false,
+});
+
+const makeTeam = (teamId: number, performOrder: number): Team => ({
+  teamId,
+  teamName: `팀${teamId}`,
+  school: "광주고",
+  performOrder,
+  status: "PENDING",
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useTeamGridData - performOrder 기준 정렬", () => {
+  it("팀 순서 데이터를 반영해 performOrder 오름차순으로 정렬한다", () => {
+    vi.mocked(useGetJudgeList).mockReturnValue({
+      data: [makeScore(1), makeScore(2), makeScore(3)],
+      isLoading: false,
+      isError: false,
+    } as never);
+    vi.mocked(useGetTeamOrder).mockReturnValue({
+      data: [makeTeam(1, 3), makeTeam(2, 1), makeTeam(3, 2)],
+      isLoading: false,
+      isError: false,
+    } as never);
+
+    const { result } = renderHook(() => useTeamGridData());
+
+    expect(result.current.teams.map(team => team.teamId)).toEqual([2, 3, 1]);
+    expect(result.current.teams.map(team => team.performOrder)).toEqual([1, 2, 3]);
+  });
+
+  it("팀 순서 데이터에 없는 teamId는 teamId 값을 performOrder로 사용한다", () => {
+    vi.mocked(useGetJudgeList).mockReturnValue({
+      data: [makeScore(1), makeScore(5)],
+      isLoading: false,
+      isError: false,
+    } as never);
+    vi.mocked(useGetTeamOrder).mockReturnValue({
+      data: [makeTeam(1, 10)],
+      isLoading: false,
+      isError: false,
+    } as never);
+
+    const { result } = renderHook(() => useTeamGridData());
+
+    const team5 = result.current.teams.find(team => team.teamId === 5);
+    expect(team5?.performOrder).toBe(5);
+  });
+});
+
+describe("useTeamGridData - 로딩/에러 상태", () => {
+  it("점수 또는 순서 데이터 중 하나라도 로딩 중이면 isLoading이 true다", () => {
+    vi.mocked(useGetJudgeList).mockReturnValue({
+      data: [],
+      isLoading: true,
+      isError: false,
+    } as never);
+    vi.mocked(useGetTeamOrder).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    } as never);
+
+    const { result } = renderHook(() => useTeamGridData());
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("점수 또는 순서 데이터 중 하나라도 에러면 isError가 true다", () => {
+    vi.mocked(useGetJudgeList).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    } as never);
+    vi.mocked(useGetTeamOrder).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: true,
+    } as never);
+
+    const { result } = renderHook(() => useTeamGridData());
+
+    expect(result.current.isError).toBe(true);
+  });
+});

--- a/src/views/judging/model/__tests__/useTeamScores.test.tsx
+++ b/src/views/judging/model/__tests__/useTeamScores.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { useTeamScores } from "../useTeamScores";
+import { saveScore } from "@/entities/judging/api/saveScore";
+import { EMPTY_SCORE, Score } from "@/entities/judging/model/score";
+
+vi.mock("@/entities/judging/api/saveScore", () => ({
+  saveScore: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const makeScore = (teamId: number, overrides: Partial<Score> = {}): Score => ({
+  judgementId: null,
+  teamId,
+  teamName: `팀${teamId}`,
+  completenessExpressionScore: 0,
+  creativityCompositionScore: 0,
+  stagePerformanceTeamworkScore: 0,
+  totalScore: 0,
+  isPerformed: false,
+  isJudged: false,
+  ...overrides,
+});
+
+const createWrapper = (queryClient: QueryClient) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+let queryClient: QueryClient;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+});
+
+describe("useTeamScores - hasUnsavedEdit", () => {
+  it("updateScore 호출 전에는 hasUnsavedEdit가 false다", () => {
+    const teams = [makeScore(1)];
+    const { result } = renderHook(() => useTeamScores(teams), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.hasUnsavedEdit(1)).toBe(false);
+  });
+
+  it("updateScore 호출 후에는 hasUnsavedEdit가 true다", () => {
+    const teams = [makeScore(1)];
+    const { result } = renderHook(() => useTeamScores(teams), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.updateScore(1, "completenessExpressionScore", 30);
+    });
+
+    expect(result.current.hasUnsavedEdit(1)).toBe(true);
+  });
+
+  it("submitScore 성공 후에는 hasUnsavedEdit가 다시 false로 돌아온다", async () => {
+    vi.mocked(saveScore).mockResolvedValueOnce({} as never);
+    const teams = [makeScore(1)];
+    const { result } = renderHook(() => useTeamScores(teams), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.updateScore(1, "completenessExpressionScore", 30);
+    });
+    expect(result.current.hasUnsavedEdit(1)).toBe(true);
+
+    act(() => {
+      result.current.submitScore(1);
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasUnsavedEdit(1)).toBe(false);
+    });
+  });
+});
+
+describe("useTeamScores - getScore", () => {
+  it("이미 채점된 팀은 해당 팀의 점수를 반환한다", () => {
+    const teams = [
+      makeScore(1, {
+        isJudged: true,
+        completenessExpressionScore: 40,
+        creativityCompositionScore: 20,
+        stagePerformanceTeamworkScore: 10,
+      }),
+    ];
+    const { result } = renderHook(() => useTeamScores(teams), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.getScore(1)).toEqual({
+      completenessExpressionScore: 40,
+      creativityCompositionScore: 20,
+      stagePerformanceTeamworkScore: 10,
+    });
+  });
+
+  it("아직 채점 안 된 팀은 EMPTY_SCORE(0점)를 반환한다", () => {
+    const teams = [makeScore(1, { isJudged: false })];
+    const { result } = renderHook(() => useTeamScores(teams), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.getScore(1)).toEqual(EMPTY_SCORE);
+  });
+});

--- a/src/views/judging/model/__tests__/useTeamScores.test.tsx
+++ b/src/views/judging/model/__tests__/useTeamScores.test.tsx
@@ -88,6 +88,39 @@ describe("useTeamScores - hasUnsavedEdit", () => {
   });
 });
 
+describe("useTeamScores - savingTeamId", () => {
+  it("저장 중인 팀의 id만 savingTeamId로 노출되고, 완료되면 다시 null이 된다", async () => {
+    let resolveSave: () => void = () => {};
+    vi.mocked(saveScore).mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveSave = () => resolve(undefined as never);
+        }),
+    );
+    const teams = [makeScore(1), makeScore(2)];
+    const { result } = renderHook(() => useTeamScores(teams), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.savingTeamId).toBeNull();
+
+    act(() => {
+      result.current.submitScore(1);
+    });
+
+    await waitFor(() => {
+      expect(result.current.savingTeamId).toBe(1);
+    });
+    expect(result.current.savingTeamId).not.toBe(2);
+
+    resolveSave();
+
+    await waitFor(() => {
+      expect(result.current.savingTeamId).toBeNull();
+    });
+  });
+});
+
 describe("useTeamScores - getScore", () => {
   it("이미 채점된 팀은 해당 팀의 점수를 반환한다", () => {
     const teams = [

--- a/src/views/judging/model/queryKeys.ts
+++ b/src/views/judging/model/queryKeys.ts
@@ -1,3 +1,5 @@
 export const judgeListQueryKey = ["judgeList"] as const;
 
 export const judgeCommentQueryKey = (teamId: number) => ["judgeComment", teamId] as const;
+
+export const teamOrderQueryKey = ["teamOrder"] as const;

--- a/src/views/judging/model/useGetTeamOrder.ts
+++ b/src/views/judging/model/useGetTeamOrder.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { Team } from "@/entities/team/model/types";
+import { getAllTeams } from "@/entities/team/api/getAllTeams";
+import { teamOrderQueryKey } from "./queryKeys";
+
+export const useGetTeamOrder = () => {
+  return useQuery<Team[]>({
+    queryKey: teamOrderQueryKey,
+    queryFn: getAllTeams,
+  });
+};

--- a/src/views/judging/model/useReorderTeams.ts
+++ b/src/views/judging/model/useReorderTeams.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Team } from "@/entities/team/model/types";
+import { updateTeamOrder } from "@/entities/team/api/updateTeamOrder";
+import { teamOrderQueryKey } from "./queryKeys";
+
+export const useReorderTeams = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate: reorderTeams, isPending: isReordering } = useMutation({
+    mutationFn: (orderedTeamIds: number[]) =>
+      updateTeamOrder(orderedTeamIds.map((teamId, index) => ({ teamId, order: index + 1 }))),
+    onMutate: async (orderedTeamIds: number[]) => {
+      await queryClient.cancelQueries({ queryKey: teamOrderQueryKey });
+      const previousTeams = queryClient.getQueryData<Team[]>(teamOrderQueryKey);
+
+      if (previousTeams) {
+        const teamMap = new Map(previousTeams.map(team => [team.teamId, team]));
+        const reordered = orderedTeamIds
+          .map((teamId, index) => {
+            const team = teamMap.get(teamId);
+            return team ? { ...team, performOrder: index + 1 } : null;
+          })
+          .filter((team): team is Team => team !== null);
+        queryClient.setQueryData<Team[]>(teamOrderQueryKey, reordered);
+      }
+
+      return { previousTeams };
+    },
+    onError: (error, _orderedTeamIds, context) => {
+      if (context?.previousTeams) {
+        queryClient.setQueryData(teamOrderQueryKey, context.previousTeams);
+      }
+      toast.error(error instanceof Error ? error.message : "팀 순서 변경에 실패했습니다.");
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: teamOrderQueryKey });
+    },
+  });
+
+  return { reorderTeams, isReordering };
+};

--- a/src/views/judging/model/useTeamGridData.ts
+++ b/src/views/judging/model/useTeamGridData.ts
@@ -1,0 +1,26 @@
+import { useMemo } from "react";
+import { Score } from "@/entities/judging/model/score";
+import { useGetJudgeList } from "./useGetJudgeList";
+import { useGetTeamOrder } from "./useGetTeamOrder";
+
+export type OrderedTeam = Score & { performOrder: number };
+
+export const useTeamGridData = () => {
+  const { data: scores = [], isLoading: isScoresLoading, isError: isScoresError } =
+    useGetJudgeList();
+  const { data: teamOrder = [], isLoading: isOrderLoading, isError: isOrderError } =
+    useGetTeamOrder();
+
+  const teams = useMemo<OrderedTeam[]>(() => {
+    const orderMap = new Map(teamOrder.map(team => [team.teamId, team.performOrder]));
+    return [...scores]
+      .map(score => ({ ...score, performOrder: orderMap.get(score.teamId) ?? score.teamId }))
+      .sort((a, b) => a.performOrder - b.performOrder);
+  }, [scores, teamOrder]);
+
+  return {
+    teams,
+    isLoading: isScoresLoading || isOrderLoading,
+    isError: isScoresError || isOrderError,
+  };
+};

--- a/src/views/judging/model/useTeamScores.ts
+++ b/src/views/judging/model/useTeamScores.ts
@@ -38,7 +38,11 @@ export const useTeamScores = (teams: Score[]) => {
 
   const hasUnsavedEdit = useCallback((teamId: number) => teamId in edits, [edits]);
 
-  const { mutate: submitScore, isPending: isSaving } = useMutation({
+  const {
+    mutate: submitScore,
+    isPending,
+    variables: savingVariables,
+  } = useMutation({
     mutationFn: (teamId: number) => saveScore(teamId, getScore(teamId)),
     onMutate: async (teamId: number) => {
       await queryClient.cancelQueries({ queryKey: judgeListQueryKey });
@@ -69,5 +73,7 @@ export const useTeamScores = (teams: Score[]) => {
     },
   });
 
-  return { getScore, updateScore, submitScore, isSaving, hasUnsavedEdit };
+  const savingTeamId = isPending ? (savingVariables ?? null) : null;
+
+  return { getScore, updateScore, submitScore, savingTeamId, hasUnsavedEdit };
 };

--- a/src/views/judging/model/useTeamScores.ts
+++ b/src/views/judging/model/useTeamScores.ts
@@ -36,6 +36,8 @@ export const useTeamScores = (teams: Score[]) => {
     [getScore],
   );
 
+  const hasUnsavedEdit = useCallback((teamId: number) => teamId in edits, [edits]);
+
   const { mutate: submitScore, isPending: isSaving } = useMutation({
     mutationFn: (teamId: number) => saveScore(teamId, getScore(teamId)),
     onMutate: async (teamId: number) => {
@@ -67,5 +69,5 @@ export const useTeamScores = (teams: Score[]) => {
     },
   });
 
-  return { getScore, updateScore, submitScore, isSaving };
+  return { getScore, updateScore, submitScore, isSaving, hasUnsavedEdit };
 };

--- a/src/views/judging/ui/JudgingPage/index.tsx
+++ b/src/views/judging/ui/JudgingPage/index.tsx
@@ -34,7 +34,8 @@ const JudgingPage = () => {
     }
   }, [selectedTeamId, teams]);
 
-  const { getScore, updateScore, submitScore, isSaving, hasUnsavedEdit } = useTeamScores(teams);
+  const { getScore, updateScore, submitScore, savingTeamId, hasUnsavedEdit } =
+    useTeamScores(teams);
   const { data: judgeComment } = useGetJudgeComment(selectedTeamId);
   const { save: saveJudgeComment, saveImmediately: clearJudgeComment } =
     useSaveJudgeComment(selectedTeamId);
@@ -108,7 +109,7 @@ const JudgingPage = () => {
             score={score}
             onChange={(key, value) => updateScore(selectedTeamId, key, value)}
             onSave={() => submitScore(selectedTeamId)}
-            isSaving={isSaving}
+            isSaving={savingTeamId === selectedTeamId}
           />
         )}
 

--- a/src/views/judging/ui/JudgingPage/index.tsx
+++ b/src/views/judging/ui/JudgingPage/index.tsx
@@ -4,11 +4,11 @@ import { useEffect, useState } from "react";
 import { DescriptionCard } from "@/entities/apply/ui/DescriptionCard";
 import BackHeader from "@/shared/ui/BackHeader";
 import { EVALUATION_CRITERIA, TOTAL_MAX } from "@/entities/judging/model/score";
-import { getVisibleTeams } from "@/entities/judging/model/teams";
 import TeamGrid from "@/widgets/judging/ui/TeamGrid";
 import ScoreForm from "@/widgets/judging/ui/ScoreForm";
 import HandwritingCanvas from "@/widgets/judging/ui/HandwritingCanvas";
-import { useGetJudgeList } from "../../model/useGetJudgeList";
+import { useTeamGridData } from "../../model/useTeamGridData";
+import { useReorderTeams } from "../../model/useReorderTeams";
 import { useTeamScores } from "../../model/useTeamScores";
 import { useGetJudgeComment } from "../../model/useGetJudgeComment";
 import { useSaveJudgeComment } from "../../model/useSaveJudgeComment";
@@ -19,8 +19,8 @@ const CRITERIA_ITEMS: string[] = EVALUATION_CRITERIA.map(
 const TEAM_SKELETON_COUNT = 12;
 
 const JudgingPage = () => {
-  const { data: scores = [], isLoading, isError } = useGetJudgeList();
-  const teams = getVisibleTeams(scores);
+  const { teams, isLoading, isError } = useTeamGridData();
+  const { reorderTeams } = useReorderTeams();
   const isTeamGridUnavailable = isLoading || isError || teams.length === 0;
 
   const [selectedTeamId, setSelectedTeamId] = useState<number | null>(null);
@@ -31,7 +31,7 @@ const JudgingPage = () => {
     }
   }, [selectedTeamId, teams]);
 
-  const { getScore, updateScore, submitScore, isSaving } = useTeamScores(scores);
+  const { getScore, updateScore, submitScore, isSaving } = useTeamScores(teams);
   const { data: judgeComment } = useGetJudgeComment(selectedTeamId);
   const { save: saveJudgeComment, saveImmediately: clearJudgeComment } =
     useSaveJudgeComment(selectedTeamId);
@@ -63,6 +63,7 @@ const JudgingPage = () => {
             teams={teams}
             selectedTeamId={selectedTeamId ?? teams[0].teamId}
             onSelect={setSelectedTeamId}
+            onReorder={reorderTeams}
           />
         )}
 

--- a/src/views/judging/ui/JudgingPage/index.tsx
+++ b/src/views/judging/ui/JudgingPage/index.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import { DescriptionCard } from "@/entities/apply/ui/DescriptionCard";
 import BackHeader from "@/shared/ui/BackHeader";
 import { EVALUATION_CRITERIA, TOTAL_MAX } from "@/entities/judging/model/score";
+import { downloadJudgingSummary } from "@/entities/judging/api/downloadJudgingSummary";
 import TeamGrid from "@/widgets/judging/ui/TeamGrid";
 import ScoreForm from "@/widgets/judging/ui/ScoreForm";
 import HandwritingCanvas from "@/widgets/judging/ui/HandwritingCanvas";
@@ -24,6 +26,7 @@ const JudgingPage = () => {
   const isTeamGridUnavailable = isLoading || isError || teams.length === 0;
 
   const [selectedTeamId, setSelectedTeamId] = useState<number | null>(null);
+  const [isDownloading, setIsDownloading] = useState(false);
 
   useEffect(() => {
     if (selectedTeamId === null && teams.length > 0) {
@@ -31,7 +34,7 @@ const JudgingPage = () => {
     }
   }, [selectedTeamId, teams]);
 
-  const { getScore, updateScore, submitScore, isSaving } = useTeamScores(teams);
+  const { getScore, updateScore, submitScore, isSaving, hasUnsavedEdit } = useTeamScores(teams);
   const { data: judgeComment } = useGetJudgeComment(selectedTeamId);
   const { save: saveJudgeComment, saveImmediately: clearJudgeComment } =
     useSaveJudgeComment(selectedTeamId);
@@ -39,17 +42,38 @@ const JudgingPage = () => {
   const selectedTeam = teams.find(team => team.teamId === selectedTeamId);
   const score = selectedTeamId !== null ? getScore(selectedTeamId) : null;
 
+  const handleSelectTeam = (teamId: number) => {
+    if (selectedTeamId !== null && selectedTeamId !== teamId && hasUnsavedEdit(selectedTeamId)) {
+      submitScore(selectedTeamId);
+    }
+    setSelectedTeamId(teamId);
+  };
+
+  const handleDownload = async () => {
+    setIsDownloading(true);
+    try {
+      await downloadJudgingSummary();
+      toast.success("심사 집계표 다운로드를 시작합니다");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "심사 집계표를 다운로드하지 못했습니다.");
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
   return (
     <div className="w-full min-h-screen flex flex-col items-center py-40 px-40 mobile:px-16">
       <div className="max-w-[1280px] w-full flex flex-col gap-24">
         <div className="flex items-center justify-between">
           <BackHeader text="심사 안내" />
-          <a
-            href="/api/excel/summary"
-            className="shrink-0 text-caption1b text-orange-500 underline underline-offset-4 hover:text-orange-400 transition-colors"
+          <button
+            type="button"
+            onClick={handleDownload}
+            disabled={isDownloading}
+            className="shrink-0 text-caption1b text-orange-500 underline underline-offset-4 hover:text-orange-400 transition-colors disabled:opacity-50"
           >
-            심사 결과 다운로드
-          </a>
+            {isDownloading ? "다운로드 중..." : "심사 결과 다운로드"}
+          </button>
         </div>
 
         {isTeamGridUnavailable ? (
@@ -62,7 +86,7 @@ const JudgingPage = () => {
           <TeamGrid
             teams={teams}
             selectedTeamId={selectedTeamId ?? teams[0].teamId}
-            onSelect={setSelectedTeamId}
+            onSelect={handleSelectTeam}
             onReorder={reorderTeams}
           />
         )}

--- a/src/widgets/judging/ui/TeamGrid/__tests__/TeamGrid.test.tsx
+++ b/src/widgets/judging/ui/TeamGrid/__tests__/TeamGrid.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TeamGrid from "../index";
+import { Score } from "@/entities/judging/model/score";
+
+const makeScore = (teamId: number, teamName: string): Score => ({
+  judgementId: null,
+  teamId,
+  teamName,
+  completenessExpressionScore: 0,
+  creativityCompositionScore: 0,
+  stagePerformanceTeamworkScore: 0,
+  totalScore: 0,
+  isPerformed: false,
+  isJudged: false,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("TeamGrid - 렌더링", () => {
+  it("전달된 순서대로 팀 카드를 렌더링한다", () => {
+    const teams = [makeScore(1, "댄스팀"), makeScore(2, "밴드팀"), makeScore(3, "합창팀")];
+
+    render(
+      <TeamGrid teams={teams} selectedTeamId={1} onSelect={vi.fn()} onReorder={vi.fn()} />,
+    );
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.map(button => button.textContent)).toEqual([
+      expect.stringContaining("댄스팀"),
+      expect.stringContaining("밴드팀"),
+      expect.stringContaining("합창팀"),
+    ]);
+  });
+
+  it("선택된 팀 이름이 화면에 표시된다", () => {
+    const teams = [makeScore(1, "댄스팀"), makeScore(2, "밴드팀")];
+
+    render(
+      <TeamGrid teams={teams} selectedTeamId={2} onSelect={vi.fn()} onReorder={vi.fn()} />,
+    );
+
+    expect(screen.getByText("밴드팀")).toBeInTheDocument();
+  });
+});
+
+describe("TeamGrid - 카드 클릭", () => {
+  it("팀 카드를 클릭하면 onSelect가 해당 teamId와 함께 호출된다", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const teams = [makeScore(1, "댄스팀"), makeScore(2, "밴드팀")];
+
+    render(
+      <TeamGrid teams={teams} selectedTeamId={1} onSelect={onSelect} onReorder={vi.fn()} />,
+    );
+
+    await user.click(screen.getByText("밴드팀"));
+
+    expect(onSelect).toHaveBeenCalledWith(2);
+  });
+
+  it("카드 클릭 시 onReorder는 호출되지 않는다", async () => {
+    const user = userEvent.setup();
+    const onReorder = vi.fn();
+    const teams = [makeScore(1, "댄스팀"), makeScore(2, "밴드팀")];
+
+    render(
+      <TeamGrid teams={teams} selectedTeamId={1} onSelect={vi.fn()} onReorder={onReorder} />,
+    );
+
+    await user.click(screen.getByText("댄스팀"));
+
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+});

--- a/src/widgets/judging/ui/TeamGrid/index.tsx
+++ b/src/widgets/judging/ui/TeamGrid/index.tsx
@@ -1,5 +1,15 @@
 "use client";
 
+import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { SortableContext, arrayMove, rectSortingStrategy, useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { cn } from "@/shared/utils/cn";
 import { getScoreTotal, Score } from "@/entities/judging/model/score";
 
@@ -7,46 +17,87 @@ type TeamGridProps = {
   teams: Score[];
   selectedTeamId: number;
   onSelect: (teamId: number) => void;
+  onReorder: (orderedTeamIds: number[]) => void;
 };
 
-const TeamGrid = ({ teams, selectedTeamId, onSelect }: TeamGridProps) => {
+const TeamGrid = ({ teams, selectedTeamId, onSelect, onReorder }: TeamGridProps) => {
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = teams.findIndex(team => team.teamId === active.id);
+    const newIndex = teams.findIndex(team => team.teamId === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    onReorder(arrayMove(teams, oldIndex, newIndex).map(team => team.teamId));
+  };
+
   return (
-    <div className="grid grid-cols-6 tablet:grid-cols-4 mobile:grid-cols-3 gap-14 mobile:gap-8">
-      {teams.map(team => {
-        const isSelected = team.teamId === selectedTeamId;
-        const paddedId = String(team.teamId).padStart(2, "0");
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={teams.map(team => team.teamId)} strategy={rectSortingStrategy}>
+        <div className="grid grid-cols-6 tablet:grid-cols-4 mobile:grid-cols-3 gap-14 mobile:gap-8">
+          {teams.map((team, index) => (
+            <TeamCard
+              key={team.teamId}
+              team={team}
+              order={index + 1}
+              isSelected={team.teamId === selectedTeamId}
+              onSelect={onSelect}
+            />
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+};
 
-        return (
-          <button
-            key={team.teamId}
-            type="button"
-            onClick={() => onSelect(team.teamId)}
-            className={cn(
-              "relative overflow-hidden rounded-2xl p-16 mobile:p-12 text-left transition-colors",
-              "bg-gradient-to-br from-orange-50 to-white border",
-              isSelected ? "border-orange-500" : "border-orange-100 hover:border-orange-300",
-            )}
-          >
-            <span
-              className="absolute -bottom-8 -right-4 text-[48px] font-bold text-orange-200 leading-none select-none pointer-events-none"
-              aria-hidden="true"
-            >
-              {paddedId}
-            </span>
+type TeamCardProps = {
+  team: Score;
+  order: number;
+  isSelected: boolean;
+  onSelect: (teamId: number) => void;
+};
 
-            <div className="relative z-10 flex flex-col gap-8">
-              <span className="text-caption2b text-orange-400">{paddedId}</span>
-              <p className="text-caption1b text-black break-keep leading-snug line-clamp-1">
-                {team.teamName}
-              </p>
-              <span className={cn("text-body3b", team.isJudged ? "text-orange-500" : "text-gray-300")}>
-                {team.isJudged ? getScoreTotal(team) : "/"}
-              </span>
-            </div>
-          </button>
-        );
-      })}
-    </div>
+const TeamCard = ({ team, order, isSelected, onSelect }: TeamCardProps) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: team.teamId,
+  });
+  const paddedOrder = String(order).padStart(2, "0");
+
+  return (
+    <button
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      type="button"
+      onClick={() => onSelect(team.teamId)}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(
+        "relative overflow-hidden rounded-2xl p-16 mobile:p-12 text-left transition-colors touch-none",
+        "bg-gradient-to-br from-orange-50 to-white border",
+        isSelected ? "border-orange-500" : "border-orange-100 hover:border-orange-300",
+        isDragging && "z-10 shadow-lg",
+      )}
+    >
+      <span
+        className="absolute -bottom-8 -right-4 text-[48px] font-bold text-orange-200 leading-none select-none pointer-events-none"
+        aria-hidden="true"
+      >
+        {paddedOrder}
+      </span>
+
+      <div className="relative z-10 flex flex-col gap-8">
+        <span className="text-caption2b text-orange-400">{paddedOrder}</span>
+        <p className="text-caption1b text-black break-keep leading-snug line-clamp-1">
+          {team.teamName}
+        </p>
+        <span className={cn("text-body3b", team.isJudged ? "text-orange-500" : "text-gray-300")}>
+          {team.isJudged ? getScoreTotal(team) : "/"}
+        </span>
+      </div>
+    </button>
   );
 };
 

--- a/src/widgets/judging/ui/TeamGrid/index.tsx
+++ b/src/widgets/judging/ui/TeamGrid/index.tsx
@@ -3,7 +3,8 @@
 import {
   DndContext,
   DragEndEvent,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
   closestCenter,
   useSensor,
   useSensors,
@@ -21,7 +22,10 @@ type TeamGridProps = {
 };
 
 const TeamGrid = ({ teams, selectedTeamId, onSelect, onReorder }: TeamGridProps) => {
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } }),
+  );
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
@@ -75,7 +79,7 @@ const TeamCard = ({ team, order, isSelected, onSelect }: TeamCardProps) => {
       onClick={() => onSelect(team.teamId)}
       style={{ transform: CSS.Transform.toString(transform), transition }}
       className={cn(
-        "relative overflow-hidden rounded-2xl p-16 mobile:p-12 text-left transition-colors touch-none",
+        "relative overflow-hidden rounded-2xl p-16 mobile:p-12 text-left transition-colors touch-pan-y",
         "bg-gradient-to-br from-orange-50 to-white border",
         isSelected ? "border-orange-500" : "border-orange-100 hover:border-orange-300",
         isDragging && "z-10 shadow-lg",

--- a/src/widgets/judging/ui/TeamGrid/index.tsx
+++ b/src/widgets/judging/ui/TeamGrid/index.tsx
@@ -94,7 +94,7 @@ const TeamCard = ({ team, order, isSelected, onSelect }: TeamCardProps) => {
           {team.teamName}
         </p>
         <span className={cn("text-body3b", team.isJudged ? "text-orange-500" : "text-gray-300")}>
-          {team.isJudged ? getScoreTotal(team) : "/"}
+          {team.isJudged ? getScoreTotal(team) : 0}
         </span>
       </div>
     </button>


### PR DESCRIPTION
## 💡 PR 요약

> 해당 PR의 변경사항, 해당 이슈 등에 대한 간략한 설명을 작성해주세요.

- 심사(evaluation) 페이지 팀 카드에 드래그 앤 드롭으로 공연 순서를 바꾸는 기능 추가
- 점수 입력 중 저장 버튼을 안 누르고 다른 팀으로 넘어가면 자동으로 저장하도록 개선
- 엑셀 심사 결과 다운로드 시작/실패를 토스트로 안내하도록 개선
- 엑셀 다운로드 파일명이 깨지던 버그 수정

## 📋 작업 내용

- 백엔드에 이미 존재하던 팀 공연 순서 API(`GET /team`, `PATCH /team/order`)에 대응하는 프론트 계층(`entities/team`)을 신규 작성
- `@dnd-kit`을 도입해 `/admin/evaluation` 심사 페이지의 팀 카드 그리드(`TeamGrid`)에 마우스/터치 드래그 앤 드롭 재정렬 기능 추가
  - 8px 미만 움직임은 클릭(팀 선택)으로 처리해 기존 "카드 클릭 → 심사 대상 선택" 동작과 공존
  - 드래그로 순서를 바꾸면 낙관적 업데이트로 즉시 반영, 실패 시 자동 롤백 + 에러 토스트
  - 더 이상 쓰지 않는 `team_id` 오름차순 임시 정렬 로직(`getVisibleTeams`) 제거, 실제 `performOrder` 기준 정렬로 대체
- 점수 입력 중 저장을 누르지 않고 다른 팀 카드를 클릭하면, 이전 팀에 저장 안 된 수정사항이 있을 때 자동으로 저장 후 전환하도록 처리 (`useTeamScores`에 `hasUnsavedEdit` 추가)
- 엑셀 심사 결과 다운로드 버튼을 단순 링크에서 fetch 기반으로 변경해 다운로드 시작 시 성공 토스트, 실패 시 서버 메시지를 담은 에러 토스트가 뜨도록 개선
- 미채점 팀 카드의 점수 표시를 "/" 대신 "0"으로 변경
- 엑셀 다운로드 파일명이 깨지는 버그 수정: 백엔드가 Content-Disposition의 filename을 RFC 2047 MIME 인코디드 워드(`=?UTF-8?Q?...?=`)로 내려주는데, fetch 기반 다운로드로 바꾸며 이를 디코딩하지 않고 그대로 사용해 파일명이 깨졌던 문제를 RFC 2047/RFC 5987 디코딩 로직 추가로 해결
- 관련 API/훅/컴포넌트 단위 테스트 추가 (신규 24개), 전체 테스트 298개 통과, `npm run build`/`npm run lint` 검증 완료

## 🤝 리뷰 시 참고사항

- 드래그 앤 드롭을 위해 `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` 의존성이 추가됐습니다.
- 엑셀 파일명 디코딩 로직은 실제 운영 서버 응답(RFC 2047 Q-encoding)을 기준으로 작성했습니다. 백엔드가 향후 filename 인코딩 방식을 바꾸면 함께 확인이 필요합니다.
- 팀 순서 변경(`PATCH /team/order`)은 매번 전체 팀 목록의 순서를 1부터 재계산해서 전송합니다. 팀 수가 많아지면 이 방식이 적절한지 백엔드와 확인이 필요할 수 있습니다.
