### PR TITLE
feat: 오프라인 시 심사 데이터 로컬 임시저장 및 자동 재전송 적용

### DIFF
--- a/src/entities/judge/model/useJudgeProfile.ts
+++ b/src/entities/judge/model/useJudgeProfile.ts
@@ -1,11 +1,16 @@
 "use client";
 
+import { useRef } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { getJudgeProfile, putJudgeProfile } from "../api/judgeProfile";
 import { JudgeProfile } from "./types";
+import { readLocalDraft, removeLocalDraft } from "@/shared/utils/localDraft";
 
 export const judgeProfileQueryKey = ["judgeProfile"];
+export const JUDGE_PROFILE_DRAFT_KEY = "judge-profile-draft";
+
+export const getJudgeProfileDraft = () => readLocalDraft<JudgeProfile>(JUDGE_PROFILE_DRAFT_KEY);
 
 export const useGetJudgeProfile = (enabled: boolean) =>
   useQuery<JudgeProfile, Error>({
@@ -15,8 +20,19 @@ export const useGetJudgeProfile = (enabled: boolean) =>
     staleTime: 1000 * 60,
   });
 
-export const usePutJudgeProfile = () =>
-  useMutation<void, Error, JudgeProfile>({
+export const usePutJudgeProfile = () => {
+  const hasNotifiedFailureRef = useRef(false);
+
+  return useMutation<void, Error, JudgeProfile>({
     mutationFn: putJudgeProfile,
-    onError: () => toast.error("심사위원 정보 저장에 실패했습니다."),
+    onSuccess: () => {
+      removeLocalDraft(JUDGE_PROFILE_DRAFT_KEY);
+      hasNotifiedFailureRef.current = false;
+    },
+    onError: () => {
+      if (hasNotifiedFailureRef.current) return;
+      hasNotifiedFailureRef.current = true;
+      toast.error("네트워크 연결이 끊겨 기기에 임시 저장했어요. 연결되면 자동으로 다시 저장할게요.");
+    },
   });
+};

--- a/src/shared/hooks/__tests__/useOnlineStatus.test.ts
+++ b/src/shared/hooks/__tests__/useOnlineStatus.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useOnlineStatus } from "../useOnlineStatus";
+
+const setNavigatorOnLine = (value: boolean) => {
+  Object.defineProperty(window.navigator, "onLine", {
+    configurable: true,
+    value,
+  });
+};
+
+describe("useOnlineStatus", () => {
+  afterEach(() => {
+    setNavigatorOnLine(true);
+  });
+
+  it("navigator.onLine이 true면 온라인 상태로 시작한다", () => {
+    setNavigatorOnLine(true);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+  });
+
+  it("offline 이벤트가 발생하면 false로 바뀐다", () => {
+    setNavigatorOnLine(true);
+    const { result } = renderHook(() => useOnlineStatus());
+
+    act(() => {
+      setNavigatorOnLine(false);
+      window.dispatchEvent(new Event("offline"));
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("online 이벤트가 발생하면 다시 true로 바뀐다", () => {
+    setNavigatorOnLine(false);
+    const { result } = renderHook(() => useOnlineStatus());
+
+    act(() => {
+      setNavigatorOnLine(true);
+      window.dispatchEvent(new Event("online"));
+    });
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/shared/hooks/useOnlineStatus.ts
+++ b/src/shared/hooks/useOnlineStatus.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+
+export function useOnlineStatus() {
+  const [isOnline, setIsOnline] = useState(true);
+
+  useEffect(() => {
+    setIsOnline(navigator.onLine);
+
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  return isOnline;
+}

--- a/src/shared/ui/OfflineBadge/index.tsx
+++ b/src/shared/ui/OfflineBadge/index.tsx
@@ -1,0 +1,19 @@
+import { cn } from "@/shared/utils/cn";
+
+type OfflineBadgeProps = {
+  className?: string;
+};
+
+const OfflineBadge = ({ className }: OfflineBadgeProps) => (
+  <span
+    role="status"
+    className={cn(
+      "inline-flex items-center gap-6 rounded-full bg-system-error/10 px-12 py-6 text-caption1b text-system-error",
+      className,
+    )}
+  >
+    오프라인 · 기기에 임시 저장 중
+  </span>
+);
+
+export default OfflineBadge;

--- a/src/shared/utils/__tests__/localDraft.test.ts
+++ b/src/shared/utils/__tests__/localDraft.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { readLocalDraft, writeLocalDraft, removeLocalDraft, readLocalDraftsByPrefix } from "../localDraft";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("writeLocalDraft / readLocalDraft", () => {
+  it("저장한 값을 그대로 읽어온다", () => {
+    writeLocalDraft("draft-key", { a: 1 });
+    expect(readLocalDraft("draft-key")).toEqual({ a: 1 });
+  });
+
+  it("저장된 값이 없으면 null을 반환한다", () => {
+    expect(readLocalDraft("missing-key")).toBeNull();
+  });
+});
+
+describe("removeLocalDraft", () => {
+  it("저장된 draft를 삭제한다", () => {
+    writeLocalDraft("draft-key", { a: 1 });
+    removeLocalDraft("draft-key");
+    expect(readLocalDraft("draft-key")).toBeNull();
+  });
+});
+
+describe("readLocalDraftsByPrefix", () => {
+  it("접두사가 일치하는 draft를 모두 모아 반환한다", () => {
+    writeLocalDraft("judge-score-draft-1", { score: 10 });
+    writeLocalDraft("judge-score-draft-2", { score: 20 });
+    writeLocalDraft("other-key", { score: 99 });
+
+    expect(readLocalDraftsByPrefix("judge-score-draft-")).toEqual({
+      "1": { score: 10 },
+      "2": { score: 20 },
+    });
+  });
+
+  it("일치하는 draft가 없으면 빈 객체를 반환한다", () => {
+    expect(readLocalDraftsByPrefix("judge-score-draft-")).toEqual({});
+  });
+});

--- a/src/shared/utils/localDraft.ts
+++ b/src/shared/utils/localDraft.ts
@@ -1,0 +1,38 @@
+"use client";
+
+export const readLocalDraft = <T>(key: string): T | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch {
+    return null;
+  }
+};
+
+export const writeLocalDraft = <T>(key: string, value: T) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    return;
+  }
+};
+
+export const removeLocalDraft = (key: string) => {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(key);
+};
+
+// 팀별로 키가 나뉘는 draft(judge-score-draft-1, judge-score-draft-2 ...)를 한 번에 복원할 때 사용
+export const readLocalDraftsByPrefix = <T>(prefix: string): Record<string, T> => {
+  if (typeof window === "undefined") return {};
+  const result: Record<string, T> = {};
+  for (let i = 0; i < window.localStorage.length; i += 1) {
+    const key = window.localStorage.key(i);
+    if (!key || !key.startsWith(prefix)) continue;
+    const value = readLocalDraft<T>(key);
+    if (value !== null) result[key.slice(prefix.length)] = value;
+  }
+  return result;
+};

--- a/src/views/judging/model/__tests__/useSaveJudgeComment.test.tsx
+++ b/src/views/judging/model/__tests__/useSaveJudgeComment.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { useSaveJudgeComment, getJudgeCommentDraft } from "../useSaveJudgeComment";
+import { saveJudgeComment } from "../../api/saveJudgeComment";
+
+vi.mock("../../api/saveJudgeComment", () => ({
+  saveJudgeComment: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const setNavigatorOnLine = (value: boolean) => {
+  Object.defineProperty(window.navigator, "onLine", {
+    configurable: true,
+    value,
+  });
+};
+
+const createWrapper = (queryClient: QueryClient) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+let queryClient: QueryClient;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+  setNavigatorOnLine(true);
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+});
+
+afterEach(() => {
+  setNavigatorOnLine(true);
+});
+
+describe("useSaveJudgeComment - 온라인 상태", () => {
+  it("saveImmediately를 호출하면 서버로 전송되고 draft는 남지 않는다", async () => {
+    vi.mocked(saveJudgeComment).mockResolvedValueOnce(undefined as never);
+    const { result } = renderHook(() => useSaveJudgeComment(1), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.saveImmediately([{ color: "#000", points: [{ x: 0, y: 0 }] }]);
+    });
+
+    await waitFor(() =>
+      expect(saveJudgeComment).toHaveBeenCalledWith(1, [{ color: "#000", points: [{ x: 0, y: 0 }] }]),
+    );
+    await waitFor(() => expect(getJudgeCommentDraft(1)).toBeNull());
+  });
+});
+
+describe("useSaveJudgeComment - 오프라인 상태", () => {
+  it("오프라인이면 서버 전송을 시도하지 않고 로컬에만 임시 저장한다", () => {
+    setNavigatorOnLine(false);
+    const { result } = renderHook(() => useSaveJudgeComment(1), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.saveImmediately([{ color: "#000", points: [{ x: 1, y: 1 }] }]);
+    });
+
+    expect(saveJudgeComment).not.toHaveBeenCalled();
+    expect(getJudgeCommentDraft(1)).toEqual([{ color: "#000", points: [{ x: 1, y: 1 }] }]);
+  });
+
+  it("연결이 복구되면 남아있던 draft를 자동으로 재전송한다", async () => {
+    setNavigatorOnLine(false);
+    const { result } = renderHook(() => useSaveJudgeComment(1), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.saveImmediately([{ color: "#000", points: [{ x: 2, y: 2 }] }]);
+    });
+    expect(saveJudgeComment).not.toHaveBeenCalled();
+
+    vi.mocked(saveJudgeComment).mockResolvedValueOnce(undefined as never);
+    act(() => {
+      setNavigatorOnLine(true);
+      window.dispatchEvent(new Event("online"));
+    });
+
+    await waitFor(() =>
+      expect(saveJudgeComment).toHaveBeenCalledWith(1, [{ color: "#000", points: [{ x: 2, y: 2 }] }]),
+    );
+  });
+});

--- a/src/views/judging/model/__tests__/useTeamScores.test.tsx
+++ b/src/views/judging/model/__tests__/useTeamScores.test.tsx
@@ -36,8 +36,17 @@ const createWrapper = (queryClient: QueryClient) => {
 
 let queryClient: QueryClient;
 
+const setNavigatorOnLine = (value: boolean) => {
+  Object.defineProperty(window.navigator, "onLine", {
+    configurable: true,
+    value,
+  });
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
+  window.localStorage.clear();
+  setNavigatorOnLine(true);
   queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
@@ -149,5 +158,88 @@ describe("useTeamScores - getScore", () => {
     });
 
     expect(result.current.getScore(1)).toEqual(EMPTY_SCORE);
+  });
+});
+
+describe("useTeamScores - 로컬 임시 저장", () => {
+  it("updateScore를 호출하면 로컬에도 draft가 저장된다", () => {
+    const teams = [makeScore(1)];
+    const { result } = renderHook(() => useTeamScores(teams), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.updateScore(1, "completenessExpressionScore", 30);
+    });
+
+    expect(window.localStorage.getItem("judge-score-draft-1")).not.toBeNull();
+  });
+
+  it("저장에 성공하면 로컬 draft가 삭제된다", async () => {
+    vi.mocked(saveScore).mockResolvedValueOnce({} as never);
+    const teams = [makeScore(1)];
+    const { result } = renderHook(() => useTeamScores(teams), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.updateScore(1, "completenessExpressionScore", 30);
+    });
+    act(() => {
+      result.current.submitScore(1);
+    });
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem("judge-score-draft-1")).toBeNull();
+    });
+  });
+
+  it("새로 마운트되어도 로컬에 남아있던 draft로 편집값을 복원한다", () => {
+    window.localStorage.setItem(
+      "judge-score-draft-1",
+      JSON.stringify({
+        completenessExpressionScore: 25,
+        creativityCompositionScore: 0,
+        stagePerformanceTeamworkScore: 0,
+      }),
+    );
+    const teams = [makeScore(1)];
+    const { result } = renderHook(() => useTeamScores(teams), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.getScore(1)).toEqual({
+      completenessExpressionScore: 25,
+      creativityCompositionScore: 0,
+      stagePerformanceTeamworkScore: 0,
+    });
+  });
+});
+
+describe("useTeamScores - 오프라인 재시도", () => {
+  it("네트워크 실패로 저장이 안 된 팀은 연결이 복구되면 자동으로 재시도한다", async () => {
+    setNavigatorOnLine(false);
+    vi.mocked(saveScore).mockRejectedValueOnce(new Error("네트워크 오류"));
+    const teams = [makeScore(1)];
+    const { result } = renderHook(() => useTeamScores(teams), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.updateScore(1, "completenessExpressionScore", 30);
+    });
+    act(() => {
+      result.current.submitScore(1);
+    });
+
+    await waitFor(() => expect(saveScore).toHaveBeenCalledTimes(1));
+
+    vi.mocked(saveScore).mockResolvedValueOnce({} as never);
+    act(() => {
+      setNavigatorOnLine(true);
+      window.dispatchEvent(new Event("online"));
+    });
+
+    await waitFor(() => expect(saveScore).toHaveBeenCalledTimes(2));
   });
 });

