### PR TITLE
fix: 손글씨 메모 입력 씹힘 및 유실 수정

### DIFF
--- a/src/widgets/judging/ui/HandwritingCanvas/index.tsx
+++ b/src/widgets/judging/ui/HandwritingCanvas/index.tsx
@@ -83,15 +83,19 @@ const HandwritingCanvas = ({ teamId, value, onChange, onClear }: HandwritingCanv
   }, [drawStrokes]);
 
   useEffect(() => {
-    if (loadedTeamId.current === teamId) return;
+    loadedTeamId.current = null;
+    setStrokes([]);
+    setRedoStack([]);
+    drawStrokes([]);
+  }, [teamId, drawStrokes]);
 
-    if (value === undefined) {
-      setStrokes([]);
-      setRedoStack([]);
-      drawStrokes([]);
+  useEffect(() => {
+    if (loadedTeamId.current === teamId || value === undefined) return;
+    // 서버 응답이 늦게 도착하는 사이 이미 손으로 쓰기 시작했다면, 로컬 획을 서버 값으로 덮어써 지우지 않는다
+    if (strokesRef.current.length > 0) {
+      loadedTeamId.current = teamId;
       return;
     }
-
     setStrokes(value);
     setRedoStack([]);
     drawStrokes(value);
@@ -273,8 +277,8 @@ const HandwritingCanvas = ({ teamId, value, onChange, onClear }: HandwritingCanv
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerEnd}
-        onPointerLeave={handlePointerEnd}
         onPointerCancel={handlePointerEnd}
+        onLostPointerCapture={handlePointerEnd}
       />
     </div>
   );


### PR DESCRIPTION
## 💡 PR 요약

> 심사 페이지 손글씨 메모(코멘트) 작성 시 획이 중간에 끊기거나("씹힘") 작성한 글씨가 사라지는 문제 수정

- `onPointerLeave` 로 인한 획 조기 종료 제거
- 서버 응답 지연 중 작성한 획이 로드 값으로 덮어써져 유실되는 경쟁 조건 수정

## 📋 작업 내용

**1. 획 씹힘 (`onPointerLeave` 조기 종료)**
- 손으로 빠르게 쓰다 손가락이 캔버스 경계 밖으로 잠깐 나가면 `onPointerLeave` 가 `handlePointerEnd` 를 호출해 획이 조기 종료되고 `activePointerId` 가 초기화됨
- 이후 손을 떼지 않고 계속 써도 `handlePointerMove` 가드에서 무시되어 나머지 입력이 전부 유실됨
- `setPointerCapture` 가 이미 경계 밖 이동까지 전달하므로 `onPointerLeave` 는 불필요하고 유해함 → 제거
- 캡처가 강제 해제되어 캔버스가 먹통 되는 경우 대비 `onLostPointerCapture` 추가

**2. 획 유실 (로드 경쟁 조건)**
- 팀 선택 직후 `useGetJudgeComment` GET 응답이 오기 전(`value === undefined`)에 쓰기 시작하면, 응답 도착 시 로드 이펙트가 로컬 획을 서버 값으로 덮어써 사라짐
- 기존 `value === undefined` 분기가 `loadedTeamId` 를 설정하지 않아 경쟁 창이 계속 열려 있었음
- 로드 이펙트를 팀 변경 초기화 / 서버 값 하이드레이션 두 개로 분리
- 이미 로컬 편집이 시작된 경우 서버 값으로 덮어쓰지 않도록 가드 추가

## 🤝 리뷰 시 참고사항

- 로드 경쟁 조건 수정에서, 서버에 기존 메모가 있는 팀을 선택하자마자(응답 도착 전 수백 ms 내) 곧바로 쓰기 시작하는 극단적 경우에는 로컬 획을 우선해 서버 값을 하이드레이션하지 않습니다. 데이터 유실보다 이 트레이드오프가 안전하다고 판단했는데 방향이 맞는지 확인 부탁드립니다.