### PR TITLE
feat: 예선 중계 2일차 영상 교체 및 자동재생 적용

### DIFF
--- a/src/shared/ui/YouTubeLazyEmbed/index.tsx
+++ b/src/shared/ui/YouTubeLazyEmbed/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/shared/utils/cn";
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import { useInView } from "react-intersection-observer";
 import Image from "next/image";
 import dynamic from "next/dynamic";
@@ -19,9 +19,10 @@ interface YouTubeLazyEmbedProps {
   videoId: string;
   title: string;
   className?: string;
+  autoPlay?: boolean;
 }
 
-const YouTubeLazyEmbed = ({ videoId, title, className }: YouTubeLazyEmbedProps) => {
+const YouTubeLazyEmbed = ({ videoId, title, className, autoPlay = false }: YouTubeLazyEmbedProps) => {
   const [isLoaded, setIsLoaded] = useState(false);
 
   const { ref, inView } = useInView({
@@ -29,6 +30,11 @@ const YouTubeLazyEmbed = ({ videoId, title, className }: YouTubeLazyEmbedProps) 
     rootMargin: "100px",
     triggerOnce: true,
   });
+
+  // autoPlay는 사용자 클릭 없이 재생되므로 브라우저 자동재생 정책상 음소거 필수
+  useEffect(() => {
+    if (autoPlay && inView) setIsLoaded(true);
+  }, [autoPlay, inView]);
 
   const thumbnailUrl = useMemo(
     () => `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`,
@@ -87,7 +93,7 @@ const YouTubeLazyEmbed = ({ videoId, title, className }: YouTubeLazyEmbedProps) 
         </div>
       ) : (
         <iframe
-          src={`https://www.youtube.com/embed/${videoId}?autoplay=1&rel=0&modestbranding=1`}
+          src={`https://www.youtube.com/embed/${videoId}?autoplay=1&rel=0&modestbranding=1${autoPlay ? "&mute=1" : ""}`}
           title={title}
           className="w-full h-full"
           allow="autoplay; encrypted-media"

--- a/src/widgets/main/PreliminaryLiveSection/index.tsx
+++ b/src/widgets/main/PreliminaryLiveSection/index.tsx
@@ -8,11 +8,11 @@ import YouTubeLazyEmbed from "@/shared/ui/YouTubeLazyEmbed";
 
 const LIVE_STREAMS = [
   { date: "7월 24일 (금)", label: "1일차", videoId: "nL0pdTRB6Hc" },
-  { date: "7월 25일 (토)", label: "2일차", videoId: "eR3Tx134-dU" },
+  { date: "7월 25일 (토)", label: "2일차", videoId: "518wlDEojOs" },
 ] as const;
 
 const PreliminaryLiveSection = () => {
-  const [activeDay, setActiveDay] = useState(0);
+  const [activeDay, setActiveDay] = useState(1);
   const activeStream = LIVE_STREAMS[activeDay];
 
   return (
@@ -71,6 +71,7 @@ const PreliminaryLiveSection = () => {
             key={activeStream.videoId}
             videoId={activeStream.videoId}
             title={`2026 광탈페 예선 ${activeStream.label} 실시간 중계`}
+            autoPlay
           />
         </div>
 


### PR DESCRIPTION
## 💡 PR 요약

> 해당 PR의 변경사항, 해당 이슈 등에 대한 간략한 설명을 작성해주세요.

- 메인 예선 실시간 중계 2일차 유튜브 영상을 교체했습니다 (videoId: `518wlDEojOs`)
- 페이지 진입 시 2일차 탭이 기본으로 선택되도록 변경했습니다
- 화면에 영상이 들어오면 클릭 없이 자동으로 재생되도록 자동재생을 적용했습니다

## 📋 작업 내용

> 해당 PR에서 작업한 내용을 자세히 설명해주세요.

- `YouTubeLazyEmbed` 공통 컴포넌트에 `autoPlay` prop을 추가했습니다.
  - `autoPlay`가 켜진 상태에서 영상이 뷰포트에 들어오면(`inView`) 사용자 클릭 없이 iframe을 로드해 자동으로 재생합니다.
  - 브라우저 자동재생 정책상 클릭 없는 재생은 음소거 상태에서만 허용되므로, `autoPlay`일 때 embed URL에 `mute=1`을 추가했습니다. 소리는 사용자가 직접 켜야 합니다.
- `PreliminaryLiveSection`에서 2일차 영상 `videoId`를 `518wlDEojOs`로 교체했습니다.
- 기본 선택 탭을 1일차(`activeDay = 0`)에서 2일차(`activeDay = 1`)로 변경했습니다.
- 중계 영상 임베드에 `autoPlay`를 적용했습니다.

## 🤝 리뷰 시 참고사항

> 리뷰어분들이 리뷰를 할 때 참고하면 좋을 사항이나 질문사항을 작성해주세요.

- 자동재생은 브라우저 정책상 음소거(`mute=1`) 상태로 시작됩니다. 이는 정책 준수를 위한 의도된 동작이며, 사용자가 재생 후 직접 소리를 켤 수 있습니다.