--- a/src/views/judging/model/useSaveJudgeComment.ts
+++ b/src/views/judging/model/useSaveJudgeComment.ts
@@ -6,20 +6,34 @@ import { toast } from "sonner";
 import { saveJudgeComment } from "../api/saveJudgeComment";
 import { Stroke } from "@/entities/judging/model/handwriting";
 import { judgeCommentQueryKey } from "./queryKeys";
+import { readLocalDraft, removeLocalDraft, writeLocalDraft } from "@/shared/utils/localDraft";
+import { useOnlineStatus } from "@/shared/hooks/useOnlineStatus";
 
 const SAVE_DEBOUNCE_MS = 500;
+const DRAFT_KEY_PREFIX = "judge-comment-draft-";
+const draftKey = (teamId: number) => `${DRAFT_KEY_PREFIX}${teamId}`;
 
 type PendingSave = { teamId: number; strokes: Stroke[] };
 
+export const getJudgeCommentDraft = (teamId: number) => readLocalDraft<Stroke[]>(draftKey(teamId));
+
 export const useSaveJudgeComment = (teamId: number | null) => {
   const queryClient = useQueryClient();
+  const isOnline = useOnlineStatus();
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingRef = useRef<PendingSave | null>(null);
+  const hasNotifiedFailureRef = useRef(false);
 
   const { mutate } = useMutation({
     mutationFn: ({ teamId, strokes }: PendingSave) => saveJudgeComment(teamId, strokes),
+    onSuccess: (_data, { teamId }) => {
+      removeLocalDraft(draftKey(teamId));
+      hasNotifiedFailureRef.current = false;
+    },
     onError: () => {
-      toast.error("필기 메모 저장에 실패했습니다.");
+      if (hasNotifiedFailureRef.current) return;
+      hasNotifiedFailureRef.current = true;
+      toast.error("네트워크 연결이 끊겨 기기에 임시 저장했어요. 연결되면 자동으로 다시 저장할게요.");
     },
   });
 
@@ -29,6 +43,8 @@ export const useSaveJudgeComment = (teamId: number | null) => {
         teamId: pending.teamId,
         strokes: pending.strokes,
       });
