### PR TITLE
fix: 아이패드 손글씨 필기 끊김 및 페이지 드래그 개선

### DIFF
--- a/src/widgets/judging/ui/HandwritingCanvas/index.tsx
+++ b/src/widgets/judging/ui/HandwritingCanvas/index.tsx
@@ -28,6 +28,7 @@ const HandwritingCanvas = ({ teamId, value, onChange, onClear }: HandwritingCanv
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const currentStroke = useRef<Stroke | null>(null);
   const activePointerId = useRef<number | null>(null);
+  const activePointerType = useRef<string | null>(null);
   const loadedTeamId = useRef<number | null>(null);
   const strokesRef = useRef<Stroke[]>([]);
 
@@ -82,6 +83,19 @@ const HandwritingCanvas = ({ teamId, value, onChange, onClear }: HandwritingCanv
     return () => observer.disconnect();
   }, [drawStrokes]);
 
+  // iOS는 passive 리스너로는 preventDefault가 막히지 않아 필기 중 페이지가 스크롤되고, 그 과정에서 pointercancel이 떠 획이 끊긴다. 네이티브 non-passive 리스너로 터치 기본동작을 직접 막는다
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const prevent = (e: TouchEvent) => e.preventDefault();
+    canvas.addEventListener("touchstart", prevent, { passive: false });
+    canvas.addEventListener("touchmove", prevent, { passive: false });
+    return () => {
+      canvas.removeEventListener("touchstart", prevent);
+      canvas.removeEventListener("touchmove", prevent);
+    };
+  }, []);
+
   useEffect(() => {
     loadedTeamId.current = null;
     setStrokes([]);
@@ -114,14 +128,23 @@ const HandwritingCanvas = ({ teamId, value, onChange, onClear }: HandwritingCanv
 
   const handlePointerDown = (e: ReactPointerEvent<HTMLCanvasElement>) => {
     e.preventDefault();
-    // 이미 그리는 중인 포인터가 있으면 손바닥/보조 손가락 등 추가 터치는 무시한다(두 손가락 동시 입력 시 선이 섞이는 문제 방지)
-    if (activePointerId.current !== null) return;
 
     const canvas = canvasRef.current;
     const ctx = canvas?.getContext("2d");
     if (!canvas || !ctx) return;
 
+    if (activePointerId.current !== null) {
+      // 손가락으로 쓰던 중 펜이 닿으면 손바닥으로 판단해 진행 중이던 터치 획을 버리고 펜에 우선권을 준다. 그 외 추가 포인터(손바닥/보조 손가락)는 무시해 선 섞임을 막는다
+      const penTakesOver = e.pointerType === "pen" && activePointerType.current === "touch";
+      if (!penTakesOver) return;
+      if (canvas.hasPointerCapture(activePointerId.current))
+        canvas.releasePointerCapture(activePointerId.current);
+      currentStroke.current = null;
+      drawStrokes(strokesRef.current);
+    }
+
     activePointerId.current = e.pointerId;
+    activePointerType.current = e.pointerType;
     canvas.setPointerCapture(e.pointerId);
 
     const point = getPoint(e);
@@ -179,6 +202,7 @@ const HandwritingCanvas = ({ teamId, value, onChange, onClear }: HandwritingCanv
     const canvas = canvasRef.current;
     if (canvas?.hasPointerCapture(e.pointerId)) canvas.releasePointerCapture(e.pointerId);
     activePointerId.current = null;
+    activePointerType.current = null;
     commitCurrentStroke();
   };
 
@@ -214,7 +238,7 @@ const HandwritingCanvas = ({ teamId, value, onChange, onClear }: HandwritingCanv
   };
 
   return (
-    <div className="w-full flex flex-col gap-12 bg-white border border-gray-100 rounded-xl p-22">
+    <div className="w-full flex flex-col gap-12 bg-white border border-gray-100 rounded-xl p-22 select-none">
       <div className="flex items-center justify-between gap-10">
         <h2 className="text-body3b">메모</h2>
         <button type="button" onClick={handleClear} className="text-caption1r text-gray-500 underline">


### PR DESCRIPTION
## 💡 PR 요약

> 심사 페이지 손글씨 메모를 아이패드(애플펜슬/손가락)로 작성할 때 획이 끊기고, 필기 중 페이지가 드래그되는 문제 수정

- 필기 중 페이지 스크롤(드래그) 및 획 끊김 방지
- 애플펜슬 우선권 부여 + 손가락 입력 유지
- 상단 툴바 텍스트 선택 드래그 방지

## 📋 작업 내용

**1. 획 끊김 + 페이지 드래그 (`touchstart`/`touchmove` 기본동작)**
- iOS Safari는 React가 등록하는 passive 리스너에서 `preventDefault` 가 동작하지 않아, 필기 중 페이지가 스크롤되고 그 과정에서 `pointercancel` 이 발생해 획이 중간에 끊김
- 캔버스에 네이티브 non-passive `touchstart`/`touchmove` 리스너를 붙여 기본 스크롤 동작을 직접 차단 → 스크롤/끊김 동시 해결

**2. 애플펜슬 우선권 (팜리젝션)**
- 손바닥(터치)이 펜보다 먼저 캔버스에 닿으면 손바닥이 포인터를 선점해 펜 입력이 무시되던 문제
- 펜이 나중에 닿으면 진행 중이던 터치 획을 폐기하고 펜에 우선권을 넘김
- 펜 스트로크 진행 중 추가로 닿는 손바닥/보조 터치는 무시

**3. 손가락 입력 유지**
- 펜을 쓰지 않는 경우 손가락 터치로도 그대로 필기 가능

**4. 상단 툴바 드래그 방지**
- 메모 제목/지우기/화살표/펜 선택 영역에서 텍스트 선택 드래그가 발생하던 문제를 컨테이너 `select-none` 으로 차단

## 🤝 리뷰 시 참고사항

- 실기기(아이패드) 테스트에서 확인 부탁드립니다. 특히 애플펜슬 + 손바닥 동시 사용, 손가락 단독 필기 두 케이스 모두 정상 동작하는지 봐주시면 좋겠습니다.
- 팜리젝션은 "한 번에 하나의 포인터만 필기"를 전제로 하며, 펜이 없을 때는 첫 터치가 우선입니다.