### PR TITLE
fix: 예매 페이지 하단 버튼 레이아웃 및 좌석 그리드 스크롤 개선

### DIFF
--- a/src/entities/booking/ui/SeatGrid/index.tsx
+++ b/src/entities/booking/ui/SeatGrid/index.tsx
@@ -226,11 +226,11 @@ export const SeatGrid = memo<SeatGridProps>(
     );
 
     const getGridContainerStyles = () => {
-      return "relative bg-gray-800 rounded-lg w-full p-3 overflow-x-auto";
+      return "relative bg-gray-800 rounded-lg w-full h-full p-3 overflow-auto";
     };
 
     return (
-      <div className={cn(className)}>
+      <div className={cn("min-h-0", className)}>
         <div className={getGridContainerStyles()}>
           {layout ? renderSingleSectionGrid() : renderAllSectionsGrid()}
         </div>

--- a/src/views/booking/ui/BookingPage/index.tsx
+++ b/src/views/booking/ui/BookingPage/index.tsx
@@ -194,7 +194,7 @@ const BookingPage = () => {
         <BackHeader goto="/home" text="예매하기" />
       </div>
 
-      <div className="flex flex-col p-4 pt-8 gap-8">
+      <div className="flex-1 flex flex-col p-4 pt-8 gap-8">
         <div>
           <SelectSection
             selectedSection={isPerformer ? performerSelectedSection : selectedSection}
@@ -214,7 +214,7 @@ const BookingPage = () => {
             allowOccupiedSelect={isAdmin}
           />
         </div>
-        <div className="pb-4">
+        <div className="mt-auto pb-4">
           <div className={`w-full ${isAdmin ? "flex gap-2" : ""}`}>
             <Button
               className={`h-[48px] ${isAdmin ? "flex-1" : "w-full"}`}

--- a/src/views/booking/ui/BookingPage/index.tsx
+++ b/src/views/booking/ui/BookingPage/index.tsx
@@ -189,19 +189,19 @@ const BookingPage = () => {
   };
 
   return (
-    <main className="w-full max-w-[480px] mx-auto min-h-screen bg-white flex flex-col">
+    <main className="w-full max-w-[480px] mx-auto h-screen bg-white flex flex-col overflow-hidden">
       <div className="px-4">
         <BackHeader goto="/home" text="예매하기" />
       </div>
 
-      <div className="flex-1 flex flex-col p-4 pt-8 gap-8">
+      <div className="flex-1 flex flex-col min-h-0 p-4 pt-8 gap-4">
         <div>
           <SelectSection
             selectedSection={isPerformer ? performerSelectedSection : selectedSection}
             onSectionSelect={handleSectionSelect}
           />
         </div>
-        <div>
+        <div className="flex-1 min-h-0">
           <SeatSection
             selectedSection={isPerformer ? performerSelectedSection : selectedSection}
             selectedSeat={isPerformer ? null : selectedSeat}
@@ -214,7 +214,7 @@ const BookingPage = () => {
             allowOccupiedSelect={isAdmin}
           />
         </div>
-        <div className="mt-auto pb-4">
+        <div className="shrink-0 pb-4">
           <div className={`w-full ${isAdmin ? "flex gap-2" : ""}`}>
             <Button
               className={`h-[48px] ${isAdmin ? "flex-1" : "w-full"}`}

--- a/src/widgets/booking/ui/SeatSection/index.tsx
+++ b/src/widgets/booking/ui/SeatSection/index.tsx
@@ -91,8 +91,9 @@ export const SeatSection = memo<SeatSectionProps>(
     const layout = getLayout();
 
     return (
-      <div className={cn(className)}>
+      <div className={cn("flex flex-col h-full min-h-0", className)}>
         <SeatGrid
+          className="flex-1 min-h-0"
           layout={layout}
           selectedSeat={selectedSeat}
           onSeatSelect={isLoading || !!error ? NOOP_SEAT_SELECT : onSeatSelect}
@@ -105,7 +106,7 @@ export const SeatSection = memo<SeatSectionProps>(
           allowOccupiedSelect={allowOccupiedSelect}
         />
 
-        <div className="pt-8">
+        <div className="shrink-0 pt-4">
           <SelectedSeatDisplay
             selectedSeat={!isPerformerMode ? selectedSeatInfo : null}
             selectedSection={selectedSection}


### PR DESCRIPTION
## 💡 PR 요약

> 해당 PR의 변경사항, 해당 이슈 등에 대한 간략한 설명을 작성해주세요.

- 예매 페이지 하단 버튼 배치와 좌석 그리드 스크롤 동작을 개선했어요.
- 콘텐츠가 짧을 때 버튼과 화면 하단 사이에 빈 공간이 크게 남던 문제를 수정했어요.
- 모바일에서 페이지 전체를 스크롤해야 버튼이 보이던 문제를 뷰포트 고정 방식으로 해결했어요.
- 이미 머지된 PR #257(fix/booking)의 예매 페이지 레이아웃 후속 수정 2건을 별도 브랜치로 분리한 PR이에요.

## 📋 작업 내용

> 해당 PR에서 작업한 내용을 자세히 설명해주세요.

1. 하단 버튼을 고정(fixed) 배치에서 일반 흐름으로 변경했으나, 콘텐츠가 짧을 때 버튼과 화면 하단 사이에 빈 공간이 크게 남던 문제를 수정했어요.
2. 예매 페이지를 뷰포트 높이(`h-screen`)에 고정하고, 섹션 버튼·좌석 안내·하단 버튼은 항상 화면에 보이게 하고, 좌석 그리드만 남는 공간 안에서 내부 스크롤되도록 개선했어요. (모바일에서 페이지 전체가 넘쳐 스크롤해야 버튼이 보이던 문제 해결)

## 🤝 리뷰 시 참고사항

> 리뷰어분들이 리뷰를 할 때 참고하면 좋을 사항이나 질문사항을 작성해주세요.

- MyBookingPage(내 예매 페이지)는 flex 컨텍스트가 아니라 좌석 그리드 높이 동작에 영향이 없어요.
- lint 클린 상태예요.