+      writeLocalDraft(draftKey(pending.teamId), pending.strokes);
+      if (typeof navigator !== "undefined" && !navigator.onLine) return;
       mutate(pending);
     },
     [mutate, queryClient],
@@ -70,5 +86,12 @@ export const useSaveJudgeComment = (teamId: number | null) => {
     };
   }, [teamId, flush]);
 
-  return { save, saveImmediately };
+  // 오프라인이라 전송하지 못한 draft가 남아있으면, 연결이 복구됐을 때(또는 마운트 시점에 이미 온라인이면) 자동으로 재전송한다
+  useEffect(() => {
+    if (!isOnline || teamId === null) return;
+    const draft = readLocalDraft<Stroke[]>(draftKey(teamId));
+    if (draft) commit({ teamId, strokes: draft });
+  }, [isOnline, teamId, commit]);
+
+  return { save, saveImmediately, isOnline };
 };

--- a/src/views/judging/model/useTeamScores.ts
+++ b/src/views/judging/model/useTeamScores.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
@@ -12,10 +12,29 @@ import {
 } from "@/entities/judging/model/score";
 import { saveScore } from "@/entities/judging/api/saveScore";
 import { judgeListQueryKey } from "./queryKeys";
+import { readLocalDraftsByPrefix, removeLocalDraft, writeLocalDraft } from "@/shared/utils/localDraft";
+import { useOnlineStatus } from "@/shared/hooks/useOnlineStatus";
+
+const DRAFT_KEY_PREFIX = "judge-score-draft-";
+const draftKey = (teamId: number) => `${DRAFT_KEY_PREFIX}${teamId}`;
 
 export const useTeamScores = (teams: Score[]) => {
   const queryClient = useQueryClient();
+  const isOnline = useOnlineStatus();
   const [edits, setEdits] = useState<Record<number, TeamScore>>({});
+  const failedTeamIdsRef = useRef<Set<number>>(new Set());
+
+  // 저장 버튼을 누르기 전에 이탈(새로고침/오프라인 등)해도 편집 중이던 점수를 잃지 않도록 복원한다
+  useEffect(() => {
+    const drafts = readLocalDraftsByPrefix<TeamScore>(DRAFT_KEY_PREFIX);
+    const restored = Object.entries(drafts).reduce<Record<number, TeamScore>>(
+      (acc, [teamId, score]) => ({ ...acc, [Number(teamId)]: score }),
+      {},
+    );
+    if (Object.keys(restored).length > 0) {
+      setEdits(prev => ({ ...restored, ...prev }));
+    }
+  }, []);
 
   const getScore = useCallback(
     (teamId: number): TeamScore => {
@@ -28,10 +47,11 @@ export const useTeamScores = (teams: Score[]) => {
 
   const updateScore = useCallback(
     (teamId: number, key: EvaluationScoreKey, value: number) => {
-      setEdits(prev => ({
-        ...prev,
-        [teamId]: { ...(prev[teamId] ?? getScore(teamId)), [key]: value },
-      }));
+      setEdits(prev => {
+        const next = { ...prev, [teamId]: { ...(prev[teamId] ?? getScore(teamId)), [key]: value } };
+        writeLocalDraft(draftKey(teamId), next[teamId]);
+        return next;
+      });
     },
     [getScore],
   );
@@ -58,22 +78,35 @@ export const useTeamScores = (teams: Score[]) => {
     },
     onSuccess: (_data, teamId, context) => {
       toast.success(context?.wasJudged ? "심사가 수정되었습니다" : "심사가 저장되었습니다");
+      failedTeamIdsRef.current.delete(teamId);
+      removeLocalDraft(draftKey(teamId));
       setEdits(prev => {
         const next = { ...prev };
         delete next[teamId];
         return next;
       });
     },
-    onError: (error, _teamId, context) => {
+    onError: (error, teamId, context) => {
       if (context?.previousScores) {
         queryClient.setQueryData(judgeListQueryKey, context.previousScores);
       }
-      toast.error(error instanceof Error ? error.message : "심사 저장에 실패했습니다.");
+      failedTeamIdsRef.current.add(teamId);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "심사 저장에 실패했습니다. 기기에 임시 저장했으니 연결되면 다시 시도해주세요.",
+      );
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: judgeListQueryKey });
     },
   });
