### PR TITLE
fix: 심사 채점 화면 글씨 및 버튼 크기/모양 개선

### DIFF
--- a/src/widgets/judging/ui/ScoreForm/index.tsx
+++ b/src/widgets/judging/ui/ScoreForm/index.tsx
@@ -40,12 +40,12 @@ const ScoreForm = ({
       <h2 className="text-body3b">채점</h2>
 
       <div className="w-full border border-gray-100 rounded-xl overflow-hidden">
-        <div className="grid grid-cols-3 text-center text-caption1b bg-gray-50 py-12 mobile:text-caption2b">
+        <div className="grid grid-cols-3 text-center text-body3b bg-gray-50 py-12 mobile:text-caption1b">
           {EVALUATION_CRITERIA.map(({ key, label }) => (
             <div key={key}>
               {label}
               <br />
-              <span className="text-caption2r text-gray-400">(최대 {SCORE_MAX[key]}점)</span>
+              <span className="text-body3r text-gray-400">(최대 {SCORE_MAX[key]}점)</span>
             </div>
           ))}
         </div>
@@ -63,7 +63,7 @@ const ScoreForm = ({
                       type="button"
                       onClick={() => onChange(key, Math.max(score[key] + step, 0))}
                       aria-label={`${label} ${-step}점 내리기`}
-                      className="w-44 h-44 mobile:w-28 mobile:h-28 rounded-full border border-gray-200 text-gray-600 text-body3b mobile:text-caption2b hover:bg-gray-50 active:bg-gray-100 transition-colors touch-manipulation select-none"
+                      className="w-52 h-52 mobile:w-32 mobile:h-32 rounded-md border border-gray-200 text-gray-600 text-body3b mobile:text-caption2b hover:bg-gray-50 active:bg-gray-100 transition-colors touch-manipulation select-none"
                     >
                       {step}
                     </button>
@@ -79,7 +79,7 @@ const ScoreForm = ({
                       type="button"
                       onClick={() => onChange(key, Math.min(score[key] + step, maxAllowed))}
                       aria-label={`${label} ${step}점 올리기`}
-                      className="w-44 h-44 mobile:w-28 mobile:h-28 rounded-full border border-orange-300 text-orange-500 text-body3b mobile:text-caption2b hover:bg-orange-50 active:bg-orange-100 transition-colors touch-manipulation select-none"
+                      className="w-52 h-52 mobile:w-32 mobile:h-32 rounded-md border border-orange-300 text-orange-500 text-body3b mobile:text-caption2b hover:bg-orange-50 active:bg-orange-100 transition-colors touch-manipulation select-none"
                     >
                       +{step}
                     </button>


### PR DESCRIPTION
## 💡 PR 요약

> 심사 채점 화면의 가독성과 조작 편의성을 높이기 위한 UI 조정입니다.

- 평가 항목명 및 최대 점수 표시 글씨 크기 확대
- 가점/감점 버튼 크기 확대 및 모양을 원형에서 사각형으로 변경

## 📋 작업 내용

- `ScoreForm` 평가 항목 헤더 텍스트 한 단계 확대 (`caption1b` → `body3b`, 모바일 `caption2b` → `caption1b`)
- 최대 점수 표시(`(최대 40점)` 등)를 항목명과 동일한 크기로 확대 (`caption2r` → `body3r`)
- 가점/감점 버튼(-5, -1, +1, +5) 크기 확대 (`w-44 h-44` → `w-52 h-52`, 모바일 `w-28 h-28` → `w-32 h-32`)
- 버튼 모양을 원형(`rounded-full`)에서 저장 버튼과 통일된 사각형(`rounded-md`)으로 변경

## 🤝 리뷰 시 참고사항

- 저장 버튼과 현재 점수 표시는 이번 요청 범위 밖이라 변경하지 않았습니다
- 데스크톱/모바일 뷰포트 모두에서 버튼 크기·모양·텍스트 확대 여부 확인 부탁드립니다
