### PR TITLE
feat: 심사 화면 UI 확대 및 인터랙션 개선

### DIFF
--- a/src/entities/apply/ui/DescriptionCard/index.tsx
+++ b/src/entities/apply/ui/DescriptionCard/index.tsx
@@ -2,16 +2,22 @@ type DescriptionCardProps = {
   title: string;
   items: string[];
   renderCustomItem?: (item: string, index: number) => React.ReactNode;
+  large?: boolean;
 };
 
-export const DescriptionCard = ({ title, items, renderCustomItem }: DescriptionCardProps) => {
+export const DescriptionCard = ({
+  title,
+  items,
+  renderCustomItem,
+  large = false,
+}: DescriptionCardProps) => {
   return (
     <div className="bg-white border border-gray-100 border-l-4 border-l-orange-400 rounded-xl p-22">
-      <h2 className="text-body3b mb-16">{title}</h2>
-      <ul className="text-gray-500 space-y-8 text-body3r">
+      <h2 className={`${large ? "text-body1b" : "text-body3b"} mb-16`}>{title}</h2>
+      <ul className={`text-gray-600 space-y-8 ${large ? "text-body2r" : "text-body3r"}`}>
         {items.map((item, index) => (
           <li key={index} className="flex gap-8 items-start">
-            <span className="mt-10 shrink-0 w-6 h-6 rounded-full bg-orange-400" />
+            <span className={`mt-10 shrink-0 rounded-full bg-orange-400 ${large ? "w-8 h-8" : "w-6 h-6"}`} />
             <span>{renderCustomItem ? renderCustomItem(item, index) : item}</span>
           </li>
         ))}

--- a/src/views/judging/ui/JudgingPage/index.tsx
+++ b/src/views/judging/ui/JudgingPage/index.tsx
@@ -72,10 +72,10 @@ const JudgingPage = () => {
         {selectedTeamId === null || !selectedTeam ? (
           <div className="h-24 w-160 rounded bg-gray-100 animate-pulse" />
         ) : (
-          <h2 className="text-body2b">{selectedTeam.teamName} 심사</h2>
+          <h2 className="text-body1b">{selectedTeam.teamName} 심사</h2>
         )}
 
-        <DescriptionCard title={`심사 기준 (총 ${TOTAL_MAX}점)`} items={CRITERIA_ITEMS} />
+        <DescriptionCard title={`심사 기준 (총 ${TOTAL_MAX}점)`} items={CRITERIA_ITEMS} large />
 
         {selectedTeamId === null || score === null ? (
           <div className="h-260 w-full rounded-xl bg-gray-100 animate-pulse" />

--- a/src/widgets/judging/ui/HandwritingCanvas/index.tsx
+++ b/src/widgets/judging/ui/HandwritingCanvas/index.tsx
@@ -238,37 +238,41 @@ const HandwritingCanvas = ({ teamId, value, onChange, onClear }: HandwritingCanv
   };
 
   return (
-    <div className="w-full flex flex-col gap-12 bg-white border border-gray-100 rounded-xl p-22 select-none">
+    <div className="w-full flex flex-col gap-16 bg-white border border-gray-100 rounded-xl p-22 select-none">
       <div className="flex items-center justify-between gap-10">
-        <h2 className="text-body3b">메모</h2>
-        <button type="button" onClick={handleClear} className="text-caption1r text-gray-500 underline">
+        <h2 className="text-body1b">심사 의견</h2>
+        <button
+          type="button"
+          onClick={handleClear}
+          className="text-body2b text-gray-600 px-24 py-12 rounded-lg border border-gray-200 hover:bg-gray-50 active:bg-gray-100 transition-colors"
+        >
           지우기
         </button>
       </div>
 
       <div className="flex items-center justify-between gap-10 flex-wrap">
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-10">
           <button
             type="button"
             onClick={handleUndo}
             disabled={strokes.length === 0}
             aria-label="뒤로가기"
-            className="w-22 h-22 rounded-full border border-gray-200 flex items-center justify-center hover:bg-gray-50 disabled:opacity-30 disabled:hover:bg-transparent transition-colors"
+            className="w-48 h-48 rounded-full border border-gray-300 flex items-center justify-center cursor-pointer hover:bg-gray-200 hover:border-gray-400 active:bg-gray-300 active:scale-95 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:border-gray-300 disabled:active:scale-100 transition"
           >
-            <LeftArrow height={12} width={12} color="#4E4E4E" />
+            <LeftArrow height={22} width={22} color="#121212" />
           </button>
           <button
             type="button"
             onClick={handleRedo}
             disabled={redoStack.length === 0}
             aria-label="앞으로가기"
-            className="w-22 h-22 rounded-full border border-gray-200 flex items-center justify-center hover:bg-gray-50 disabled:opacity-30 disabled:hover:bg-transparent transition-colors"
+            className="w-48 h-48 rounded-full border border-gray-300 flex items-center justify-center cursor-pointer hover:bg-gray-200 hover:border-gray-400 active:bg-gray-300 active:scale-95 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:border-gray-300 disabled:active:scale-100 transition"
           >
-            <RightArrow height={12} width={12} color="#4E4E4E" />
+            <RightArrow height={22} width={22} color="#121212" />
           </button>
         </div>
 
-        <div className="flex items-center gap-6">
+        <div className="flex items-center gap-12">
           {PEN_COLORS.map(color => {
             const isSelected = penColor === color.hex;
             return (
@@ -279,14 +283,14 @@ const HandwritingCanvas = ({ teamId, value, onChange, onClear }: HandwritingCanv
                 aria-label={`${color.key} 펜 선택`}
                 aria-pressed={isSelected}
                 className={cn(
-                  "relative w-18 h-18 rounded-full flex items-center justify-center transition-transform",
+                  "relative w-36 h-36 rounded-full flex items-center justify-center transition-transform",
                   color.swatchClass,
                   isSelected
                     ? "ring-2 ring-offset-2 ring-gray-500 scale-110"
                     : "opacity-50 hover:opacity-80",
                 )}
               >
-                {isSelected && <CheckIcon height={10} width={10} color="white" />}
+                {isSelected && <CheckIcon height={18} width={18} color="white" />}
               </button>
             );
           })}
@@ -297,7 +301,7 @@ const HandwritingCanvas = ({ teamId, value, onChange, onClear }: HandwritingCanv
         ref={canvasRef}
         width={640}
         height={320}
-        className="w-full h-[520px] tablet:h-[440px] mobile:h-[360px] touch-none select-none border border-gray-200 rounded-lg bg-white bg-[repeating-linear-gradient(180deg,transparent_0px,transparent_99px,#e2e2e2_99px,#e2e2e2_100px)]"
+        className="w-full h-[400px] mobile:h-[390px] touch-none select-none border border-gray-200 rounded-lg bg-white bg-[repeating-linear-gradient(180deg,transparent_0px,transparent_124px,#e2e2e2_124px,#e2e2e2_125px)]"
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerEnd}

--- a/src/widgets/judging/ui/ScoreForm/index.tsx
+++ b/src/widgets/judging/ui/ScoreForm/index.tsx
@@ -36,40 +36,39 @@ const ScoreForm = ({
   const total = getScoreTotal(score);
 
   return (
-    <div className="w-full flex flex-col gap-16">
-      <h2 className="text-body3b">채점</h2>
+    <div className="w-full flex flex-col gap-20">
+      <h2 className="text-body1b">채점</h2>
 
       <div className="w-full border border-gray-100 rounded-xl overflow-hidden">
-        <div className="grid grid-cols-3 text-center text-body3b bg-gray-50 py-12 mobile:text-caption1b">
+        <div className="grid grid-cols-3 text-center text-body1b bg-gray-50 py-16 mobile:text-body3b">
           {EVALUATION_CRITERIA.map(({ key, label }) => (
-            <div key={key}>
+            <div key={key} className="flex items-baseline justify-center gap-6 px-8">
               {label}
-              <br />
-              <span className="text-body3r text-gray-400">(최대 {SCORE_MAX[key]}점)</span>
+              <span className="text-body2r text-gray-400 mobile:text-caption1r">(최대 {SCORE_MAX[key]}점)</span>
             </div>
           ))}
         </div>
 
-        <div className="grid grid-cols-3 py-20 gap-16 mobile:py-16 mobile:gap-6">
+        <div className="grid grid-cols-3 py-28 gap-16 mobile:py-16 mobile:gap-6">
           {EVALUATION_CRITERIA.map(({ key, label, max }) => {
             const maxAllowed = Math.min(max, score[key] + (TOTAL_MAX - total));
 
             return (
               <div key={key} className="flex flex-col items-center justify-center gap-8 mobile:gap-2">
-                <div className="flex items-center gap-10 mobile:gap-4">
+                <div className="flex items-center gap-12 mobile:gap-4">
                   {NEGATIVE_STEPS.map(step => (
                     <button
                       key={step}
                       type="button"
                       onClick={() => onChange(key, Math.max(score[key] + step, 0))}
                       aria-label={`${label} ${-step}점 내리기`}
-                      className="w-52 h-52 mobile:w-32 mobile:h-32 rounded-md border border-gray-200 text-gray-600 text-body3b mobile:text-caption2b hover:bg-gray-50 active:bg-gray-100 transition-colors touch-manipulation select-none"
+                      className="w-64 h-64 mobile:w-48 mobile:h-48 rounded-lg border border-gray-200 text-gray-600 text-body1b mobile:text-caption1b cursor-pointer hover:bg-gray-100 hover:border-gray-300 active:bg-gray-200 active:scale-95 transition touch-manipulation select-none"
                     >
                       {step}
                     </button>
                   ))}
 
-                  <span className="w-44 mobile:w-32 text-center text-body1b mobile:text-body2b text-gray-900 tabular-nums">
+                  <span className="w-60 mobile:w-36 text-center text-title2b mobile:text-title4b text-gray-900 tabular-nums">
                     {score[key]}
                   </span>
 
@@ -79,7 +78,7 @@ const ScoreForm = ({
                       type="button"
                       onClick={() => onChange(key, Math.min(score[key] + step, maxAllowed))}
                       aria-label={`${label} ${step}점 올리기`}
-                      className="w-52 h-52 mobile:w-32 mobile:h-32 rounded-md border border-orange-300 text-orange-500 text-body3b mobile:text-caption2b hover:bg-orange-50 active:bg-orange-100 transition-colors touch-manipulation select-none"
+                      className="w-64 h-64 mobile:w-48 mobile:h-48 rounded-lg border border-orange-300 text-orange-500 text-body1b mobile:text-caption1b cursor-pointer hover:bg-orange-100 hover:border-orange-400 active:bg-orange-200 active:scale-95 transition touch-manipulation select-none"
                     >
                       +{step}
                     </button>
@@ -97,7 +96,12 @@ const ScoreForm = ({
         <StatChip label="현재 순위" value={rank !== null ? `${rank}위` : "-"} />
       </div>
 
-      <Button type="button" onClick={onSave} disabled={isSaving} className="w-full">
+      <Button
+        type="button"
+        onClick={onSave}
+        disabled={isSaving}
+        className="w-full h-64 text-body1b mobile:h-[50px] mobile:text-body3b"
+      >
         {isSaving ? "저장 중..." : "저장"}
       </Button>
     </div>
@@ -110,9 +114,9 @@ type StatChipProps = {
 };
 
 const StatChip = ({ label, value }: StatChipProps) => (
-  <div className="flex flex-col gap-4 rounded-2xl bg-orange-50 px-20 py-16 mobile:px-16 mobile:py-12">
-    <span className="text-caption1b text-gray-800">{label}</span>
-    <span className="text-title4b text-orange-500 mobile:text-body1b">{value}</span>
+  <div className="flex flex-col gap-8 rounded-2xl bg-orange-50 px-24 py-20 mobile:px-16 mobile:py-12">
+    <span className="text-body3b text-gray-800 mobile:text-caption1b">{label}</span>
+    <span className="text-title2b text-orange-500 mobile:text-body1b">{value}</span>
   </div>
 );
 


### PR DESCRIPTION
## 💡 PR 요약

> 해당 PR의 변경사항, 해당 이슈 등에 대한 간략한 설명을 작성해주세요.

- 심사 화면의 심사 기준 카드·제목·채점 영역·심사 의견 영역을 전반적으로 확대해 가독성과 조작성을 개선했어요.
- 채점 버튼과 화살표(뒤로/앞으로) 버튼에 호버·클릭(active:scale) 인터랙션을 추가했어요.
- 메모 라벨을 "심사 의견"으로 변경하고 필기 캔버스의 줄 간격·줄 수를 조정했어요.

## 📋 작업 내용

> 해당 PR에서 작업한 내용을 자세히 설명해주세요.

**1. 심사 기준 카드·제목 확대**
- `DescriptionCard`에 `large` prop을 추가해 제목·항목 텍스트와 불릿 크기를 확대할 수 있도록 했어요.
- 심사 페이지에서만 `large`를 적용하며, apply/result 등 기존 사용처는 기본값(`false`)이라 영향이 없어요.
- 심사 페이지 팀명 제목을 `text-body2b`에서 `text-body1b`로 확대했어요.

**2. 채점 영역 확대 및 버튼 인터랙션 추가**
- 채점 표의 제목·라벨·점수 표시 텍스트를 확대하고 세로 여백을 넓혔어요.
- +/- 버튼 크기를 키우고 호버·클릭(active:scale) 인터랙션과 커서 스타일을 추가했어요.
- 통계 칩(현재 순위 등)과 저장 버튼 크기를 확대했어요.

**3. 심사 의견 영역 확대 및 화살표 버튼 개선**
- "메모" 라벨을 "심사 의견"으로 변경했어요.
- 지우기·색상 선택·화살표(뒤로/앞으로) 버튼을 확대하고 호버·클릭 인터랙션을 개선했어요.
- 필기 줄 간격을 1.25배(100px → 125px)로 넓히고 줄 수를 3개로 조정했어요.

## 🤝 리뷰 시 참고사항

> 리뷰어분들이 리뷰를 할 때 참고하면 좋을 사항이나 질문사항을 작성해주세요.

- `DescriptionCard`의 `large` prop은 심사 페이지에서만 사용되며, 기본값이 `false`라 apply/result 페이지 렌더링에는 변화가 없어요.