+
+  // 저장 버튼을 눌렀지만 네트워크 문제로 실패했던 팀은, 연결이 복구되면 자동으로 재시도한다
+  useEffect(() => {
+    if (!isOnline) return;
+    failedTeamIdsRef.current.forEach(teamId => submitScore(teamId));
+  }, [isOnline, submitScore]);
 
   const savingTeamId = isPending ? (savingVariables ?? null) : null;
 

--- a/src/views/judging/ui/JudgingPage/index.tsx
+++ b/src/views/judging/ui/JudgingPage/index.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { DescriptionCard } from "@/entities/apply/ui/DescriptionCard";
 import BackHeader from "@/shared/ui/BackHeader";
+import OfflineBadge from "@/shared/ui/OfflineBadge";
 import { computeRanks, EVALUATION_CRITERIA, TOTAL_MAX } from "@/entities/judging/model/score";
 import TeamGrid from "@/widgets/judging/ui/TeamGrid";
 import ScoreForm from "@/widgets/judging/ui/ScoreForm";
@@ -11,7 +12,7 @@ import { useTeamGridData } from "../../model/useTeamGridData";
 import { useReorderTeams } from "../../model/useReorderTeams";
 import { useTeamScores } from "../../model/useTeamScores";
 import { useGetJudgeComment } from "../../model/useGetJudgeComment";
