### PR TITLE
fix: 좌석 예매 페이지 버그 수정 및 어드민 좌석 밴 기능 추가

### DIFF
--- a/src/entities/booking/lib/useSeatState.ts
+++ b/src/entities/booking/lib/useSeatState.ts
@@ -103,28 +103,20 @@ export function useAllSectionsSeatState() {
   });
 }
 
-export function updateSeatInCache(
+export function applySeatChange(
   queryClient: ReturnType<typeof useQueryClient>,
-  seatChangeEvent: SeatChangeEvent,
+  event: SeatChangeEvent,
 ): void {
-  const {
-    seat_section: section,
-    seat_row: seatRow,
-    seat_number: seatNumber,
-    is_available: isAvailable,
-  } = seatChangeEvent;
+  const status = event.is_available ? SEAT_STATUS.AVAILABLE : SEAT_STATUS.OCCUPIED;
+  const matches = (seat: Seat) =>
+    seat.section === event.seat_section &&
+    seat.row === event.seat_row &&
+    seat.seatNumber === event.seat_number.toString();
 
-  queryClient.setQueryData<Seat[]>(seatQueryKeys.seatState(section), oldData => {
-    if (!oldData) return oldData;
-
-    return oldData.map(seat => {
-      if (seat.seatNumber === seatNumber.toString() && seat.row === seatRow) {
-        return {
-          ...seat,
-          status: isAvailable ? SEAT_STATUS.AVAILABLE : SEAT_STATUS.OCCUPIED,
-        };
-      }
-      return seat;
-    });
-  });
+  queryClient.setQueryData<Seat[]>(seatQueryKeys.seatState(event.seat_section), oldData =>
+    oldData?.map(seat => (matches(seat) ? { ...seat, status } : seat)),
+  );
+  queryClient.setQueryData<Seat[]>(["allSectionsSeatState"], oldData =>
+    oldData?.map(seat => (matches(seat) ? { ...seat, status } : seat)),
+  );
 }

--- a/src/entities/booking/model/__tests__/types.test.ts
+++ b/src/entities/booking/model/__tests__/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { getSectionFromLabel, SECTIONS } from "../types"
+import { getSectionFromLabel, formatSeatLabel, SECTIONS } from "../types"
 
 describe("getSectionFromLabel - 섹션 라벨 변환", () => {
   it("A를 RED로 변환한다", () => {
@@ -31,5 +31,15 @@ describe("getSectionFromLabel - 섹션 라벨 변환", () => {
     validLabels.forEach(label => {
       expect(SECTIONS).toContain(getSectionFromLabel(label))
     })
+  })
+})
+
+describe("formatSeatLabel - 좌석 라벨 표기", () => {
+  it("일반 섹션은 섹션라벨+행+번호로 표기한다", () => {
+    expect(formatSeatLabel({ section: "RED", row: "A", seatNumber: "1" })).toBe("AA1")
+  })
+
+  it("휠체어석은 행을 생략해 WW1이 아닌 W1로 표기한다", () => {
+    expect(formatSeatLabel({ section: "WHEELCHAIR", row: "W", seatNumber: "1" })).toBe("W1")
   })
 })

--- a/src/entities/booking/model/types.ts
+++ b/src/entities/booking/model/types.ts
@@ -23,6 +23,16 @@ export const SECTION_LABELS: Record<Section, string> = {
 
 export const getSectionLabel = (section: Section): string => SECTION_LABELS[section];
 
+// 휠체어석은 행 라벨("W")이 섹션 라벨과 같아 그대로 이으면 "WW1"로 중복 표기됨
+export const formatSeatLabel = (seat: {
+  section: Section;
+  row: string;
+  seatNumber: string;
+}): string =>
+  seat.section === "WHEELCHAIR"
+    ? `${SECTION_LABELS[seat.section]}${seat.seatNumber}`
+    : `${SECTION_LABELS[seat.section]}${seat.row}${seat.seatNumber}`;
+
 export const SEAT_STATUS = {
   OCCUPIED: "occupied",
   AVAILABLE: "available",

--- a/src/entities/booking/ui/BookingInfoDisplay/index.tsx
+++ b/src/entities/booking/ui/BookingInfoDisplay/index.tsx
@@ -2,7 +2,7 @@
 
 import { memo, ReactNode } from "react";
 import { cn } from "@/shared/utils/cn";
-import { Seat, getSectionLabel } from "../../model/types";
+import { Seat, formatSeatLabel } from "../../model/types";
 
 interface InfoRowProps {
   label: string;
@@ -34,11 +34,9 @@ export const BookingInfoDisplay = memo<BookingInfoDisplayProps>(
         <div className="space-y-8">
           <InfoRow className="text-main-600 text-body1b" label="예약좌석">
             {mySeats && mySeats.length > 0
-              ? mySeats
-                  .map(seat => `${getSectionLabel(seat.section)}${seat.row}${seat.seatNumber}`)
-                  .join(", ")
+              ? mySeats.map(formatSeatLabel).join(", ")
               : mySeat
-                ? `${getSectionLabel(mySeat.section)}${mySeat.row}${mySeat.seatNumber}`
+                ? formatSeatLabel(mySeat)
                 : "좌석이 없습니다"}
           </InfoRow>
           <InfoRow label="관람일자">2025.9.27.(토)</InfoRow>

--- a/src/entities/booking/ui/SeatGrid/index.tsx
+++ b/src/entities/booking/ui/SeatGrid/index.tsx
@@ -119,7 +119,7 @@ export const SeatGrid = memo<SeatGridProps>(
     );
 
     const renderSingleSectionGrid = () => (
-      <div className="min-w-max flex flex-col justify-start">
+      <div className="w-max mx-auto flex flex-col justify-start">
         {seatGrid.map((row, rowIndex) => (
           <div key={rowIndex} className="flex items-center gap-4 mb-4">
             {row.map(({ seat, key }) => (
@@ -214,7 +214,7 @@ export const SeatGrid = memo<SeatGridProps>(
     };
 
     const renderAllSectionsGrid = () => (
-      <div className="flex flex-col gap-8 items-center">
+      <div className="w-max mx-auto flex flex-col gap-8 items-center">
         {allSectionsGrid.map((sectionsRow, rowIndex) => (
           <div key={rowIndex} className="flex gap-8 items-end">
             {sectionsRow.map(section => (
@@ -226,7 +226,7 @@ export const SeatGrid = memo<SeatGridProps>(
     );
 
     const getGridContainerStyles = () => {
-      return "relative bg-gray-800 rounded-lg w-full flex justify-center p-3 overflow-x-auto";
+      return "relative bg-gray-800 rounded-lg w-full max-h-80 p-3 overflow-auto";
     };
 
     return (

--- a/src/entities/booking/ui/SeatGrid/index.tsx
+++ b/src/entities/booking/ui/SeatGrid/index.tsx
@@ -226,7 +226,7 @@ export const SeatGrid = memo<SeatGridProps>(
     );
 
     const getGridContainerStyles = () => {
-      return "relative bg-gray-800 rounded-lg w-full max-h-80 p-3 overflow-auto";
+      return "relative bg-gray-800 rounded-lg w-full p-3 overflow-x-auto";
     };
 
     return (

--- a/src/entities/booking/ui/SeatGrid/index.tsx
+++ b/src/entities/booking/ui/SeatGrid/index.tsx
@@ -22,6 +22,7 @@ export interface SeatGridProps {
   isPerformerMode?: boolean;
   myAllSeats?: Seat[];
   selectedSeatsForCancel?: Set<string>;
+  allowOccupiedSelect?: boolean;
 }
 
 export const SeatGrid = memo<SeatGridProps>(
@@ -36,6 +37,7 @@ export const SeatGrid = memo<SeatGridProps>(
     isPerformerMode = false,
     myAllSeats,
     selectedSeatsForCancel,
+    allowOccupiedSelect = false,
   }) => {
     const queryClient = useQueryClient();
 
@@ -127,6 +129,7 @@ export const SeatGrid = memo<SeatGridProps>(
                     seat={seat}
                     isSelected={getSeatSelectedState(seat)}
                     onSelect={mySeat ? NOOP_SEAT_SELECT : handleSeatSelect}
+                    allowOccupiedSelect={allowOccupiedSelect}
                   />
                 ) : (
                   <div className="w-5 h-5" />

--- a/src/entities/booking/ui/SeatItem/index.tsx
+++ b/src/entities/booking/ui/SeatItem/index.tsx
@@ -9,45 +9,55 @@ export interface SeatItemProps {
   isSelected: boolean;
   onSelect: (seat: Seat) => void;
   className?: string;
+  allowOccupiedSelect?: boolean;
 }
 
-export const SeatItem = memo<SeatItemProps>(({ seat, isSelected, onSelect, className }) => {
-  const handleClick = useCallback(() => {
-    if (seat.status === SEAT_STATUS.OCCUPIED) return;
-    onSelect(seat);
-  }, [seat, onSelect]);
+export const SeatItem = memo<SeatItemProps>(
+  ({ seat, isSelected, onSelect, className, allowOccupiedSelect = false }) => {
+    const isOccupied = seat.status === SEAT_STATUS.OCCUPIED;
+    const isDisabled = isOccupied && !allowOccupiedSelect;
 
-  const getSeatStyles = () => {
-    const baseStyles =
-      "w-5 h-5 text-xs font-medium transition-all duration-200 flex items-center justify-center";
+    const handleClick = useCallback(() => {
+      if (seat.status === SEAT_STATUS.OCCUPIED && !allowOccupiedSelect) return;
+      onSelect(seat);
+    }, [seat, onSelect, allowOccupiedSelect]);
 
-    if (isSelected) {
-      return cn(baseStyles, "bg-orange-500 text-white shadow-lg scale-110 cursor-pointer");
-    }
+    const getSeatStyles = () => {
+      const baseStyles =
+        "w-5 h-5 text-xs font-medium transition-all duration-200 flex items-center justify-center";
 
-    if (seat.status === SEAT_STATUS.OCCUPIED) {
-      return cn(baseStyles, "bg-gray-400 text-gray-600 cursor-not-allowed");
-    }
+      if (isSelected) {
+        return cn(baseStyles, "bg-orange-500 text-white shadow-lg scale-110 cursor-pointer");
+      }
 
-    return cn(baseStyles, "bg-white text-gray-700 cursor-pointer");
-  };
+      if (isOccupied) {
+        return cn(
+          baseStyles,
+          "bg-gray-400 text-gray-600",
+          isDisabled ? "cursor-not-allowed" : "cursor-pointer",
+        );
+      }
 
-  const getSeatNumber = () => {
-    return seat.seatNumber;
-  };
+      return cn(baseStyles, "bg-white text-gray-700 cursor-pointer");
+    };
 
-  return (
-    <button
-      className={cn(getSeatStyles(), className)}
-      onClick={handleClick}
-      disabled={seat.status === SEAT_STATUS.OCCUPIED}
-      title={`좌석 ${seat.seatNumber} - ${seat.status === SEAT_STATUS.OCCUPIED ? "선택불가" : "선택가능"}`}
-      aria-label={`좌석 ${seat.seatNumber}`}
-    >
-      {getSeatNumber()}
-    </button>
-  );
-});
+    const getSeatNumber = () => {
+      return seat.seatNumber;
+    };
+
+    return (
+      <button
+        className={cn(getSeatStyles(), className)}
+        onClick={handleClick}
+        disabled={isDisabled}
+        title={`좌석 ${seat.seatNumber} - ${isDisabled ? "선택불가" : "선택가능"}`}
+        aria-label={`좌석 ${seat.seatNumber}`}
+      >
+        {getSeatNumber()}
+      </button>
+    );
+  },
+);
 
 SeatItem.displayName = "SeatItem";
 

--- a/src/entities/booking/ui/SelectedSeatDisplay/index.tsx
+++ b/src/entities/booking/ui/SelectedSeatDisplay/index.tsx
@@ -74,7 +74,7 @@ export const SelectedSeatDisplay = memo<SelectedSeatDisplayProps>(
     }
 
     return (
-      <div className={cn("h-24 p-4 rounded-lg border border-orange-200", className)}>
+      <div className={cn("relative min-h-24 p-4 rounded-lg border border-orange-200 bg-white", className)}>
         <div className="flex items-center justify-between h-full">
           <div className="flex flex-col justify-center gap-1">
             <div>

--- a/src/entities/booking/ui/SelectedSeatDisplay/index.tsx
+++ b/src/entities/booking/ui/SelectedSeatDisplay/index.tsx
@@ -9,7 +9,7 @@ import {
   Section,
   SEAT_STATUS,
   Seat,
-  getSectionLabel,
+  formatSeatLabel,
 } from "../../model/types";
 import { useAllSectionsSeatState } from "../../lib/useSeatState";
 
@@ -44,11 +44,9 @@ export const SelectedSeatDisplay = memo<SelectedSeatDisplayProps>(
     const section = selectedSeat?.section || selectedSection;
     const seatPosition =
       selectedSeats && selectedSeats.length > 0
-        ? selectedSeats
-            .map(seat => `${getSectionLabel(seat.section)}${seat.row}${seat.seatNumber}`)
-            .join(", ")
+        ? selectedSeats.map(formatSeatLabel).join(", ")
         : selectedSeat
-          ? `${getSectionLabel(selectedSeat.section)}${selectedSeat.seat.row}${selectedSeat.seat.seatNumber}`
+          ? formatSeatLabel(selectedSeat.seat)
           : null;
 
     let availableSeatsCount = 0;

--- a/src/views/booking/ui/BookingPage/index.tsx
+++ b/src/views/booking/ui/BookingPage/index.tsx
@@ -7,10 +7,12 @@ import Button from "@/shared/ui/Button";
 import BackHeader from "@/shared/ui/BackHeader";
 import { useSeatSelection } from "@/widgets/booking/lib/useSeatSelection";
 import { usePerformerSeatSelection } from "@/widgets/booking/lib/usePerformerSeatSelection";
-import { SectionType, Seat } from "@/entities/booking/model/types";
+import { SectionType, Seat, SeatChangeEvent, SEAT_STATUS } from "@/entities/booking/model/types";
 import { useSeatBooking, useMultipleSeatBooking } from "@/widgets/booking/lib/useSeatBooking";
 import { useAdminSeatBan } from "@/widgets/booking/lib/useAdminSeatBan";
-import { SEAT_STATUS } from "@/entities/booking/model/types";
+import { useSeatChangeSSE } from "@/entities/booking/lib/useSeatChangeSSE";
+import { applySeatChange } from "@/entities/booking/lib/useSeatState";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import { getTokenFromCookie } from "@/shared/utils/auth";
@@ -52,6 +54,21 @@ const BookingPage = () => {
     const role = getTokenFromCookie("role");
     setUserRole(role);
   }, []);
+
+  const queryClient = useQueryClient();
+
+  // 백엔드가 유저당 SSE 연결을 1개만 유지하므로 페이지에서 연결 하나만 열고 공용 처리
+  const handleSeatChange = useCallback(
+    (event: SeatChangeEvent) => {
+      applySeatChange(queryClient, event);
+      if (!event.is_available && isPerformer) {
+        removeOccupiedSeat(event.seat_section, event.seat_row, event.seat_number.toString());
+      }
+    },
+    [queryClient, isPerformer, removeOccupiedSeat],
+  );
+
+  useSeatChangeSSE({ onSeatChange: handleSeatChange });
 
   const handleSectionSelect = useCallback(
     (section: SectionType) => {
@@ -194,7 +211,6 @@ const BookingPage = () => {
             isSeatSelected={isPerformer ? isSeatSelected : undefined}
             isPerformerMode={isPerformer}
             myBookedSeats={myBookedSeats}
-            removeOccupiedSeat={isPerformer ? removeOccupiedSeat : undefined}
             allowOccupiedSelect={isAdmin}
           />
         </div>

--- a/src/views/booking/ui/BookingPage/index.tsx
+++ b/src/views/booking/ui/BookingPage/index.tsx
@@ -9,6 +9,8 @@ import { useSeatSelection } from "@/widgets/booking/lib/useSeatSelection";
 import { usePerformerSeatSelection } from "@/widgets/booking/lib/usePerformerSeatSelection";
 import { SectionType, Seat } from "@/entities/booking/model/types";
 import { useSeatBooking, useMultipleSeatBooking } from "@/widgets/booking/lib/useSeatBooking";
+import { useAdminSeatBan } from "@/widgets/booking/lib/useAdminSeatBan";
+import { SEAT_STATUS } from "@/entities/booking/model/types";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import { getTokenFromCookie } from "@/shared/utils/auth";
@@ -19,6 +21,9 @@ const BookingPage = () => {
   const router = useRouter();
   const { seats: myBookedSeats } = useMyBookedSeats();
 
+  const isAdmin = userRole === "ADMIN";
+  const isPerformer = userRole === "PERFORMER";
+
   const {
     selectedSection,
     selectedSeat,
@@ -26,7 +31,7 @@ const BookingPage = () => {
     setSelectedSection,
     selectSeat,
     isComplete,
-  } = useSeatSelection();
+  } = useSeatSelection({ holdOnSelect: !isAdmin, allowOccupied: isAdmin });
 
   const {
     selectedSection: performerSelectedSection,
@@ -41,13 +46,13 @@ const BookingPage = () => {
 
   const seatBookingMutation = useSeatBooking();
   const multipleSeatBookingMutation = useMultipleSeatBooking();
+  const { ban: seatBanMutation, unban: seatUnbanMutation } = useAdminSeatBan();
 
   useEffect(() => {
     const role = getTokenFromCookie("role");
     setUserRole(role);
   }, []);
 
-  const isPerformer = userRole === "PERFORMER";
   const handleSectionSelect = useCallback(
     (section: SectionType) => {
       if (isPerformer) {
@@ -73,6 +78,17 @@ const BookingPage = () => {
   );
 
   const handleBookingClick = useCallback(() => {
+    if (isAdmin) {
+      if (!isComplete || !selectedSeat) return;
+
+      const seat = selectedSeat;
+      const mutation = seat.status === SEAT_STATUS.OCCUPIED ? seatUnbanMutation : seatBanMutation;
+      mutation.mutate(seat, {
+        onSuccess: () => selectSeat(seat),
+      });
+      return;
+    }
+
     if (isPerformer) {
       if (canBook && selectedSeats.length > 0) {
         multipleSeatBookingMutation.mutate(selectedSeats, {
@@ -97,17 +113,35 @@ const BookingPage = () => {
       }
     }
   }, [
+    isAdmin,
     isPerformer,
     canBook,
     selectedSeats,
     multipleSeatBookingMutation,
     isComplete,
+    selectedSeat,
     selectedSeatInfo,
     seatBookingMutation,
+    seatBanMutation,
+    seatUnbanMutation,
+    selectSeat,
     router,
   ]);
 
   const getButtonText = () => {
+    if (isAdmin) {
+      if (seatBanMutation.isPending || seatUnbanMutation.isPending) {
+        return "처리 중...";
+      }
+      if (!selectedSection) {
+        return "구역을 선택해주세요";
+      }
+      if (!selectedSeat) {
+        return "좌석을 선택해주세요";
+      }
+      return selectedSeat.status === SEAT_STATUS.OCCUPIED ? "좌석 밴 해제하기" : "좌석 밴하기";
+    }
+
     if (isPerformer) {
       if (multipleSeatBookingMutation.isPending) {
         return "예매 중...";
@@ -161,6 +195,7 @@ const BookingPage = () => {
             isPerformerMode={isPerformer}
             myBookedSeats={myBookedSeats}
             removeOccupiedSeat={isPerformer ? removeOccupiedSeat : undefined}
+            allowOccupiedSelect={isAdmin}
           />
         </div>
         <Button

--- a/src/views/booking/ui/BookingPage/index.tsx
+++ b/src/views/booking/ui/BookingPage/index.tsx
@@ -214,7 +214,7 @@ const BookingPage = () => {
             allowOccupiedSelect={isAdmin}
           />
         </div>
-        <div className="fixed bottom-[48px] inset-x-0 px-4">
+        <div className="fixed bottom-4 inset-x-0 px-4">
           <div className="w-full max-w-[448px] mx-auto">
             <Button
               className="w-full h-[48px]"

--- a/src/views/booking/ui/BookingPage/index.tsx
+++ b/src/views/booking/ui/BookingPage/index.tsx
@@ -98,9 +98,16 @@ const BookingPage = () => {
     if (!isComplete || !selectedSeat) return;
 
     const seat = selectedSeat;
-    const mutation = seat.status === SEAT_STATUS.OCCUPIED ? seatUnbanMutation : seatBanMutation;
+    const isOccupied = seat.status === SEAT_STATUS.OCCUPIED;
+    const mutation = isOccupied ? seatUnbanMutation : seatBanMutation;
     mutation.mutate(seat, {
-      onSuccess: () => selectSeat(seat),
+      onSuccess: () => {
+        // 선택을 해제하지 않고 바뀐 상태로 유지 — 밴 해제 직후 바로 예매 가능
+        selectSeat({
+          ...seat,
+          status: isOccupied ? SEAT_STATUS.AVAILABLE : SEAT_STATUS.OCCUPIED,
+        });
+      },
     });
   }, [isComplete, selectedSeat, seatBanMutation, seatUnbanMutation, selectSeat]);
 

--- a/src/views/booking/ui/BookingPage/index.tsx
+++ b/src/views/booking/ui/BookingPage/index.tsx
@@ -33,7 +33,7 @@ const BookingPage = () => {
     setSelectedSection,
     selectSeat,
     isComplete,
-  } = useSeatSelection({ holdOnSelect: !isAdmin, allowOccupied: isAdmin });
+  } = useSeatSelection({ allowOccupied: isAdmin });
 
   const {
     selectedSection: performerSelectedSection,

--- a/src/views/booking/ui/BookingPage/index.tsx
+++ b/src/views/booking/ui/BookingPage/index.tsx
@@ -207,8 +207,8 @@ const BookingPage = () => {
             allowOccupiedSelect={isAdmin}
           />
         </div>
-        <div className="fixed bottom-4 inset-x-0 px-4">
-          <div className={`w-full max-w-[448px] mx-auto ${isAdmin ? "flex gap-2" : ""}`}>
+        <div className="pb-4">
+          <div className={`w-full ${isAdmin ? "flex gap-2" : ""}`}>
             <Button
               className={`h-[48px] ${isAdmin ? "flex-1" : "w-full"}`}
               onClick={handleBookingClick}

--- a/src/views/booking/ui/BookingPage/index.tsx
+++ b/src/views/booking/ui/BookingPage/index.tsx
@@ -198,13 +198,17 @@ const BookingPage = () => {
             allowOccupiedSelect={isAdmin}
           />
         </div>
-        <Button
-          className="fixed bottom-[48px] left-1/2 -translate-x-1/2 w-[calc(100%-32px)] max-w-[448px] h-[48px]"
-          onClick={handleBookingClick}
-          disabled={isPerformer ? !canBook || maxSelectableSeats === 0 : !isComplete}
-        >
-          {getButtonText()}
-        </Button>
+        <div className="fixed bottom-[48px] inset-x-0 px-4">
+          <div className="w-full max-w-[448px] mx-auto">
+            <Button
+              className="w-full h-[48px]"
+              onClick={handleBookingClick}
+              disabled={isPerformer ? !canBook || maxSelectableSeats === 0 : !isComplete}
+            >
+              {getButtonText()}
+            </Button>
+          </div>
+        </div>
       </div>
     </main>
   );

--- a/src/views/booking/ui/BookingPage/index.tsx
+++ b/src/views/booking/ui/BookingPage/index.tsx
@@ -94,18 +94,17 @@ const BookingPage = () => {
     [isPerformer, selectPerformerSeat, selectSeat],
   );
 
+  const handleBanClick = useCallback(() => {
+    if (!isComplete || !selectedSeat) return;
+
+    const seat = selectedSeat;
+    const mutation = seat.status === SEAT_STATUS.OCCUPIED ? seatUnbanMutation : seatBanMutation;
+    mutation.mutate(seat, {
+      onSuccess: () => selectSeat(seat),
+    });
+  }, [isComplete, selectedSeat, seatBanMutation, seatUnbanMutation, selectSeat]);
+
   const handleBookingClick = useCallback(() => {
-    if (isAdmin) {
-      if (!isComplete || !selectedSeat) return;
-
-      const seat = selectedSeat;
-      const mutation = seat.status === SEAT_STATUS.OCCUPIED ? seatUnbanMutation : seatBanMutation;
-      mutation.mutate(seat, {
-        onSuccess: () => selectSeat(seat),
-      });
-      return;
-    }
-
     if (isPerformer) {
       if (canBook && selectedSeats.length > 0) {
         multipleSeatBookingMutation.mutate(selectedSeats, {
@@ -130,35 +129,29 @@ const BookingPage = () => {
       }
     }
   }, [
-    isAdmin,
     isPerformer,
     canBook,
     selectedSeats,
     multipleSeatBookingMutation,
     isComplete,
-    selectedSeat,
     selectedSeatInfo,
     seatBookingMutation,
-    seatBanMutation,
-    seatUnbanMutation,
-    selectSeat,
     router,
   ]);
 
-  const getButtonText = () => {
-    if (isAdmin) {
-      if (seatBanMutation.isPending || seatUnbanMutation.isPending) {
-        return "처리 중...";
-      }
-      if (!selectedSection) {
-        return "구역을 선택해주세요";
-      }
-      if (!selectedSeat) {
-        return "좌석을 선택해주세요";
-      }
-      return selectedSeat.status === SEAT_STATUS.OCCUPIED ? "좌석 밴 해제하기" : "좌석 밴하기";
-    }
+  const isSelectedSeatOccupied = selectedSeat?.status === SEAT_STATUS.OCCUPIED;
 
+  const getBanButtonText = () => {
+    if (seatBanMutation.isPending || seatUnbanMutation.isPending) {
+      return "처리 중...";
+    }
+    if (!selectedSeat) {
+      return "좌석을 선택해주세요";
+    }
+    return isSelectedSeatOccupied ? "밴 해제하기" : "밴하기";
+  };
+
+  const getButtonText = () => {
     if (isPerformer) {
       if (multipleSeatBookingMutation.isPending) {
         return "예매 중...";
@@ -215,14 +208,23 @@ const BookingPage = () => {
           />
         </div>
         <div className="fixed bottom-4 inset-x-0 px-4">
-          <div className="w-full max-w-[448px] mx-auto">
+          <div className={`w-full max-w-[448px] mx-auto ${isAdmin ? "flex gap-2" : ""}`}>
             <Button
-              className="w-full h-[48px]"
+              className={`h-[48px] ${isAdmin ? "flex-1" : "w-full"}`}
               onClick={handleBookingClick}
-              disabled={isPerformer ? !canBook || maxSelectableSeats === 0 : !isComplete}
+              disabled={
+                isPerformer
+                  ? !canBook || maxSelectableSeats === 0
+                  : !isComplete || isSelectedSeatOccupied
+              }
             >
               {getButtonText()}
             </Button>
+            {isAdmin && (
+              <Button className="flex-1 h-[48px]" onClick={handleBanClick} disabled={!isComplete}>
+                {getBanButtonText()}
+              </Button>
+            )}
           </div>
         </div>
       </div>

--- a/src/views/booking/ui/MyBookingPage/index.tsx
+++ b/src/views/booking/ui/MyBookingPage/index.tsx
@@ -13,7 +13,7 @@ import { cancelSeatBooking } from "@/entities/booking/api/cancelSeatBooking";
 import { cancelPerformerSeats } from "@/entities/booking/api/cancelPerformerSeats";
 import { useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
-import { Seat, getSectionLabel } from "@/entities/booking/model/types";
+import { Seat, formatSeatLabel } from "@/entities/booking/model/types";
 
 const MyBookingPage = () => {
   const { seats, isMultiple, isLoading, error } = useMyBookedSeats();
@@ -51,9 +51,7 @@ const MyBookingPage = () => {
 
       try {
         await cancelPerformerSeats([seat]);
-        toast.success(
-          `${getSectionLabel(seat.section)}${seat.row}${seat.seatNumber} 좌석 예매가 취소되었습니다.`,
-        );
+        toast.success(`${formatSeatLabel(seat)} 좌석 예매가 취소되었습니다.`);
 
         queryClient.invalidateQueries({ queryKey: ["mySeat"] });
         queryClient.invalidateQueries({ queryKey: ["mySeats"] });
@@ -148,9 +146,7 @@ const MyBookingPage = () => {
                   onClick={() => handleIndividualSeatCancel(seat)}
                   disabled={seats.length === 0}
                 >
-                  {getSectionLabel(seat.section)}
-                  {seat.row}
-                  {seat.seatNumber} 취소
+                  {formatSeatLabel(seat)} 취소
                 </Button>
               ))}
             </div>

--- a/src/views/lottery/ui/LotteryView.tsx
+++ b/src/views/lottery/ui/LotteryView.tsx
@@ -6,7 +6,7 @@ import Button from "@/shared/ui/Button";
 import { LotterySeatGrid } from "@/entities/booking/ui/LotterySeatGrid";
 import { useLotteryAnimation } from "@/entities/booking/lib/useLotteryAnimation";
 import { getLotteryConfig, convertToSeats } from "@/entities/booking/model/lotterySeats";
-import { Seat, SECTIONS, getSectionLabel } from "@/entities/booking/model/types";
+import { Seat, SECTIONS, formatSeatLabel } from "@/entities/booking/model/types";
 import { getSeatLayout } from "@/entities/booking/model/seatLayouts";
 import { cn } from "@/shared/utils/cn";
 import { redirect } from "next/navigation";
@@ -105,7 +105,7 @@ const LotteryView = () => {
         if (allSeats.length === 0) return;
         const r = Math.floor(Math.random() * allSeats.length);
         const s = allSeats[r];
-        setSlotLabel(`${getSectionLabel(s.section)}${s.row}${s.seatNumber}`);
+        setSlotLabel(formatSeatLabel(s));
       }, 60);
     } else {
       cleanupSlotInterval();
@@ -198,9 +198,7 @@ const LotteryView = () => {
                     key={`target-${currentTarget.section}-${currentTarget.row}-${currentTarget.seatNumber}`}
                     className="inline-flex items-center justify-center rounded-full border border-purple-200 text-purple-100 px-1 py-1 text-body2b font-semibold min-w-[60px] h-8 my-8 animate-pulse"
                   >
-                    {isAnimating && slotLabel
-                      ? slotLabel
-                      : `${getSectionLabel(currentTarget.section)}${currentTarget.row}${currentTarget.seatNumber}`}
+                    {isAnimating && slotLabel ? slotLabel : formatSeatLabel(currentTarget)}
                   </span>
                 )}
             </div>

--- a/src/widgets/booking/lib/__tests__/useSeatSelection.test.ts
+++ b/src/widgets/booking/lib/__tests__/useSeatSelection.test.ts
@@ -194,6 +194,15 @@ describe("useSeatSelection - 어드민 옵션", () => {
 
     expect(result.current.selectedSeat).toEqual(seat)
   })
+
+  it("같은 좌석이라도 상태가 바뀌면 선택 해제 대신 상태만 갱신된다", () => {
+    const { result } = renderHook(() => useSeatSelection({ allowOccupied: true }))
+
+    act(() => { result.current.selectSeat(makeSeat("1", SEAT_STATUS.OCCUPIED)) })
+    act(() => { result.current.selectSeat(makeSeat("1", SEAT_STATUS.AVAILABLE)) })
+
+    expect(result.current.selectedSeat).toEqual(makeSeat("1", SEAT_STATUS.AVAILABLE))
+  })
 })
 
 describe("useSeatSelection - isComplete", () => {

--- a/src/widgets/booking/lib/__tests__/useSeatSelection.test.ts
+++ b/src/widgets/booking/lib/__tests__/useSeatSelection.test.ts
@@ -276,6 +276,39 @@ describe("useSeatSelection - 임시 저장(좌석 홀드)", () => {
   })
 })
 
+describe("useSeatSelection - 어드민 옵션", () => {
+  it("holdOnSelect가 false면 좌석 선택 시 임시 저장 API를 호출하지 않는다", () => {
+    const { result } = renderHook(() => useSeatSelection({ holdOnSelect: false }))
+    const seat = makeSeat("1")
+
+    act(() => { result.current.selectSeat(seat) })
+
+    expect(banSeat).not.toHaveBeenCalled()
+    expect(result.current.selectedSeat).toEqual(seat)
+  })
+
+  it("holdOnSelect가 false면 선택 해제·교체 시에도 해제 API를 호출하지 않는다", () => {
+    const { result } = renderHook(() => useSeatSelection({ holdOnSelect: false }))
+
+    act(() => { result.current.selectSeat(makeSeat("1")) })
+    act(() => { result.current.selectSeat(makeSeat("2")) })
+    act(() => { result.current.setSelectedSection("YELLOW") })
+
+    expect(cancelSeatBan).not.toHaveBeenCalled()
+  })
+
+  it("allowOccupied가 true면 OCCUPIED 좌석도 선택할 수 있다", () => {
+    const { result } = renderHook(() =>
+      useSeatSelection({ holdOnSelect: false, allowOccupied: true }),
+    )
+    const seat = makeSeat("1", SEAT_STATUS.OCCUPIED)
+
+    act(() => { result.current.selectSeat(seat) })
+
+    expect(result.current.selectedSeat).toEqual(seat)
+  })
+})
+
 describe("useSeatSelection - isComplete", () => {
   it("섹션과 좌석이 모두 선택되면 true다", () => {
     const { result } = renderHook(() => useSeatSelection())

--- a/src/widgets/booking/lib/__tests__/useSeatSelection.test.ts
+++ b/src/widgets/booking/lib/__tests__/useSeatSelection.test.ts
@@ -1,17 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest"
 import { renderHook, act } from "@testing-library/react"
 import { useSeatSelection } from "../useSeatSelection"
-import { banSeat, cancelSeatBan } from "@/entities/booking/api/banSeat"
 import { Seat, Section, SeatStatus, SEAT_STATUS } from "@/entities/booking/model/types"
-
-vi.mock("@/entities/booking/api/banSeat", () => ({
-  banSeat: vi.fn(() => Promise.resolve({ data: null })),
-  cancelSeatBan: vi.fn(() => Promise.resolve({ data: null })),
-}))
-
-vi.mock("sonner", () => ({
-  toast: { error: vi.fn(), success: vi.fn() },
-}))
 
 const makeSeat = (
   seatNumber: string,
@@ -195,112 +185,9 @@ describe("useSeatSelection - 초기 상태", () => {
   })
 })
 
-describe("useSeatSelection - 임시 저장(좌석 홀드)", () => {
-  it("좌석 선택 시 임시 저장 API를 호출한다", () => {
-    const { result } = renderHook(() => useSeatSelection())
-    const seat = makeSeat("1")
-
-    act(() => { result.current.selectSeat(seat) })
-
-    expect(banSeat).toHaveBeenCalledWith(seat)
-  })
-
-  it("좌석 선택 해제 시 임시 저장 해제 API를 호출한다", () => {
-    const { result } = renderHook(() => useSeatSelection())
-    const seat = makeSeat("1")
-
-    act(() => { result.current.selectSeat(seat) })
-    act(() => { result.current.selectSeat(seat) })
-
-    expect(cancelSeatBan).toHaveBeenCalledWith(seat)
-  })
-
-  it("다른 좌석으로 교체 시 이전 좌석의 임시 저장을 해제한다", () => {
-    const { result } = renderHook(() => useSeatSelection())
-    const seatA = makeSeat("1")
-    const seatB = makeSeat("2")
-
-    act(() => { result.current.selectSeat(seatA) })
-    act(() => { result.current.selectSeat(seatB) })
-
-    expect(cancelSeatBan).toHaveBeenCalledWith(seatA)
-    expect(banSeat).toHaveBeenCalledWith(seatB)
-  })
-
-  it("섹션 변경 시 선택돼 있던 좌석의 임시 저장을 해제한다", () => {
-    const { result } = renderHook(() => useSeatSelection())
-    const seat = makeSeat("1")
-
-    act(() => { result.current.setSelectedSection("RED") })
-    act(() => { result.current.selectSeat(seat) })
-    act(() => { result.current.setSelectedSection("YELLOW") })
-
-    expect(cancelSeatBan).toHaveBeenCalledWith(seat)
-  })
-
-  it("다른 사용자가 선점한 좌석(409)이면 재시도 후에도 실패 시 선택이 해제된다", async () => {
-    const conflict = Object.assign(new Error("이미 차단된 좌석"), { status: 409 })
-    vi.mocked(banSeat).mockRejectedValueOnce(conflict).mockRejectedValueOnce(conflict)
-    const { result } = renderHook(() => useSeatSelection())
-    const seat = makeSeat("1")
-
-    await act(async () => { result.current.selectSeat(seat) })
-
-    expect(result.current.selectedSeat).toBeNull()
-  })
-
-  it("본인의 이전 홀드로 409가 나면 해제 후 재시도해 선택을 유지한다", async () => {
-    vi.mocked(banSeat).mockRejectedValueOnce(
-      Object.assign(new Error("이미 차단된 좌석"), { status: 409 }),
-    )
-    const { result } = renderHook(() => useSeatSelection())
-    const seat = makeSeat("1")
-
-    await act(async () => { result.current.selectSeat(seat) })
-
-    expect(cancelSeatBan).toHaveBeenCalledWith(seat)
-    expect(banSeat).toHaveBeenCalledTimes(2)
-    expect(result.current.selectedSeat).toEqual(seat)
-  })
-
-  it("선점 외 사유(권한 없음 등)로 임시 저장이 실패해도 선택은 유지된다", async () => {
-    vi.mocked(banSeat).mockRejectedValueOnce(
-      Object.assign(new Error("권한 없음"), { status: 403 }),
-    )
-    const { result } = renderHook(() => useSeatSelection())
-    const seat = makeSeat("1")
-
-    await act(async () => { result.current.selectSeat(seat) })
-
-    expect(result.current.selectedSeat).toEqual(seat)
-  })
-})
-
 describe("useSeatSelection - 어드민 옵션", () => {
-  it("holdOnSelect가 false면 좌석 선택 시 임시 저장 API를 호출하지 않는다", () => {
-    const { result } = renderHook(() => useSeatSelection({ holdOnSelect: false }))
-    const seat = makeSeat("1")
-
-    act(() => { result.current.selectSeat(seat) })
-
-    expect(banSeat).not.toHaveBeenCalled()
-    expect(result.current.selectedSeat).toEqual(seat)
-  })
-
-  it("holdOnSelect가 false면 선택 해제·교체 시에도 해제 API를 호출하지 않는다", () => {
-    const { result } = renderHook(() => useSeatSelection({ holdOnSelect: false }))
-
-    act(() => { result.current.selectSeat(makeSeat("1")) })
-    act(() => { result.current.selectSeat(makeSeat("2")) })
-    act(() => { result.current.setSelectedSection("YELLOW") })
-
-    expect(cancelSeatBan).not.toHaveBeenCalled()
-  })
-
   it("allowOccupied가 true면 OCCUPIED 좌석도 선택할 수 있다", () => {
-    const { result } = renderHook(() =>
-      useSeatSelection({ holdOnSelect: false, allowOccupied: true }),
-    )
+    const { result } = renderHook(() => useSeatSelection({ allowOccupied: true }))
     const seat = makeSeat("1", SEAT_STATUS.OCCUPIED)
 
     act(() => { result.current.selectSeat(seat) })

--- a/src/widgets/booking/lib/useAdminSeatBan.ts
+++ b/src/widgets/booking/lib/useAdminSeatBan.ts
@@ -2,20 +2,26 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { banSeat, cancelSeatBan } from "@/entities/booking/api/banSeat";
 import { Seat, formatSeatLabel } from "@/entities/booking/model/types";
-import { seatQueryKeys } from "@/entities/booking/lib/useSeatState";
+import { applySeatChange } from "@/entities/booking/lib/useSeatState";
 
 export function useAdminSeatBan() {
   const queryClient = useQueryClient();
 
-  const invalidateSeat = (seat: Pick<Seat, "section">) => {
-    queryClient.invalidateQueries({ queryKey: seatQueryKeys.seatState(seat.section) });
-    queryClient.invalidateQueries({ queryKey: ["allSectionsSeatState"] });
+  // 재조회 대신 캐시 직접 갱신 — 백엔드 조회 응답에 밴 상태가 늦게 반영돼도
+  // 화면에서는 즉시 회색/흰색으로 전환된다
+  const setSeatAvailability = (seat: Omit<Seat, "status">, isAvailable: boolean) => {
+    applySeatChange(queryClient, {
+      seat_section: seat.section,
+      seat_row: seat.row,
+      seat_number: Number(seat.seatNumber),
+      is_available: isAvailable,
+    });
   };
 
   const ban = useMutation({
     mutationFn: (seat: Omit<Seat, "status">) => banSeat(seat),
     onSuccess: (_result, seat) => {
-      invalidateSeat(seat);
+      setSeatAvailability(seat, false);
       toast.success(`${formatSeatLabel(seat)} 좌석을 밴했습니다.`);
     },
     onError: (error: Error) => {
@@ -26,7 +32,7 @@ export function useAdminSeatBan() {
   const unban = useMutation({
     mutationFn: (seat: Omit<Seat, "status">) => cancelSeatBan(seat),
     onSuccess: (_result, seat) => {
-      invalidateSeat(seat);
+      setSeatAvailability(seat, true);
       toast.success(`${formatSeatLabel(seat)} 좌석 밴을 해제했습니다.`);
     },
     onError: (error: Error) => {

--- a/src/widgets/booking/lib/useAdminSeatBan.ts
+++ b/src/widgets/booking/lib/useAdminSeatBan.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { banSeat, cancelSeatBan } from "@/entities/booking/api/banSeat";
+import { Seat, formatSeatLabel } from "@/entities/booking/model/types";
+import { seatQueryKeys } from "@/entities/booking/lib/useSeatState";
+
+export function useAdminSeatBan() {
+  const queryClient = useQueryClient();
+
+  const invalidateSeat = (seat: Pick<Seat, "section">) => {
+    queryClient.invalidateQueries({ queryKey: seatQueryKeys.seatState(seat.section) });
+    queryClient.invalidateQueries({ queryKey: ["allSectionsSeatState"] });
+  };
+
+  const ban = useMutation({
+    mutationFn: (seat: Omit<Seat, "status">) => banSeat(seat),
+    onSuccess: (_result, seat) => {
+      invalidateSeat(seat);
+      toast.success(`${formatSeatLabel(seat)} 좌석을 밴했습니다.`);
+    },
+    onError: (error: Error) => {
+      toast.error(error.message ?? "좌석 밴에 실패했습니다.");
+    },
+  });
+
+  const unban = useMutation({
+    mutationFn: (seat: Omit<Seat, "status">) => cancelSeatBan(seat),
+    onSuccess: (_result, seat) => {
+      invalidateSeat(seat);
+      toast.success(`${formatSeatLabel(seat)} 좌석 밴을 해제했습니다.`);
+    },
+    onError: (error: Error) => {
+      toast.error(error.message ?? "좌석 밴 해제에 실패했습니다.");
+    },
+  });
+
+  return { ban, unban };
+}

--- a/src/widgets/booking/lib/useSeatSelection.ts
+++ b/src/widgets/booking/lib/useSeatSelection.ts
@@ -23,7 +23,8 @@ export const useSeatSelection = ({ allowOccupied = false }: UseSeatSelectionOpti
       if (seat.status === SEAT_STATUS.OCCUPIED && !allowOccupied) return;
 
       if (selectedSeat && isSameSeat(selectedSeat, seat)) {
-        setSelectedSeat(null);
+        // 같은 좌석이라도 상태가 바뀐 경우(밴/해제)는 선택을 유지하고 상태만 갱신
+        setSelectedSeat(selectedSeat.status !== seat.status ? seat : null);
       } else {
         setSelectedSeat(seat);
         setSelectedSection(seat.section);

--- a/src/widgets/booking/lib/useSeatSelection.ts
+++ b/src/widgets/booking/lib/useSeatSelection.ts
@@ -6,13 +6,27 @@ import { banSeat, cancelSeatBan, SeatBanError } from "@/entities/booking/api/ban
 const isSameSeat = (a: Seat, b: Seat) =>
   a.seatNumber === b.seatNumber && a.row === b.row && a.section === b.section;
 
-export const useSeatSelection = () => {
+interface UseSeatSelectionOptions {
+  // 어드민은 선택이 홀드가 아니라 밴 대상 지정이므로 홀드 요청을 보내지 않고,
+  // 밴 해제를 위해 점유(회색) 좌석도 선택할 수 있어야 한다
+  holdOnSelect?: boolean;
+  allowOccupied?: boolean;
+}
+
+export const useSeatSelection = ({
+  holdOnSelect = true,
+  allowOccupied = false,
+}: UseSeatSelectionOptions = {}) => {
   const [selectedSection, setSelectedSection] = useState<Section | null>(null);
   const [selectedSeat, setSelectedSeat] = useState<Seat | null>(null);
 
-  const releaseHold = useCallback((seat: Seat) => {
-    cancelSeatBan(seat).catch(() => {});
-  }, []);
+  const releaseHold = useCallback(
+    (seat: Seat) => {
+      if (!holdOnSelect) return;
+      cancelSeatBan(seat).catch(() => {});
+    },
+    [holdOnSelect],
+  );
 
   const holdSeat = useCallback((seat: Seat) => {
     banSeat(seat)
@@ -42,7 +56,7 @@ export const useSeatSelection = () => {
 
   const selectSeat = useCallback(
     (seat: Seat) => {
-      if (seat.status === SEAT_STATUS.OCCUPIED) return;
+      if (seat.status === SEAT_STATUS.OCCUPIED && !allowOccupied) return;
 
       if (selectedSeat && isSameSeat(selectedSeat, seat)) {
         releaseHold(selectedSeat);
@@ -51,10 +65,10 @@ export const useSeatSelection = () => {
         if (selectedSeat) releaseHold(selectedSeat);
         setSelectedSeat(seat);
         setSelectedSection(seat.section);
-        holdSeat(seat);
+        if (holdOnSelect) holdSeat(seat);
       }
     },
-    [selectedSeat, releaseHold, holdSeat],
+    [selectedSeat, releaseHold, holdSeat, holdOnSelect, allowOccupied],
   );
 
   const canSelectSeat = useCallback((seat: Seat) => {

--- a/src/widgets/booking/lib/useSeatSelection.ts
+++ b/src/widgets/booking/lib/useSeatSelection.ts
@@ -1,74 +1,35 @@
 import { useState, useCallback, useMemo } from "react";
-import { toast } from "sonner";
 import { Section, Seat, SelectedSeatInfo, SEAT_STATUS } from "@/entities/booking/model/types";
-import { banSeat, cancelSeatBan, SeatBanError } from "@/entities/booking/api/banSeat";
 
 const isSameSeat = (a: Seat, b: Seat) =>
   a.seatNumber === b.seatNumber && a.row === b.row && a.section === b.section;
 
 interface UseSeatSelectionOptions {
-  // 어드민은 선택이 홀드가 아니라 밴 대상 지정이므로 홀드 요청을 보내지 않고,
-  // 밴 해제를 위해 점유(회색) 좌석도 선택할 수 있어야 한다
-  holdOnSelect?: boolean;
+  // 어드민은 밴 해제를 위해 점유(회색) 좌석도 선택할 수 있어야 한다
   allowOccupied?: boolean;
 }
 
-export const useSeatSelection = ({
-  holdOnSelect = true,
-  allowOccupied = false,
-}: UseSeatSelectionOptions = {}) => {
+export const useSeatSelection = ({ allowOccupied = false }: UseSeatSelectionOptions = {}) => {
   const [selectedSection, setSelectedSection] = useState<Section | null>(null);
   const [selectedSeat, setSelectedSeat] = useState<Seat | null>(null);
 
-  const releaseHold = useCallback(
-    (seat: Seat) => {
-      if (!holdOnSelect) return;
-      cancelSeatBan(seat).catch(() => {});
-    },
-    [holdOnSelect],
-  );
-
-  const holdSeat = useCallback((seat: Seat) => {
-    banSeat(seat)
-      .catch(async (error: SeatBanError) => {
-        // 409 외(권한 없음 등)는 선택 유지하고 예매 시점에 판정
-        if (error.status !== 409) return;
-        // 본인이 이전에 남긴 홀드일 수 있으니 해제 후 1회 재시도
-        await cancelSeatBan(seat).catch(() => {});
-        await banSeat(seat);
-      })
-      .catch(() => {
-        setSelectedSeat(current => (current && isSameSeat(current, seat) ? null : current));
-        toast.error("이미 다른 사용자가 선택한 좌석입니다.");
-      });
+  const handleSectionChange = useCallback((section: Section | null) => {
+    setSelectedSection(section);
+    setSelectedSeat(null);
   }, []);
-
-  const handleSectionChange = useCallback(
-    (section: Section | null) => {
-      setSelectedSection(section);
-      setSelectedSeat(current => {
-        if (current) releaseHold(current);
-        return null;
-      });
-    },
-    [releaseHold],
-  );
 
   const selectSeat = useCallback(
     (seat: Seat) => {
       if (seat.status === SEAT_STATUS.OCCUPIED && !allowOccupied) return;
 
       if (selectedSeat && isSameSeat(selectedSeat, seat)) {
-        releaseHold(selectedSeat);
         setSelectedSeat(null);
       } else {
-        if (selectedSeat) releaseHold(selectedSeat);
         setSelectedSeat(seat);
         setSelectedSection(seat.section);
-        if (holdOnSelect) holdSeat(seat);
       }
     },
-    [selectedSeat, releaseHold, holdSeat, holdOnSelect, allowOccupied],
+    [selectedSeat, allowOccupied],
   );
 
   const canSelectSeat = useCallback((seat: Seat) => {

--- a/src/widgets/booking/ui/SeatSection/index.tsx
+++ b/src/widgets/booking/ui/SeatSection/index.tsx
@@ -105,7 +105,7 @@ export const SeatSection = memo<SeatSectionProps>(
           allowOccupiedSelect={allowOccupiedSelect}
         />
 
-        <div className="mt-6">
+        <div className="pt-8">
           <SelectedSeatDisplay
             selectedSeat={!isPerformerMode ? selectedSeatInfo : null}
             selectedSection={selectedSection}

--- a/src/widgets/booking/ui/SeatSection/index.tsx
+++ b/src/widgets/booking/ui/SeatSection/index.tsx
@@ -27,6 +27,7 @@ interface SeatSectionProps {
   isPerformerMode?: boolean;
   myBookedSeats?: Seat[];
   removeOccupiedSeat?: (section: Section, row: string, seatNumber: string) => void;
+  allowOccupiedSelect?: boolean;
 }
 
 export const SeatSection = memo<SeatSectionProps>(
@@ -41,6 +42,7 @@ export const SeatSection = memo<SeatSectionProps>(
     isPerformerMode = false,
     myBookedSeats,
     removeOccupiedSeat,
+    allowOccupiedSelect = false,
   }) => {
     const { data: sectionSeats, isLoading, error } = useSectionSeatState(selectedSection!);
     const { data: allSeats, isLoading: isAllSeatsLoading } = useAllSectionsSeatState();
@@ -175,8 +177,9 @@ export const SeatSection = memo<SeatSectionProps>(
             selectedSeats={selectedSeats}
             isSeatSelected={isSeatSelected}
             isPerformerMode={isPerformerMode}
-            mySeat={!isPerformerMode ? (myBookedSeats?.[0] ?? null) : null}
+            mySeat={!isPerformerMode && !allowOccupiedSelect ? (myBookedSeats?.[0] ?? null) : null}
             myAllSeats={myBookedSeats}
+            allowOccupiedSelect={allowOccupiedSelect}
           />
         </div>
 

--- a/src/widgets/booking/ui/SeatSection/index.tsx
+++ b/src/widgets/booking/ui/SeatSection/index.tsx
@@ -91,7 +91,7 @@ export const SeatSection = memo<SeatSectionProps>(
     const layout = getLayout();
 
     return (
-      <div className={cn("pb-20", className)}>
+      <div className={cn("pb-24", className)}>
         <SeatGrid
           layout={layout}
           selectedSeat={selectedSeat}

--- a/src/widgets/booking/ui/SeatSection/index.tsx
+++ b/src/widgets/booking/ui/SeatSection/index.tsx
@@ -91,7 +91,7 @@ export const SeatSection = memo<SeatSectionProps>(
     const layout = getLayout();
 
     return (
-      <div className={cn("pb-24", className)}>
+      <div className={cn(className)}>
         <SeatGrid
           layout={layout}
           selectedSeat={selectedSeat}

--- a/src/widgets/booking/ui/SeatSection/index.tsx
+++ b/src/widgets/booking/ui/SeatSection/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback, useEffect, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { cn } from "@/shared/utils/cn";
 import { Section, Seat, SelectedSeatInfo, SEAT_STATUS } from "@/entities/booking/model/types";
 import { SeatGrid } from "@/entities/booking/ui/SeatGrid";
@@ -8,11 +8,8 @@ import { SelectedSeatDisplay } from "@/entities/booking/ui/SelectedSeatDisplay";
 import {
   useSectionSeatState,
   useAllSectionsSeatState,
-  seatQueryKeys,
 } from "@/entities/booking/lib/useSeatState";
-import { useSeatChangeSSE } from "@/entities/booking/lib/useSeatChangeSSE";
 import { getSeatLayout } from "@/entities/booking/model/seatLayouts";
-import { useQueryClient } from "@tanstack/react-query";
 
 const NOOP_SEAT_SELECT = () => {};
 
@@ -26,7 +23,6 @@ interface SeatSectionProps {
   isSeatSelected?: (seat: Seat) => boolean;
   isPerformerMode?: boolean;
   myBookedSeats?: Seat[];
-  removeOccupiedSeat?: (section: Section, row: string, seatNumber: string) => void;
   allowOccupiedSelect?: boolean;
 }
 
@@ -41,83 +37,11 @@ export const SeatSection = memo<SeatSectionProps>(
     isSeatSelected,
     isPerformerMode = false,
     myBookedSeats,
-    removeOccupiedSeat,
     allowOccupiedSelect = false,
   }) => {
     const { data: sectionSeats, isLoading, error } = useSectionSeatState(selectedSection!);
     const { data: allSeats, isLoading: isAllSeatsLoading } = useAllSectionsSeatState();
     const [realTimeSeats, setRealTimeSeats] = useState<Seat[] | null>(null);
-    const queryClient = useQueryClient();
-
-    const handleSeatChange = useCallback(
-      (event: {
-        seat_section: Section;
-        seat_row: string;
-        seat_number: number;
-        is_available: boolean;
-      }) => {
-        if (event.seat_section !== selectedSection) return;
-
-        if (!event.is_available && isPerformerMode && removeOccupiedSeat) {
-          removeOccupiedSeat(event.seat_section, event.seat_row, event.seat_number.toString());
-        }
-
-        setRealTimeSeats(prevSeats => {
-          if (!prevSeats) return prevSeats;
-
-          return prevSeats.map(seat => {
-            if (seat.seatNumber === event.seat_number.toString() && seat.row === event.seat_row) {
-              return {
-                ...seat,
-                status: event.is_available ? SEAT_STATUS.AVAILABLE : SEAT_STATUS.OCCUPIED,
-              };
-            }
-            return seat;
-          });
-        });
-
-        const sectionCache = queryClient.getQueryData<Seat[]>(
-          seatQueryKeys.seatState(event.seat_section),
-        );
-        if (sectionCache) {
-          const updatedSeats = sectionCache.map(seat => {
-            if (seat.seatNumber === event.seat_number.toString() && seat.row === event.seat_row) {
-              return {
-                ...seat,
-                status: event.is_available ? SEAT_STATUS.AVAILABLE : SEAT_STATUS.OCCUPIED,
-              };
-            }
-            return seat;
-          });
-          queryClient.setQueryData(seatQueryKeys.seatState(event.seat_section), updatedSeats);
-        }
-
-        const allSeatsCache = queryClient.getQueryData<Seat[]>(["allSectionsSeatState"]);
-        if (allSeatsCache) {
-          const updatedAllSeats = allSeatsCache.map(seat => {
-            if (
-              seat.section === event.seat_section &&
-              seat.row === event.seat_row &&
-              seat.seatNumber === event.seat_number.toString()
-            ) {
-              const newStatus = event.is_available ? SEAT_STATUS.AVAILABLE : SEAT_STATUS.OCCUPIED;
-              return {
-                ...seat,
-                status: newStatus,
-              };
-            }
-            return seat;
-          });
-          queryClient.setQueryData(["allSectionsSeatState"], updatedAllSeats);
-        }
-      },
-      [selectedSection, queryClient, isPerformerMode, removeOccupiedSeat],
-    );
-
-    useSeatChangeSSE({
-      onSeatChange: handleSeatChange,
-      enabled: !!selectedSection,
-    });
 
     useEffect(() => {
       if (!selectedSection) {

--- a/src/widgets/booking/ui/SeatSection/index.tsx
+++ b/src/widgets/booking/ui/SeatSection/index.tsx
@@ -168,24 +168,20 @@ export const SeatSection = memo<SeatSectionProps>(
 
     return (
       <div className={cn("pb-20", className)}>
-        <div className="h-80">
-          <SeatGrid
-            layout={layout}
-            selectedSeat={selectedSeat}
-            onSeatSelect={isLoading || !!error ? NOOP_SEAT_SELECT : onSeatSelect}
-            allSeats={realTimeSeats}
-            selectedSeats={selectedSeats}
-            isSeatSelected={isSeatSelected}
-            isPerformerMode={isPerformerMode}
-            mySeat={!isPerformerMode && !allowOccupiedSelect ? (myBookedSeats?.[0] ?? null) : null}
-            myAllSeats={myBookedSeats}
-            allowOccupiedSelect={allowOccupiedSelect}
-          />
-        </div>
+        <SeatGrid
+          layout={layout}
+          selectedSeat={selectedSeat}
+          onSeatSelect={isLoading || !!error ? NOOP_SEAT_SELECT : onSeatSelect}
+          allSeats={realTimeSeats}
+          selectedSeats={selectedSeats}
+          isSeatSelected={isSeatSelected}
+          isPerformerMode={isPerformerMode}
+          mySeat={!isPerformerMode && !allowOccupiedSelect ? (myBookedSeats?.[0] ?? null) : null}
+          myAllSeats={myBookedSeats}
+          allowOccupiedSelect={allowOccupiedSelect}
+        />
 
-        <div className="h-24"></div>
-
-        <div className="h-24">
+        <div className="mt-6">
           <SelectedSeatDisplay
             selectedSeat={!isPerformerMode ? selectedSeatInfo : null}
             selectedSection={selectedSection}

--- a/src/widgets/booking/ui/SelectSection/index.tsx
+++ b/src/widgets/booking/ui/SelectSection/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, memo, useMemo, useEffect } from "react";
-import { useQueryClient, useQueries } from "@tanstack/react-query";
+import { useQueries } from "@tanstack/react-query";
 import { cn } from "@/shared/utils/cn";
 import { SectionButtons } from "@/entities/booking/ui/SectionButtons";
 import { seatQueryKeys } from "@/entities/booking/lib/useSeatState";
@@ -17,7 +17,6 @@ import {
   usePrefetchSeatCaches,
   useAllSectionsSeatState,
 } from "@/entities/booking/lib/useSeatState";
-import { useSeatChangeSSE } from "@/entities/booking/lib/useSeatChangeSSE";
 import { toast } from "sonner";
 
 interface SelectSectionProps {
@@ -28,60 +27,12 @@ interface SelectSectionProps {
 
 export const SelectSection = memo<SelectSectionProps>(
   ({ selectedSection = null, onSectionSelect, className }) => {
-  const queryClient = useQueryClient();
-
   const { isLoading: isPrefetching, error: prefetchError } = usePrefetchSeatCaches();
   const {
     data: allSeats,
     isLoading: isAllSeatsLoading,
     error: allSeatsError,
   } = useAllSectionsSeatState();
-
-  const handleSeatChange = useCallback(
-    (event: { seat_section: Section; seat_row: string; seat_number: number; is_available: boolean }) => {
-      const cachedSeats = queryClient.getQueryData<Seat[]>(
-        seatQueryKeys.seatState(event.seat_section),
-      );
-      if (cachedSeats) {
-        const updatedSeats = cachedSeats.map(seat => {
-          if (seat.seatNumber === event.seat_number.toString() && seat.row === event.seat_row) {
-            const newStatus = event.is_available ? SEAT_STATUS.AVAILABLE : SEAT_STATUS.OCCUPIED;
-            return {
-              ...seat,
-              status: newStatus,
-            };
-          }
-          return seat;
-        });
-        queryClient.setQueryData(seatQueryKeys.seatState(event.seat_section), updatedSeats);
-      }
-
-      const allSeatsCache = queryClient.getQueryData<Seat[]>(["allSectionsSeatState"]);
-      if (allSeatsCache) {
-        const updatedAllSeats = allSeatsCache.map(seat => {
-          if (
-            seat.section === event.seat_section &&
-            seat.row === event.seat_row &&
-            seat.seatNumber === event.seat_number.toString()
-          ) {
-            const newStatus = event.is_available ? SEAT_STATUS.AVAILABLE : SEAT_STATUS.OCCUPIED;
-            return {
-              ...seat,
-              status: newStatus,
-            };
-          }
-          return seat;
-        });
-        queryClient.setQueryData(["allSectionsSeatState"], updatedAllSeats);
-      }
-    },
-    [queryClient],
-  );
-
-  useSeatChangeSSE({
-    onSeatChange: handleSeatChange,
-    enabled: true,
-  });
 
   useEffect(() => {
     if (prefetchError) {


### PR DESCRIPTION
## 💡 PR 요약

> 해당 PR의 변경사항, 해당 이슈 등에 대한 간략한 설명을 작성해주세요.

- 휠체어석 좌석번호 "WW1" 중복 표기를 "W1"로 수정
- 어드민 좌석 밴/해제 기능 추가 (POST/DELETE /seat/ban 연동)
- 일반 사용자 좌석 선택 시 나가던 밴(홀드) 요청 제거
- SSE 실시간 좌석 연결을 페이지당 1개로 통합해 "실시간 좌석 정보 연결 실패" 토스트 문제 해결
- 밴/해제 성공 시 좌석 캐시 직접 갱신으로 즉시 상태 반영
- 좌석 그리드 UI 수정 (고정 높이 제거, 하단 버튼 배치 개선, 맵-안내박스 간격 확보)

## 📋 작업 내용

> 해당 PR에서 작업한 내용을 자세히 설명해주세요.

### 1. 휠체어석 좌석번호 중복 표기 수정
- 휠체어석이 "WW1"로 중복 표기되던 문제를 "W1"로 수정
- `formatSeatLabel` 공통 함수로 좌석 라벨 포맷 로직 정리

### 2. 어드민 좌석 밴/해제 기능 추가
- 어드민은 하단에 예매하기/밴하기 버튼 2개 노출
- 회색(밴) 좌석 선택 시 버튼이 "밴 해제하기"로 전환
- POST/DELETE `/seat/ban` API 연동

### 3. 일반 사용자 밴 요청 제거
- 밴 API는 관리자 전용 정책이므로, 일반 사용자 좌석 선택 시 나가던 밴(홀드) 요청 제거

### 4. SSE 실시간 좌석 연결 통합
- 백엔드가 유저당 1 connection만 유지해 구역 선택 시 "실시간 좌석 정보 연결 실패" 토스트가 뜨던 문제 해결
- SSE 연결을 페이지당 1개로 통합
- 중복 캐시 갱신 로직을 `applySeatChange` 공용 함수로 정리

### 5. 밴/해제 즉시 반영
- 밴/해제 성공 시 좌석 캐시를 직접 갱신해 즉시 회색/흰색 전환

### 6. 좌석 그리드 UI 수정
- 고정 높이 제거로 불필요한 스크롤 및 하단 UI 가림 해결
- 하단 버튼을 fixed에서 일반 흐름 배치로 변경해 콘텐츠 겹침 제거 및 가로 폭 정렬
- 좌석 맵과 안내 박스 사이 간격 확보

## 🤝 리뷰 시 참고사항

> 리뷰어분들이 리뷰를 할 때 참고하면 좋을 사항이나 질문사항을 작성해주세요.

- **백엔드 확인 필요**: GET `/seat` 응답에 밴 좌석이 불가능(false)으로 반영되는지 확인이 필요합니다. 미반영 시 새로고침하면 밴 좌석이 흰색으로 보입니다.
- 테스트 111개 통과, tsc/lint 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)