### PR TITLE
feat: 심사위원 정보 섹션 및 필기 자동저장 구현

### DIFF
--- a/src/entities/judge/api/judgeProfile.ts
+++ b/src/entities/judge/api/judgeProfile.ts
@@ -1,0 +1,17 @@
+import instance from "@/shared/lib/axios";
+import { JudgeProfile, ProfileStroke } from "../model/types";
+
+const toStrokes = (value: unknown): ProfileStroke[] => (Array.isArray(value) ? value : []);
+
+export const getJudgeProfile = async (): Promise<JudgeProfile> => {
+  const { data } = await instance.get<Partial<JudgeProfile>>("/judge/profile");
+  return {
+    affiliationStrokes: toStrokes(data?.affiliationStrokes),
+    positionStrokes: toStrokes(data?.positionStrokes),
+    nameStrokes: toStrokes(data?.nameStrokes),
+  };
+};
+
+export const putJudgeProfile = async (profile: JudgeProfile): Promise<void> => {
+  await instance.put("/judge/profile", profile);
+};

--- a/src/entities/judge/model/types.ts
+++ b/src/entities/judge/model/types.ts
@@ -1,0 +1,8 @@
+export type ProfilePoint = { x: number; y: number };
+export type ProfileStroke = ProfilePoint[];
+
+export interface JudgeProfile {
+  affiliationStrokes: ProfileStroke[];
+  positionStrokes: ProfileStroke[];
+  nameStrokes: ProfileStroke[];
+}

--- a/src/entities/judge/model/useJudgeProfile.ts
+++ b/src/entities/judge/model/useJudgeProfile.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { getJudgeProfile, putJudgeProfile } from "../api/judgeProfile";
+import { JudgeProfile } from "./types";
+
+export const judgeProfileQueryKey = ["judgeProfile"];
+
+export const useGetJudgeProfile = (enabled: boolean) =>
+  useQuery<JudgeProfile, Error>({
+    queryKey: judgeProfileQueryKey,
+    queryFn: getJudgeProfile,
+    enabled,
+    staleTime: 1000 * 60,
+  });
+
+export const usePutJudgeProfile = () =>
+  useMutation<void, Error, JudgeProfile>({
+    mutationFn: putJudgeProfile,
+    onError: () => toast.error("심사위원 정보 저장에 실패했습니다."),
+  });

--- a/src/views/home/ui/HomePage/index.tsx
+++ b/src/views/home/ui/HomePage/index.tsx
@@ -4,6 +4,7 @@ import dynamic from "next/dynamic";
 import IntroFirstSection from "@/widgets/main/IntroFirstSection";
 import SloganSecondSection from "@/widgets/main/SloganSecondSection";
 import JudgingCtaSection from "@/widgets/main/JudgingCtaSection";
+import JudgeInfoSection from "@/widgets/main/JudgeInfoSection";
 
 import LazySection from "@/shared/ui/LazySection";
 import SloganPosterPopup from "@/widgets/main/SloganPosterPopup";
