### PR TITLE
feat: 필기 캔버스 스타일러스 전용 제한 및 심사원 전용 화면 구성

### DIFF
--- a/src/shared/ui/Header/index.tsx
+++ b/src/shared/ui/Header/index.tsx
@@ -5,6 +5,7 @@ import { MobileMenuIcon } from "@/shared/asset/svg/MobileMenuIcon";
 import { CloseIcon } from "@/shared/asset/svg/CloseIcon";
 import { isHiddenPath, links } from "@/shared/const/headerValues";
 import { cn } from "@/shared/utils/cn";
+import { getTokenFromCookie } from "@/shared/utils/auth";
 import { scrollToElement } from "@/shared/utils/scroll";
 import { handleLogout } from "@/widgets/signin/lib/handleLogout";
 import Link from "next/link";
@@ -19,13 +20,17 @@ export default function Header() {
   const pathname = usePathname();
   const router = useRouter();
   const [mounted, setMounted] = useState(false);
+  const [userRole, setUserRole] = useState<string | null>(null);
 
   const { isUserLoggedIn } = useAuthSync();
   const { isMobileMenuOpen, toggleMobileMenu, closeMobileMenu } = useMobileMenu();
 
   useEffect(() => {
     setMounted(true);
+    setUserRole(getTokenFromCookie("role"));
   }, []);
+
+  const isJudge = userRole === "JUDGE";
 
   const handleClick = useCallback(() => {
     if (isUserLoggedIn) {
@@ -53,13 +58,15 @@ export default function Header() {
         <Link href="/">
           <Logo className="h-[42px] w-[67px] mobile:h-[32px] mobile:w-[52px]" color="#FF9644" />
         </Link>
-        <div className={cn("flex gap-[2.5rem] text-body3b mobile:hidden")}>
-          {links.map((link, index) => (
-            <button key={index} onClick={() => handleScrollToSection(link.section)}>
-              {link.label}
-            </button>
-          ))}
-        </div>
+        {!isJudge && (
+          <div className={cn("flex gap-[2.5rem] text-body3b mobile:hidden")}>
+            {links.map((link, index) => (
+              <button key={index} onClick={() => handleScrollToSection(link.section)}>
+                {link.label}
+              </button>
+            ))}
+          </div>
+        )}
 
         <div
           className={cn(
@@ -86,7 +93,7 @@ export default function Header() {
               </div>
             </div>
 
-            {pathname.startsWith("/home") && (
+            {!isJudge && pathname.startsWith("/home") && (
               <div onClick={toggleMobileMenu} className={cn("place-self-center")}>
                 {isMobileMenuOpen ? <CloseIcon /> : <MobileMenuIcon />}
               </div>
@@ -94,7 +101,7 @@ export default function Header() {
           </div>
         </div>
       </header>
-      {isMobileMenuOpen && pathname.startsWith("/home") && (
+      {!isJudge && isMobileMenuOpen && pathname.startsWith("/home") && (
         <MobileSidebar onClose={closeMobileMenu} onLinkClick={handleScrollToSection} />
       )}
     </>

--- a/src/views/home/ui/HomePage/index.tsx
+++ b/src/views/home/ui/HomePage/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
 import IntroFirstSection from "@/widgets/main/IntroFirstSection";
 import SloganSecondSection from "@/widgets/main/SloganSecondSection";
 import JudgingCtaSection from "@/widgets/main/JudgingCtaSection";
@@ -8,6 +9,7 @@ import JudgeInfoSection from "@/widgets/main/JudgeInfoSection";
 
 import LazySection from "@/shared/ui/LazySection";
 import SloganPosterPopup from "@/widgets/main/SloganPosterPopup";
+import { getTokenFromCookie } from "@/shared/utils/auth";
 
 const PreliminaryLiveSection = dynamic(() => import("@/widgets/main/PreliminaryLiveSection"), {
   loading: () => <SectionPlaceholder />,
@@ -43,6 +45,16 @@ const SectionPlaceholder = ({ height = "400px" }: { height?: string }) => (
 );
 
 const HomePage = () => {
+  const [userRole, setUserRole] = useState<string | null>(null);
+
+  useEffect(() => {
+    setUserRole(getTokenFromCookie("role"));
+  }, []);
+
+  if (userRole === "JUDGE") {
+    return <JudgeInfoSection />;
+  }
+
   return (
     <>
       <SloganPosterPopup />

--- a/src/widgets/judging/ui/HandwritingCanvas/index.tsx
+++ b/src/widgets/judging/ui/HandwritingCanvas/index.tsx
@@ -8,6 +8,8 @@ import { LeftArrow } from "@/shared/asset/svg/LeftArrow";
 import { RightArrow } from "@/shared/asset/svg/RightArrow";
 import { Stroke, StrokePoint } from "@/entities/judging/model/handwriting";
 
+type StylusTouch = Touch & { touchType?: "direct" | "stylus" };
+
 type HandwritingCanvasProps = {
   teamId: number;
   value?: Stroke[];
@@ -83,11 +85,15 @@ const HandwritingCanvas = ({ teamId, value, onChange, onClear }: HandwritingCanv
     return () => observer.disconnect();
   }, [drawStrokes]);
 
-  // iOS는 passive 리스너로는 preventDefault가 막히지 않아 필기 중 페이지가 스크롤되고, 그 과정에서 pointercancel이 떠 획이 끊긴다. 네이티브 non-passive 리스너로 터치 기본동작을 직접 막는다
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const prevent = (e: TouchEvent) => e.preventDefault();
+    const prevent = (e: TouchEvent) => {
+      const hasStylus = Array.from(e.touches).some(
+        t => (t as StylusTouch).touchType === "stylus",
+      );
+      if (hasStylus) e.preventDefault();
+    };
     canvas.addEventListener("touchstart", prevent, { passive: false });
     canvas.addEventListener("touchmove", prevent, { passive: false });
     return () => {
@@ -127,7 +133,6 @@ const HandwritingCanvas = ({ teamId, value, onChange, onClear }: HandwritingCanv
   };
 
   const handlePointerDown = (e: ReactPointerEvent<HTMLCanvasElement>) => {
-    // 애플펜슬(펜)로만 필기 가능. 손가락/손바닥 터치는 무시한다
     if (e.pointerType !== "pen") return;
     e.preventDefault();
 
@@ -303,7 +308,7 @@ const HandwritingCanvas = ({ teamId, value, onChange, onClear }: HandwritingCanv
         ref={canvasRef}
         width={640}
         height={320}
-        className="w-full h-[400px] mobile:h-[390px] touch-none select-none border border-gray-200 rounded-lg bg-white bg-[repeating-linear-gradient(180deg,transparent_0px,transparent_124px,#e2e2e2_124px,#e2e2e2_125px)]"
+        className="w-full h-[400px] mobile:h-[390px] select-none border border-gray-200 rounded-lg bg-white bg-[repeating-linear-gradient(180deg,transparent_0px,transparent_124px,#e2e2e2_124px,#e2e2e2_125px)]"
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerEnd}

--- a/src/widgets/judging/ui/HandwritingCanvas/index.tsx
+++ b/src/widgets/judging/ui/HandwritingCanvas/index.tsx
@@ -127,6 +127,8 @@ const HandwritingCanvas = ({ teamId, value, onChange, onClear }: HandwritingCanv
   };
 
   const handlePointerDown = (e: ReactPointerEvent<HTMLCanvasElement>) => {
+    // 애플펜슬(펜)로만 필기 가능. 손가락/손바닥 터치는 무시한다
+    if (e.pointerType !== "pen") return;
     e.preventDefault();
 
     const canvas = canvasRef.current;

--- a/src/widgets/main/JudgeInfoSection/ui/PenField.tsx
+++ b/src/widgets/main/JudgeInfoSection/ui/PenField.tsx
@@ -6,6 +6,7 @@ import { ProfilePoint, ProfileStroke } from "@/entities/judge/model/types";
 
 type Point = ProfilePoint;
 type Stroke = ProfileStroke;
+type StylusTouch = Touch & { touchType?: "direct" | "stylus" };
 
 type PenFieldProps = {
   value?: Stroke[];
@@ -65,11 +66,15 @@ const PenField = ({ value, onChange }: PenFieldProps) => {
     return () => observer.disconnect();
   }, []);
 
-  // iOS는 passive 리스너로 preventDefault가 막히지 않아 필기 중 페이지가 스크롤되고 pointercancel로 획이 끊긴다. 네이티브 non-passive 리스너로 기본동작을 직접 막는다
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const prevent = (e: TouchEvent) => e.preventDefault();
+    const prevent = (e: TouchEvent) => {
+      const hasStylus = Array.from(e.touches).some(
+        t => (t as StylusTouch).touchType === "stylus",
+      );
+      if (hasStylus) e.preventDefault();
+    };
     canvas.addEventListener("touchstart", prevent, { passive: false });
     canvas.addEventListener("touchmove", prevent, { passive: false });
     return () => {
@@ -97,7 +102,6 @@ const PenField = ({ value, onChange }: PenFieldProps) => {
   };
 
   const handlePointerDown = (e: ReactPointerEvent<HTMLCanvasElement>) => {
-    // 애플펜슬(펜)로만 필기 가능. 손가락/손바닥 터치는 무시한다
     if (e.pointerType !== "pen") return;
     e.preventDefault();
 
@@ -180,7 +184,7 @@ const PenField = ({ value, onChange }: PenFieldProps) => {
       </button>
       <canvas
         ref={canvasRef}
-        className="h-full w-full touch-none select-none bg-white"
+        className="h-full w-full select-none bg-white"
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerEnd}

--- a/src/widgets/main/JudgeInfoSection/ui/PenField.tsx
+++ b/src/widgets/main/JudgeInfoSection/ui/PenField.tsx
@@ -97,6 +97,8 @@ const PenField = ({ value, onChange }: PenFieldProps) => {
   };
 
   const handlePointerDown = (e: ReactPointerEvent<HTMLCanvasElement>) => {
+    // 애플펜슬(펜)로만 필기 가능. 손가락/손바닥 터치는 무시한다
+    if (e.pointerType !== "pen") return;
     e.preventDefault();
 
     const canvas = canvasRef.current;


### PR DESCRIPTION
## 💡 PR 요약

> 해당 PR의 변경사항, 해당 이슈 등에 대한 간략한 설명을 작성해주세요.

- 필기 캔버스를 애플펜슬(스타일러스) 입력으로만 동작하도록 제한하고, 손가락 터치로는 페이지 스크롤이 가능하도록 수정
- 심사원(JUDGE) 계정으로 로그인한 경우 홈 화면과 헤더를 심사원 전용 구성으로 노출

## 📋 작업 내용

> 해당 PR에서 작업한 내용을 자세히 설명해주세요.

**필기 캔버스 스타일러스 전용 제한**
- `handlePointerDown`에서 `pointerType`이 `pen`이 아닌 입력은 무시하여 손가락 필기를 차단
- non-passive 터치 리스너가 무조건 `preventDefault`하던 것을, 터치 목록에 `touchType === "stylus"`가 있을 때만 기본동작을 막도록 변경 → 손가락으로는 페이지 스크롤 허용
- 캔버스에서 `touch-none` 클래스를 제거하여 스타일러스가 아닌 터치의 스크롤을 허용
- `HandwritingCanvas`, `PenField` 두 캔버스에 동일하게 적용

**심사원 전용 화면 구성**
- 홈(`HomePage`)에서 로그인 role이 `JUDGE`이면 `JudgeInfoSection`만 렌더링
- 헤더에서 심사원일 경우 네비게이션 메뉴, 모바일 메뉴 버튼, 모바일 사이드바를 숨김 처리
- role은 `getTokenFromCookie("role")`로 마운트 후 조회

## 🤝 리뷰 시 참고사항

> 리뷰어분들이 리뷰를 할 때 참고하면 좋을 사항이나 질문사항을 작성해주세요.

- `touchType` 프로퍼티는 표준 `Touch` 타입에 없어 `StylusTouch` 확장 타입으로 처리했습니다 (iOS Safari 전용 속성)
- role 조회가 `useEffect` 기반이라 초기 렌더 시 일반 화면이 잠깐 노출될 수 있는지 확인 부탁드립니다