-import { useSaveJudgeComment } from "../../model/useSaveJudgeComment";
+import { getJudgeCommentDraft, useSaveJudgeComment } from "../../model/useSaveJudgeComment";
 
 const CRITERIA_ITEMS: string[] = EVALUATION_CRITERIA.map(
   ({ label, max }) => `${label} (${max}점)`,
@@ -34,13 +35,17 @@ const JudgingPage = () => {
   const { getScore, updateScore, submitScore, savingTeamId, hasUnsavedEdit } =
     useTeamScores(teams);
   const { data: judgeComment } = useGetJudgeComment(selectedTeamId);
-  const { save: saveJudgeComment, saveImmediately: clearJudgeComment } =
-    useSaveJudgeComment(selectedTeamId);
+  const {
+    save: saveJudgeComment,
+    saveImmediately: clearJudgeComment,
+    isOnline,
+  } = useSaveJudgeComment(selectedTeamId);
 
   const selectedTeam = teams.find(team => team.teamId === selectedTeamId);
   const score = selectedTeamId !== null ? getScore(selectedTeamId) : null;
   const ranks = useMemo(() => computeRanks(teams), [teams]);
   const rank = selectedTeamId !== null ? ranks.get(selectedTeamId) ?? null : null;
+  const commentDraft = selectedTeamId !== null ? getJudgeCommentDraft(selectedTeamId) : null;
 
   const handleSelectTeam = (teamId: number) => {
     if (selectedTeamId !== null && selectedTeamId !== teamId && hasUnsavedEdit(selectedTeamId)) {
@@ -53,6 +58,7 @@ const JudgingPage = () => {
     <div className="w-full min-h-screen flex flex-col items-center py-40 px-40 mobile:px-16 tablet:px-24">
       <div className="max-w-[1280px] w-full flex flex-col gap-24">
         <BackHeader text="심사 안내" />
+        {!isOnline && <OfflineBadge className="self-start" />}
 
         {isTeamGridUnavailable ? (
           <div className="grid grid-cols-6 tablet:grid-cols-4 mobile:grid-cols-3 gap-14 mobile:gap-8">
@@ -97,7 +103,7 @@ const JudgingPage = () => {
         ) : (
           <HandwritingCanvas
             teamId={selectedTeamId}
-            value={judgeComment?.strokes}
+            value={commentDraft ?? judgeComment?.strokes}
             onChange={saveJudgeComment}
             onClear={() => clearJudgeComment([])}
           />

--- a/src/widgets/main/JudgeInfoSection/index.tsx
+++ b/src/widgets/main/JudgeInfoSection/index.tsx
@@ -3,9 +3,17 @@
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Button from "@/shared/ui/Button";
+import OfflineBadge from "@/shared/ui/OfflineBadge";
 import { RightArrow } from "@/shared/asset/svg/RightArrow";
 import { getTokenFromCookie } from "@/shared/utils/auth";
-import { useGetJudgeProfile, usePutJudgeProfile } from "@/entities/judge/model/useJudgeProfile";
+import { useOnlineStatus } from "@/shared/hooks/useOnlineStatus";
+import { writeLocalDraft } from "@/shared/utils/localDraft";
+import {
+  getJudgeProfileDraft,
+  JUDGE_PROFILE_DRAFT_KEY,
+  useGetJudgeProfile,
+  usePutJudgeProfile,
+} from "@/entities/judge/model/useJudgeProfile";
 import { JudgeProfile } from "@/entities/judge/model/types";
 import PenField from "./ui/PenField";
 
@@ -26,8 +34,9 @@ const JUDGING_HREF = "/admin/evaluation";
 
 const JudgeInfoSection = () => {
   const router = useRouter();
+  const isOnline = useOnlineStatus();
   const [userRole, setUserRole] = useState<string | null>(null);
-  const [, setProfile] = useState<JudgeProfile>(EMPTY_PROFILE);
+  const [, setProfile] = useState<JudgeProfile>(() => getJudgeProfileDraft() ?? EMPTY_PROFILE);
 
   useEffect(() => {
     setUserRole(getTokenFromCookie("role"));
@@ -38,16 +47,30 @@ const JudgeInfoSection = () => {
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    if (data) setProfile(data);
+    if (!data) return;
+    // 아직 서버로 동기화되지 않은 로컬 draft가 있으면 서버 값(더 오래된 값)으로 덮어쓰지 않는다
+    if (getJudgeProfileDraft()) return;
+    setProfile(data);
   }, [data]);
 
   useEffect(() => () => clearTimeout(saveTimer.current ?? undefined), []);
 
+  // 오프라인이라 저장 못 한 draft가 남아있으면, 연결이 복구됐을 때(또는 마운트 시점에 이미 온라인이면) 자동으로 재전송한다
+  useEffect(() => {
+    if (!isOnline) return;
+    const draft = getJudgeProfileDraft();
+    if (draft) saveProfile(draft);
+  }, [isOnline, saveProfile]);
+
   const handleStrokesChange = (key: keyof JudgeProfile, strokes: JudgeProfile[keyof JudgeProfile]) => {
     setProfile(prev => {
       const next = { ...prev, [key]: strokes };
+      writeLocalDraft(JUDGE_PROFILE_DRAFT_KEY, next);
       if (saveTimer.current) clearTimeout(saveTimer.current);
-      saveTimer.current = setTimeout(() => saveProfile(next), SAVE_DEBOUNCE_MS);
+      saveTimer.current = setTimeout(() => {
+        if (typeof navigator !== "undefined" && !navigator.onLine) return;
+        saveProfile(next);
+      }, SAVE_DEBOUNCE_MS);
       return next;
     });
   };
@@ -56,13 +79,18 @@ const JudgeInfoSection = () => {
 
   if (userRole !== "JUDGE") return null;
 
+  const profileDraft = getJudgeProfileDraft();
+
   return (
     <section
       id="JudgeInfoSection"
       className="w-full bg-white px-40 py-40 mobile:px-16 tablet:px-24"
     >
       <div className="mx-auto flex w-full max-w-[1280px] flex-col gap-32">
-        <h2 className="text-title2b text-gray-900 mobile:text-h4b">심사위원 정보</h2>
+        <div className="flex items-center gap-12">
+          <h2 className="text-title2b text-gray-900 mobile:text-h4b">심사위원 정보</h2>
+          {!isOnline && <OfflineBadge />}
+        </div>
 
         <div className="flex flex-col gap-16">
           {INFO_FIELDS.map(({ key, label }) => (
@@ -75,7 +103,7 @@ const JudgeInfoSection = () => {
               </div>
               <div className="flex-1">
                 <PenField
-                  value={data ? data[key] : undefined}
+                  value={profileDraft ? profileDraft[key] : data ? data[key] : undefined}
                   onChange={strokes => handleStrokesChange(key, strokes)}
                 />
               </div>


### PR DESCRIPTION
## 💡 PR 요약

> 해당 PR의 변경사항, 해당 이슈 등에 대한 간략한 설명을 작성해주세요.

- 네트워크가 끊겼을 때 심사위원 프로필·점수·심사 의견 입력값을 기기에 임시 저장하고, 연결이 복구되면 자동으로 서버에 재전송합니다.
- 오프라인 상태를 감지해 심사위원 정보 화면과 심사 화면에 오프라인 배지를 노출합니다.
- 저장 실패 시 안내 토스트를 "임시 저장 후 자동 재전송" 문구로 변경합니다.

## 📋 작업 내용

- `useOnlineStatus` 훅으로 `navigator.onLine`과 `online`/`offline` 이벤트를 구독해 온라인 여부를 감지합니다.
- `localDraft` 유틸(`readLocalDraft`/`writeLocalDraft`/`removeLocalDraft`/`readLocalDraftsByPrefix`)로 localStorage 기반 임시저장 로직을 공통화했습니다.
- **심사위원 프로필**(`useJudgeProfile`): 입력할 때마다 draft를 저장하고, 아직 서버로 동기화되지 않은 draft가 있으면 서버 응답으로 덮어쓰지 않습니다. 온라인 복귀 시 자동 재전송됩니다.
- **심사 점수**(`useTeamScores`): 팀별 점수 편집값을 draft로 저장해 새로고침 후에도 복원되며, 저장에 실패한 팀은 온라인 복귀 시 자동으로 재시도합니다.
- **심사 의견**(`useSaveJudgeComment`): 필기 메모를 팀별 draft로 저장하고, 온라인 복귀 시 자동 재전송합니다.
- `OfflineBadge` 컴포넌트를 추가해 심사위원 정보·심사 화면에서 오프라인 상태를 표시합니다.
- 저장 실패 토스트가 재시도마다 중복 노출되지 않도록 실패 알림은 1회만 표시하도록 처리했습니다.
- 관련 단위 테스트를 추가했습니다 (`localDraft`, `useOnlineStatus`, `useTeamScores`, `useSaveJudgeComment`).

## 🤝 리뷰 시 참고사항

> 리뷰어분들이 리뷰를 할 때 참고하면 좋을 사항이나 질문사항을 작성해주세요.

- draft는 `localStorage`에 저장되므로 기기·브라우저 단위로만 복구되고, 다른 기기로는 이어지지 않습니다.
- 저장 실패가 네트워크 문제가 아닌 다른 서버 오류(4xx 등)로 발생해도 현재는 동일하게 "오프라인이라 임시 저장했다"는 문구가 노출됩니다 — 문구를 세분화할지 논의가 필요할 수 있습니다.