@@ -46,6 +47,7 @@ const HomePage = () => {
     <>
       <SloganPosterPopup />
       <IntroFirstSection />
+      <JudgeInfoSection />
       <SloganSecondSection />
 
       <LazySection

--- a/src/widgets/main/JudgeInfoSection/index.tsx
+++ b/src/widgets/main/JudgeInfoSection/index.tsx
@@ -29,13 +29,13 @@ const JudgeInfoSection = () => {
       <div className="mx-auto flex w-full max-w-[1280px] flex-col gap-32">
         <h2 className="text-title2b text-gray-900 mobile:text-h4b">심사위원 정보</h2>
 
-        <div className="overflow-hidden rounded-xl border border-gray-200">
+        <div className="overflow-hidden rounded-xl border-2 border-gray-300">
           {INFO_FIELDS.map((field, index) => (
             <div
               key={field}
-              className={cn("flex items-stretch", index > 0 && "border-t border-gray-200")}
+              className={cn("flex items-stretch", index > 0 && "border-t-2 border-gray-300")}
             >
-              <div className="flex w-[180px] shrink-0 items-center justify-center border-r border-gray-200 bg-gray-50 text-body2b text-gray-900 mobile:w-[88px] mobile:text-body3b">
+              <div className="flex w-[180px] shrink-0 items-center justify-center border-r-2 border-gray-300 bg-gray-50 text-body2b text-gray-900 mobile:w-[88px] mobile:text-body3b">
                 {field}
               </div>
               <div className="min-w-0 flex-1">

--- a/src/widgets/main/JudgeInfoSection/index.tsx
+++ b/src/widgets/main/JudgeInfoSection/index.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Button from "@/shared/ui/Button";
+import { RightArrow } from "@/shared/asset/svg/RightArrow";
+import { cn } from "@/shared/utils/cn";
+import { getTokenFromCookie } from "@/shared/utils/auth";
+import PenField from "./ui/PenField";
+
+const INFO_FIELDS = ["소속", "지위", "이름"];
+const JUDGING_HREF = "/admin/evaluation";
+
+const JudgeInfoSection = () => {
+  const router = useRouter();
+  const [userRole, setUserRole] = useState<string | null>(null);
+
+  useEffect(() => {
+    setUserRole(getTokenFromCookie("role"));
+  }, []);
+
+  if (userRole !== "JUDGE") return null;
+
+  return (
+    <section
+      id="JudgeInfoSection"
+      className="w-full bg-white px-40 py-40 mobile:px-16 tablet:px-24"
+    >
+      <div className="mx-auto flex w-full max-w-[1280px] flex-col gap-32">
+        <h2 className="text-title2b text-gray-900 mobile:text-h4b">심사위원 정보</h2>
+
+        <div className="overflow-hidden rounded-xl border border-gray-200">
+          {INFO_FIELDS.map((field, index) => (
+            <div
+              key={field}
+              className={cn("flex items-stretch", index > 0 && "border-t border-gray-200")}
+            >
+              <div className="flex w-[180px] shrink-0 items-center justify-center border-r border-gray-200 bg-gray-50 text-body2b text-gray-900 mobile:w-[88px] mobile:text-body3b">
+                {field}
+              </div>
+              <div className="min-w-0 flex-1">
+                <PenField />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex justify-end mobile:justify-center">
+          <Button
+            type="button"
+            onClick={() => router.push(JUDGING_HREF)}
+            className="h-[72px] rounded-xl px-48 mobile:w-full"
+          >
+            <span className="flex items-center justify-center gap-12 text-body1b">
+              심사하러 가기
+              <RightArrow color="white" />
+            </span>
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default JudgeInfoSection;

--- a/src/widgets/main/JudgeInfoSection/index.tsx
+++ b/src/widgets/main/JudgeInfoSection/index.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Button from "@/shared/ui/Button";
 import { RightArrow } from "@/shared/asset/svg/RightArrow";
-import { cn } from "@/shared/utils/cn";
 import { getTokenFromCookie } from "@/shared/utils/auth";
 import PenField from "./ui/PenField";
 
@@ -29,16 +28,16 @@ const JudgeInfoSection = () => {
       <div className="mx-auto flex w-full max-w-[1280px] flex-col gap-32">
         <h2 className="text-title2b text-gray-900 mobile:text-h4b">심사위원 정보</h2>
 
-        <div className="overflow-hidden rounded-xl border border-gray-200">
-          {INFO_FIELDS.map((field, index) => (
+        <div className="flex flex-col gap-16">
+          {INFO_FIELDS.map(field => (
             <div
               key={field}
-              className={cn("flex items-stretch", index > 0 && "border-t border-gray-300")}
+              className="flex overflow-hidden rounded-2xl border border-solid border-gray-200 bg-white shadow-sm"
             >
-              <div className="flex w-[180px] shrink-0 items-center justify-center border-r border-gray-200 bg-gray-50 text-body2b text-gray-900 mobile:w-[88px] mobile:text-body3b">
+              <div className="flex w-[180px] shrink-0 items-center justify-center border-r border-solid border-gray-200 bg-gray-50 text-body1b text-gray-900 mobile:w-[88px] mobile:text-body2b">
                 {field}
               </div>
-              <div className="min-w-0 flex-1">
+              <div className="flex-1">
                 <PenField />
               </div>
             </div>

--- a/src/widgets/main/JudgeInfoSection/index.tsx
+++ b/src/widgets/main/JudgeInfoSection/index.tsx
@@ -29,13 +29,13 @@ const JudgeInfoSection = () => {
       <div className="mx-auto flex w-full max-w-[1280px] flex-col gap-32">
         <h2 className="text-title2b text-gray-900 mobile:text-h4b">심사위원 정보</h2>
 
-        <div className="overflow-hidden rounded-xl border-2 border-gray-300">
+        <div className="overflow-hidden rounded-xl border border-gray-200">
           {INFO_FIELDS.map((field, index) => (
             <div
               key={field}
-              className={cn("flex items-stretch", index > 0 && "border-t-2 border-gray-300")}
+              className={cn("flex items-stretch", index > 0 && "border-t border-gray-300")}
             >
-              <div className="flex w-[180px] shrink-0 items-center justify-center border-r-2 border-gray-300 bg-gray-50 text-body2b text-gray-900 mobile:w-[88px] mobile:text-body3b">
+              <div className="flex w-[180px] shrink-0 items-center justify-center border-r border-gray-200 bg-gray-50 text-body2b text-gray-900 mobile:w-[88px] mobile:text-body3b">
                 {field}
               </div>
               <div className="min-w-0 flex-1">

--- a/src/widgets/main/JudgeInfoSection/index.tsx
+++ b/src/widgets/main/JudgeInfoSection/index.tsx
@@ -1,22 +1,58 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Button from "@/shared/ui/Button";
 import { RightArrow } from "@/shared/asset/svg/RightArrow";
 import { getTokenFromCookie } from "@/shared/utils/auth";
+import { useGetJudgeProfile, usePutJudgeProfile } from "@/entities/judge/model/useJudgeProfile";
+import { JudgeProfile } from "@/entities/judge/model/types";
 import PenField from "./ui/PenField";
 
-const INFO_FIELDS = ["소속", "지위", "이름"];
+const INFO_FIELDS = [
+  { key: "affiliationStrokes", label: "소속" },
+  { key: "positionStrokes", label: "지위" },
+  { key: "nameStrokes", label: "이름" },
+] as const;
+
+const EMPTY_PROFILE: JudgeProfile = {
+  affiliationStrokes: [],
+  positionStrokes: [],
+  nameStrokes: [],
+};
+
+const SAVE_DEBOUNCE_MS = 800;
 const JUDGING_HREF = "/admin/evaluation";
 
 const JudgeInfoSection = () => {
   const router = useRouter();
   const [userRole, setUserRole] = useState<string | null>(null);
+  const [, setProfile] = useState<JudgeProfile>(EMPTY_PROFILE);
 
   useEffect(() => {
     setUserRole(getTokenFromCookie("role"));
   }, []);
+
+  const { data } = useGetJudgeProfile(userRole === "JUDGE");
+  const { mutate: saveProfile } = usePutJudgeProfile();
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (data) setProfile(data);
+  }, [data]);
+
+  useEffect(() => () => clearTimeout(saveTimer.current ?? undefined), []);
+
+  const handleStrokesChange = (key: keyof JudgeProfile, strokes: JudgeProfile[keyof JudgeProfile]) => {
+    setProfile(prev => {
+      const next = { ...prev, [key]: strokes };
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+      saveTimer.current = setTimeout(() => saveProfile(next), SAVE_DEBOUNCE_MS);
+      return next;
+    });
+  };
+
+  const handleSubmit = () => router.push(JUDGING_HREF);
 
   if (userRole !== "JUDGE") return null;
 
@@ -29,16 +65,19 @@ const JudgeInfoSection = () => {
         <h2 className="text-title2b text-gray-900 mobile:text-h4b">심사위원 정보</h2>
 
         <div className="flex flex-col gap-16">
-          {INFO_FIELDS.map(field => (
+          {INFO_FIELDS.map(({ key, label }) => (
             <div
-              key={field}
+              key={key}
               className="flex overflow-hidden rounded-2xl border border-solid border-gray-200 bg-white shadow-sm"
             >
               <div className="flex w-[180px] shrink-0 items-center justify-center border-r border-solid border-gray-200 bg-gray-50 text-body1b text-gray-900 mobile:w-[88px] mobile:text-body2b">
-                {field}
+                {label}
               </div>
               <div className="flex-1">
-                <PenField />
+                <PenField
+                  value={data ? data[key] : undefined}
+                  onChange={strokes => handleStrokesChange(key, strokes)}
+                />
               </div>
             </div>
           ))}
@@ -47,7 +86,7 @@ const JudgeInfoSection = () => {
         <div className="flex justify-end mobile:justify-center">
           <Button
             type="button"
-            onClick={() => router.push(JUDGING_HREF)}
+            onClick={handleSubmit}
             className="h-[72px] rounded-xl px-48 mobile:w-full"
           >
             <span className="flex items-center justify-center gap-12 text-body1b">

--- a/src/widgets/main/JudgeInfoSection/ui/PenField.tsx
+++ b/src/widgets/main/JudgeInfoSection/ui/PenField.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { PointerEvent as ReactPointerEvent } from "react";
+
+type Point = { x: number; y: number };
+type Stroke = Point[];
+
+const LINE_WIDTH = 2;
+const PEN_COLOR = "#121212";
+const MIN_POINT_DISTANCE = 0.003;
+
+const PenField = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const strokesRef = useRef<Stroke[]>([]);
+  const currentStroke = useRef<Stroke | null>(null);
+  const activePointerId = useRef<number | null>(null);
+  const activePointerType = useRef<string | null>(null);
+
+  const draw = () => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext("2d");
+    if (!canvas || !ctx) return;
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.lineCap = "round";
+    ctx.lineWidth = LINE_WIDTH * (window.devicePixelRatio || 1);
+    ctx.strokeStyle = PEN_COLOR;
+
+    strokesRef.current.forEach(stroke => {
+      if (stroke.length === 0) return;
+      ctx.beginPath();
+      stroke.forEach((point, index) => {
+        const x = point.x * canvas.width;
+        const y = point.y * canvas.height;
+        if (index === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      });
+      ctx.stroke();
+    });
+  };
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const rect = canvas.getBoundingClientRect();
+      canvas.width = Math.round(rect.width * dpr);
+      canvas.height = Math.round(rect.height * dpr);
+      draw();
+    };
+
+    resize();
+    const observer = new ResizeObserver(resize);
+    observer.observe(canvas);
+    return () => observer.disconnect();
+  }, []);
+
+  // iOS는 passive 리스너로 preventDefault가 막히지 않아 필기 중 페이지가 스크롤되고 pointercancel로 획이 끊긴다. 네이티브 non-passive 리스너로 기본동작을 직접 막는다
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const prevent = (e: TouchEvent) => e.preventDefault();
+    canvas.addEventListener("touchstart", prevent, { passive: false });
+    canvas.addEventListener("touchmove", prevent, { passive: false });
+    return () => {
+      canvas.removeEventListener("touchstart", prevent);
+      canvas.removeEventListener("touchmove", prevent);
+    };
+  }, []);
+
+  const getPoint = (e: ReactPointerEvent<HTMLCanvasElement>): Point => {
+    const canvas = canvasRef.current;
+    if (!canvas) return { x: 0, y: 0 };
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: (e.clientX - rect.left) / rect.width,
+      y: (e.clientY - rect.top) / rect.height,
+    };
+  };
+
+  const handlePointerDown = (e: ReactPointerEvent<HTMLCanvasElement>) => {
+    e.preventDefault();
+
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext("2d");
+    if (!canvas || !ctx) return;
+
+    if (activePointerId.current !== null) {
+      // 손가락으로 쓰던 중 펜이 닿으면 손바닥으로 판단해 진행 중이던 터치 획을 버리고 펜에 우선권을 준다
+      const penTakesOver = e.pointerType === "pen" && activePointerType.current === "touch";
+      if (!penTakesOver) return;
+      if (canvas.hasPointerCapture(activePointerId.current))
+        canvas.releasePointerCapture(activePointerId.current);
+      currentStroke.current = null;
+      draw();
+    }
+
+    activePointerId.current = e.pointerId;
+    activePointerType.current = e.pointerType;
+    canvas.setPointerCapture(e.pointerId);
+
+    const point = getPoint(e);
+    currentStroke.current = [point];
+
+    ctx.lineCap = "round";
+    ctx.lineWidth = LINE_WIDTH * (window.devicePixelRatio || 1);
+    ctx.strokeStyle = PEN_COLOR;
+    ctx.beginPath();
+    ctx.moveTo(point.x * canvas.width, point.y * canvas.height);
+  };
+
+  const handlePointerMove = (e: ReactPointerEvent<HTMLCanvasElement>) => {
+    if (e.pointerId !== activePointerId.current) return;
+    e.preventDefault();
+
+    const stroke = currentStroke.current;
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext("2d");
+    if (!stroke || !canvas || !ctx) return;
+
+    const point = getPoint(e);
+    const last = stroke[stroke.length - 1];
+    if (Math.hypot(point.x - last.x, point.y - last.y) < MIN_POINT_DISTANCE) return;
+
+    stroke.push(point);
+    ctx.lineTo(point.x * canvas.width, point.y * canvas.height);
+    ctx.stroke();
+  };
+
+  const handlePointerEnd = (e: ReactPointerEvent<HTMLCanvasElement>) => {
+    if (e.pointerId !== activePointerId.current) return;
+    const canvas = canvasRef.current;
+    if (canvas?.hasPointerCapture(e.pointerId)) canvas.releasePointerCapture(e.pointerId);
+    activePointerId.current = null;
+    activePointerType.current = null;
+
+    const stroke = currentStroke.current;
+    currentStroke.current = null;
+    if (stroke && stroke.length > 0) strokesRef.current = [...strokesRef.current, stroke];
+  };
+
+  const handleClear = () => {
+    currentStroke.current = null;
+    strokesRef.current = [];
+    draw();
+  };
+
+  return (
+    <div className="relative h-[160px] w-full mobile:h-[132px]">
+      <button
+        type="button"
+        onClick={handleClear}
+        className="absolute right-10 top-10 z-10 text-caption1r text-gray-400 underline"
+      >
+        지우기
+      </button>
+      <canvas
+        ref={canvasRef}
+        className="h-full w-full touch-none select-none bg-white"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerEnd}
+        onPointerCancel={handlePointerEnd}
+        onLostPointerCapture={handlePointerEnd}
+      />
+    </div>
+  );
+};
+
+export default PenField;

--- a/src/widgets/main/JudgeInfoSection/ui/PenField.tsx
+++ b/src/widgets/main/JudgeInfoSection/ui/PenField.tsx
@@ -2,20 +2,27 @@
 
 import { useEffect, useRef } from "react";
 import type { PointerEvent as ReactPointerEvent } from "react";
+import { ProfilePoint, ProfileStroke } from "@/entities/judge/model/types";
 
-type Point = { x: number; y: number };
-type Stroke = Point[];
+type Point = ProfilePoint;
+type Stroke = ProfileStroke;
+
+type PenFieldProps = {
+  value?: Stroke[];
+  onChange?: (strokes: Stroke[]) => void;
+};
 
 const LINE_WIDTH = 2;
 const PEN_COLOR = "#121212";
 const MIN_POINT_DISTANCE = 0.003;
 
-const PenField = () => {
+const PenField = ({ value, onChange }: PenFieldProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const strokesRef = useRef<Stroke[]>([]);
   const currentStroke = useRef<Stroke | null>(null);
   const activePointerId = useRef<number | null>(null);
   const activePointerType = useRef<string | null>(null);
+  const hydratedRef = useRef(false);
 
   const draw = () => {
     const canvas = canvasRef.current;
@@ -70,6 +77,14 @@ const PenField = () => {
       canvas.removeEventListener("touchmove", prevent);
     };
   }, []);
+
+  // 저장된 필기를 최초 1회만 캔버스에 복원한다. 이후 사용자가 그리며 발생시킨 onChange가 value로 되돌아와도 무시해 그림이 초기화되지 않게 한다
+  useEffect(() => {
+    if (hydratedRef.current || value === undefined) return;
+    hydratedRef.current = true;
+    strokesRef.current = value;
+    draw();
+  }, [value]);
 
   const getPoint = (e: ReactPointerEvent<HTMLCanvasElement>): Point => {
     const canvas = canvasRef.current;
@@ -139,13 +154,17 @@ const PenField = () => {
 
     const stroke = currentStroke.current;
     currentStroke.current = null;
-    if (stroke && stroke.length > 0) strokesRef.current = [...strokesRef.current, stroke];
+    if (stroke && stroke.length > 0) {
+      strokesRef.current = [...strokesRef.current, stroke];
+      onChange?.(strokesRef.current);
+    }
   };
 
   const handleClear = () => {
     currentStroke.current = null;
     strokesRef.current = [];
     draw();
+    onChange?.(strokesRef.current);
   };
 
   return (

--- a/src/widgets/main/JudgeInfoSection/ui/PenField.tsx
+++ b/src/widgets/main/JudgeInfoSection/ui/PenField.tsx
@@ -153,7 +153,7 @@ const PenField = () => {
       <button
         type="button"
         onClick={handleClear}
-        className="absolute right-12 top-12 z-10 rounded-md border border-gray-300 bg-white px-16 py-8 text-body3b text-gray-600"
+        className="absolute right-12 top-12 z-10 rounded-lg border border-solid border-gray-200 bg-white px-16 py-8 text-body3b text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-700"
       >
         지우기
       </button>

--- a/src/widgets/main/JudgeInfoSection/ui/PenField.tsx
+++ b/src/widgets/main/JudgeInfoSection/ui/PenField.tsx
@@ -153,7 +153,7 @@ const PenField = () => {
       <button
         type="button"
         onClick={handleClear}
-        className="absolute right-10 top-10 z-10 text-caption1r text-gray-400 underline"
+        className="absolute right-12 top-12 z-10 rounded-md border border-gray-300 bg-white px-16 py-8 text-body3b text-gray-600"
       >
         지우기
       </button>


### PR DESCRIPTION
## 💡 PR 요약

> 해당 PR의 변경사항, 해당 이슈 등에 대한 간략한 설명을 작성해주세요.

- 심사위원(JUDGE)이 소속/지위/이름을 펜으로 직접 필기하는 심사위원 정보 섹션을 추가했습니다.
- 필기 영역을 카드형 UI로 퍼블리싱하고, 획을 그리거나 지울 때마다 자동으로 서버에 저장되도록 API를 연결했습니다.

## 📋 작업 내용

> 해당 PR에서 작업한 내용을 자세히 설명해주세요.

- **섹션 퍼블리싱 및 펜 필기 UI**
  - `JudgeInfoSection`을 추가하고, 소속·지위·이름 3개 필드를 `PenField`(canvas) 기반 필기 영역으로 구성했습니다.
  - `userRole`이 `JUDGE`일 때만 섹션을 렌더링하며, 하단에 심사 페이지로 이동하는 "심사하러 가기" 버튼을 배치했습니다.
- **카드형 UI 개선**
  - 표를 둥근 모서리 + gray-200 얇은 테두리의 카드형으로 개선하고, 라벨 영역과 필기 영역을 구분선으로 분리했습니다.
  - 지우기 버튼을 확대하고 칸 구분을 강화했습니다.
- **조회·자동저장 API 연결 (`entities/judge`)**
  - `GET /judge/profile`로 저장된 필기를 조회하고, `PUT /judge/profile`로 저장하는 API 및 TanStack Query 훅(`useGetJudgeProfile`, `usePutJudgeProfile`)을 추가했습니다.
  - 마운트 시 GET으로 저장된 필기를 복원하고, 획을 그리거나 지울 때마다 800ms 디바운스로 자동 저장(PUT)합니다.
  - `strokes`는 `ProfileStroke[]`(좌표 배열) 형태의 JSON으로 왕복하며, 응답이 배열이 아닐 경우 빈 배열로 방어 처리했습니다.

## 🤝 리뷰 시 참고사항

> 리뷰어분들이 리뷰를 할 때 참고하면 좋을 사항이나 질문사항을 작성해주세요.

- 자동 저장은 `SAVE_DEBOUNCE_MS = 800` 상수로 관리하며, 언마운트 시 타이머를 정리합니다.
- `GET /judge/profile` 조회는 `userRole === "JUDGE"`일 때만 `enabled` 되도록 처리했습니다.