### PR TITLE
feat: 본선 진출팀 API 연동 및 심사 화면 개선사항 반영

### DIFF
--- a/src/shared/config/dateConfig.ts
+++ b/src/shared/config/dateConfig.ts
@@ -35,3 +35,12 @@ export const preliminaryResultOpenDate = Number.isNaN(parsedPreliminaryResultOpe
   ? new Date(PRELIMINARY_RESULT_OPEN_DATE_FALLBACK)
   : parsedPreliminaryResultOpenDate;
 export const isPreliminaryResultOpen = () => new Date() >= preliminaryResultOpenDate;
+
+const FINALS_LINEUP_RELEASE_DATE_FALLBACK = "2026-07-31T10:00:00+09:00";
+const parsedFinalsLineupReleaseDate = new Date(
+  process.env.NEXT_PUBLIC_FINALS_LINEUP_RELEASE_DATE ?? FINALS_LINEUP_RELEASE_DATE_FALLBACK,
+);
+export const finalsLineupReleaseDate = Number.isNaN(parsedFinalsLineupReleaseDate.getTime())
+  ? new Date(FINALS_LINEUP_RELEASE_DATE_FALLBACK)
+  : parsedFinalsLineupReleaseDate;
+export const isFinalsLineupReleased = () => new Date() >= finalsLineupReleaseDate;

--- a/src/views/home/ui/HomePage/index.tsx
+++ b/src/views/home/ui/HomePage/index.tsx
@@ -8,7 +8,6 @@ import JudgingCtaSection from "@/widgets/main/JudgingCtaSection";
 import JudgeInfoSection from "@/widgets/main/JudgeInfoSection";
 
 import LazySection from "@/shared/ui/LazySection";
-import SloganPosterPopup from "@/widgets/main/SloganPosterPopup";
 import { getTokenFromCookie } from "@/shared/utils/auth";
 
 const PreliminaryLiveSection = dynamic(() => import("@/widgets/main/PreliminaryLiveSection"), {
@@ -57,7 +56,7 @@ const HomePage = () => {
 
   return (
     <>
-      <SloganPosterPopup />
+      {/* <SloganPosterPopup /> */}
       <IntroFirstSection />
       <JudgeInfoSection />
       <SloganSecondSection />

--- a/src/widgets/main/FinalsVenueSection/index.tsx
+++ b/src/widgets/main/FinalsVenueSection/index.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import { cn } from "@/shared/utils/cn";
 import { SectionTitle } from "@/shared/ui/SectionTitle";
+import { isFinalsLineupReleased } from "@/shared/config/dateConfig";
 import { useGetTeams } from "../model/useGetTeams";
 
 const VENUE = {
@@ -36,6 +38,15 @@ const FinalsVenueSection = () => {
   const lineupLeft = teams.slice(0, half);
   const lineupRight = teams.slice(half);
 
+  const [isLineupReleased, setIsLineupReleased] = useState(false);
+
+  useEffect(() => {
+    const check = () => setIsLineupReleased(isFinalsLineupReleased());
+    check();
+    const timer = setInterval(check, 60000);
+    return () => clearInterval(timer);
+  }, []);
+
   return (
     <section className={cn("flex flex-col items-center")}>
       <div className={cn("w-[70%] mobile:w-full mobile:px-16")}>
@@ -52,102 +63,113 @@ const FinalsVenueSection = () => {
         {/* 본선 진출팀 */}
         <div className={cn("mb-24 flex flex-col gap-12")}>
           <h3 className="text-body2b mobile:text-body3b text-black">본선 진출팀</h3>
-          <div className="w-full overflow-x-auto">
-            <div className="min-w-[720px] overflow-hidden rounded-xl">
-              <table className="w-full border-collapse text-center text-caption1r">
-                <thead className="bg-gray-50 text-caption1b text-gray-700">
-                  <tr>
-                    <th className="border border-t-0 border-l-0 border-solid border-gray-200 px-12 py-10">
-                      번호
-                    </th>
-                    <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
-                      분야
-                    </th>
-                    <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
-                      팀명(소속)
-                    </th>
-                    <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
-                      신청자명
-                    </th>
-                    <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
-                      번호
-                    </th>
-                    <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
-                      분야
-                    </th>
-                    <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
-                      팀명(소속)
-                    </th>
-                    <th className="border border-t-0 border-r-0 border-solid border-gray-200 px-12 py-10">
-                      신청자명
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {isLoading ? (
-                    <tr>
-                      <td colSpan={8} className="px-12 py-10">
-                        <div className="flex flex-col gap-8">
-                          {Array.from({ length: 5 }).map((_, index) => (
-                            <div
-                              key={index}
-                              className="h-32 w-full rounded-lg bg-gray-100 animate-pulse"
-                            />
-                          ))}
-                        </div>
-                      </td>
-                    </tr>
-                  ) : teams.length === 0 ? (
-                    <tr>
-                      <td colSpan={8} className="py-24 text-gray-400">
-                        본선 진출팀 정보가 없습니다.
-                      </td>
-                    </tr>
-                  ) : (
-                    lineupLeft.map((left, index) => {
-                      const right = lineupRight[index];
-                      return (
-                        <tr key={left.teamId}>
-                          <td className="border border-l-0 border-solid border-gray-200 px-12 py-10">
-                            {left.performOrder}
-                          </td>
-                          {/* 분야: 백엔드에 필드 추가 전까지 공란 */}
-                          <td className="border border-solid border-gray-200 px-12 py-10" />
-                          <td className="border border-solid border-gray-200 px-12 py-10 text-left">
-                            {left.school ? `${left.teamName}(${left.school})` : left.teamName}
-                          </td>
-                          {/* 신청자명: 백엔드에 필드 추가 전까지 공란 */}
-                          <td className="border border-solid border-gray-200 px-12 py-10" />
-                          <td className="border border-solid border-gray-200 px-12 py-10">
-                            {right?.performOrder}
-                          </td>
-                          <td className="border border-solid border-gray-200 px-12 py-10" />
-                          <td className="border border-solid border-gray-200 px-12 py-10 text-left">
-                            {right && (right.school ? `${right.teamName}(${right.school})` : right.teamName)}
-                          </td>
-                          <td className="border border-r-0 border-solid border-gray-200 px-12 py-10" />
-                        </tr>
-                      );
-                    })
-                  )}
-                  {!isLoading && teams.length > 0 && (
-                    <tr className="bg-gray-50 text-caption1b">
-                      <td className="border border-b-0 border-l-0 border-solid border-gray-200 px-12 py-10">
-                        계
-                      </td>
-                      <td
-                        colSpan={6}
-                        className="border border-b-0 border-solid border-gray-200 px-12 py-10"
-                      />
-                      <td className="border border-b-0 border-r-0 border-solid border-gray-200 px-12 py-10 bg-orange-50 text-orange-500">
-                        총 {teams.length}팀
-                      </td>
-                    </tr>
-                  )}
-                </tbody>
-              </table>
+          {!isLineupReleased ? (
+            <div className="flex flex-col items-center gap-4 rounded-xl bg-gray-50 py-40 text-center">
+              <p className="text-body3b mobile:text-caption1b text-gray-700">
+                본선 진출팀은 7월 31일(금) 오전 10시에 발표됩니다
+              </p>
             </div>
-          </div>
+          ) : (
+            <div className="w-full overflow-x-auto">
+              <div className="min-w-[720px] overflow-hidden rounded-xl">
+                <table className="w-full border-collapse text-center text-caption1r">
+                  <thead className="bg-gray-50 text-caption1b text-gray-700">
+                    <tr>
+                      <th className="border border-t-0 border-l-0 border-solid border-gray-200 px-12 py-10">
+                        번호
+                      </th>
+                      <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
+                        분야
+                      </th>
+                      <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
+                        팀명(소속)
+                      </th>
+                      <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
+                        신청자명
+                      </th>
+                      <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
+                        번호
+                      </th>
+                      <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
+                        분야
+                      </th>
+                      <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
+                        팀명(소속)
+                      </th>
+                      <th className="border border-t-0 border-r-0 border-solid border-gray-200 px-12 py-10">
+                        신청자명
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {isLoading ? (
+                      <tr>
+                        <td colSpan={8} className="px-12 py-10">
+                          <div className="flex flex-col gap-8">
+                            {Array.from({ length: 5 }).map((_, index) => (
+                              <div
+                                key={index}
+                                className="h-32 w-full rounded-lg bg-gray-100 animate-pulse"
+                              />
+                            ))}
+                          </div>
+                        </td>
+                      </tr>
+                    ) : teams.length === 0 ? (
+                      <tr>
+                        <td colSpan={8} className="py-24 text-gray-400">
+                          본선 진출팀 정보가 없습니다.
+                        </td>
+                      </tr>
+                    ) : (
+                      lineupLeft.map((left, index) => {
+                        const right = lineupRight[index];
+                        return (
+                          <tr key={left.teamId}>
+                            <td className="border border-l-0 border-solid border-gray-200 px-12 py-10">
+                              {left.performOrder}
+                            </td>
+                            {/* 분야: 백엔드에 필드 추가 전까지 공란 */}
+                            <td className="border border-solid border-gray-200 px-12 py-10" />
+                            <td className="border border-solid border-gray-200 px-12 py-10 text-left">
+                              {left.school ? `${left.teamName}(${left.school})` : left.teamName}
+                            </td>
+                            {/* 신청자명: 백엔드에 필드 추가 전까지 공란 */}
+                            <td className="border border-solid border-gray-200 px-12 py-10" />
+                            <td className="border border-solid border-gray-200 px-12 py-10">
+                              {right?.performOrder}
+                            </td>
+                            <td className="border border-solid border-gray-200 px-12 py-10" />
+                            <td className="border border-solid border-gray-200 px-12 py-10 text-left">
+                              {right &&
+                                (right.school
+                                  ? `${right.teamName}(${right.school})`
+                                  : right.teamName)}
+                            </td>
+                            <td className="border border-r-0 border-solid border-gray-200 px-12 py-10" />
+                          </tr>
+                        );
+                      })
+                    )}
+                    {!isLoading && teams.length > 0 && (
+                      <tr className="bg-gray-50 text-caption1b">
+                        <td className="border border-b-0 border-l-0 border-solid border-gray-200 px-12 py-10">
+                          계
+                        </td>
+                        <td
+                          colSpan={6}
+                          className="border border-b-0 border-solid border-gray-200 px-12 py-10"
+                        />
+                        <td className="border border-b-0 border-r-0 border-solid border-gray-200 px-12 py-10 bg-orange-50 text-orange-500">
+                          총 {teams.length}팀
+                        </td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
         </div>
 
         <div className={cn("flex gap-24 mb-90 mobile:mb-38 mobile:flex-col mobile:gap-20")}>

--- a/src/widgets/main/FinalsVenueSection/index.tsx
+++ b/src/widgets/main/FinalsVenueSection/index.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { cn } from "@/shared/utils/cn";
 import { SectionTitle } from "@/shared/ui/SectionTitle";
+import { useGetTeams } from "../model/useGetTeams";
 
 const VENUE = {
   name: "광주교육대학교 풍향문화관",
@@ -12,7 +13,11 @@ const VENUE = {
 const MAP_QUERY = encodeURIComponent("광주교육대학교 풍향문화관");
 
 const MAP_LINKS = [
-  { name: "카카오맵", icon: "/images/mapLogo/kakaomap.png", url: `https://map.kakao.com/?q=${MAP_QUERY}` },
+  {
+    name: "카카오맵",
+    icon: "/images/mapLogo/kakaomap.png",
+    url: `https://map.kakao.com/?q=${MAP_QUERY}`,
+  },
   {
     name: "네이버지도",
     icon: "/images/mapLogo/navermap.png",
@@ -26,26 +31,123 @@ const BUS_ROUTES = [
 ] as const;
 
 const FinalsVenueSection = () => {
+  const { data: teams = [], isLoading } = useGetTeams();
+  const half = Math.ceil(teams.length / 2);
+  const lineupLeft = teams.slice(0, half);
+  const lineupRight = teams.slice(half);
+
   return (
     <section className={cn("flex flex-col items-center")}>
       <div className={cn("w-[70%] mobile:w-full mobile:px-16")}>
         <SectionTitle
           title="2026 광탈페 본선"
-          description={<>{VENUE.date} · {VENUE.name}</>}
+          description={
+            <>
+              {VENUE.date} · {VENUE.name}
+            </>
+          }
           className={cn("mt-66 mobile:mt-[1.7rem] mb-40 mobile:mb-24")}
         />
 
-        {/* 위치 안내 */}
+        {/* 본선 진출팀 */}
         <div className={cn("mb-24 flex flex-col gap-12")}>
-          <h3 className="text-body2b mobile:text-body3b text-black">광탈페 위치</h3>
-          <Image
-            src="/images/finals-location.jpg"
-            alt="2026 광탈페 본선 위치 안내"
-            width={3508}
-            height={2480}
-            className="w-full h-auto rounded-lg border border-gray-100"
-            sizes="(max-width: 768px) 100vw, 70vw"
-          />
+          <h3 className="text-body2b mobile:text-body3b text-black">본선 진출팀</h3>
+          <div className="w-full overflow-x-auto">
+            <div className="min-w-[720px] overflow-hidden rounded-xl">
+              <table className="w-full border-collapse text-center text-caption1r">
+                <thead className="bg-gray-50 text-caption1b text-gray-700">
+                  <tr>
+                    <th className="border border-t-0 border-l-0 border-solid border-gray-200 px-12 py-10">
+                      번호
+                    </th>
+                    <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
+                      분야
+                    </th>
+                    <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
+                      팀명(소속)
+                    </th>
+                    <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
+                      신청자명
+                    </th>
+                    <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
+                      번호
+                    </th>
+                    <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
+                      분야
+                    </th>
+                    <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
+                      팀명(소속)
+                    </th>
+                    <th className="border border-t-0 border-r-0 border-solid border-gray-200 px-12 py-10">
+                      신청자명
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {isLoading ? (
+                    <tr>
+                      <td colSpan={8} className="px-12 py-10">
+                        <div className="flex flex-col gap-8">
+                          {Array.from({ length: 5 }).map((_, index) => (
+                            <div
+                              key={index}
+                              className="h-32 w-full rounded-lg bg-gray-100 animate-pulse"
+                            />
+                          ))}
+                        </div>
+                      </td>
+                    </tr>
+                  ) : teams.length === 0 ? (
+                    <tr>
+                      <td colSpan={8} className="py-24 text-gray-400">
+                        본선 진출팀 정보가 없습니다.
+                      </td>
+                    </tr>
+                  ) : (
+                    lineupLeft.map((left, index) => {
+                      const right = lineupRight[index];
+                      return (
+                        <tr key={left.teamId}>
+                          <td className="border border-l-0 border-solid border-gray-200 px-12 py-10">
+                            {left.performOrder}
+                          </td>
+                          {/* 분야: 백엔드에 필드 추가 전까지 공란 */}
+                          <td className="border border-solid border-gray-200 px-12 py-10" />
+                          <td className="border border-solid border-gray-200 px-12 py-10 text-left">
+                            {left.school ? `${left.teamName}(${left.school})` : left.teamName}
+                          </td>
+                          {/* 신청자명: 백엔드에 필드 추가 전까지 공란 */}
+                          <td className="border border-solid border-gray-200 px-12 py-10" />
+                          <td className="border border-solid border-gray-200 px-12 py-10">
+                            {right?.performOrder}
+                          </td>
+                          <td className="border border-solid border-gray-200 px-12 py-10" />
+                          <td className="border border-solid border-gray-200 px-12 py-10 text-left">
+                            {right && (right.school ? `${right.teamName}(${right.school})` : right.teamName)}
+                          </td>
+                          <td className="border border-r-0 border-solid border-gray-200 px-12 py-10" />
+                        </tr>
+                      );
+                    })
+                  )}
+                  {!isLoading && teams.length > 0 && (
+                    <tr className="bg-gray-50 text-caption1b">
+                      <td className="border border-b-0 border-l-0 border-solid border-gray-200 px-12 py-10">
+                        계
+                      </td>
+                      <td
+                        colSpan={6}
+                        className="border border-b-0 border-solid border-gray-200 px-12 py-10"
+                      />
+                      <td className="border border-b-0 border-r-0 border-solid border-gray-200 px-12 py-10 bg-orange-50 text-orange-500">
+                        총 {teams.length}팀
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
         </div>
 
         <div className={cn("flex gap-24 mb-90 mobile:mb-38 mobile:flex-col mobile:gap-20")}>

--- a/src/widgets/main/PreliminaryLiveSection/index.tsx
+++ b/src/widgets/main/PreliminaryLiveSection/index.tsx
@@ -30,26 +30,11 @@ const PreliminaryLiveSection = () => {
       <div className="relative z-10 mx-auto flex w-[70%] mobile:w-full flex-col gap-40 mobile:gap-28 px-16">
         <SectionTitle
           title="2026 광탈페 예선(光트로)"
-          description={<>7월 24일(금)·25일(토), 광주학생교육문화회관에서 열립니다</>}
+          description={<>7월 24일(금)~25일(토), 광주학생교육문화회관</>}
         />
 
-        <div className="flex flex-col gap-12">
-          <h3 className="text-body2b mobile:text-body3b text-black">예선 소개 영상</h3>
-          <video
-            src="/video/preliminary-intro.mp4"
-            autoPlay
-            muted
-            loop
-            playsInline
-            preload="metadata"
-            className="w-full rounded-lg border border-gray-100 bg-black"
-          >
-            <track kind="captions" />
-          </video>
-        </div>
-
         <div className="flex flex-col gap-16">
-          <h3 className="text-body2b mobile:text-body3b text-black">실시간 중계</h3>
+          <h3 className="text-body2b mobile:text-body3b text-black">다시보기</h3>
           <div className="flex gap-8">
             {LIVE_STREAMS.map(({ date, label }, index) => (
               <button

--- a/src/widgets/main/model/useGetTeams.ts
+++ b/src/widgets/main/model/useGetTeams.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { getAllTeams } from "@/entities/team/api/getAllTeams";
+import { Team } from "@/entities/team/model/types";
+
+export const useGetTeams = () => {
+  return useQuery<Team[]>({
+    queryKey: ["mainTeams"],
+    queryFn: getAllTeams,
+  });
+};


### PR DESCRIPTION
## 💡 PR 요약

- 메인 페이지 "본선 진출팀" 표를 하드코딩 대신 `GET /team` API 조회 결과로 렌더링
- 본선 진출팀 결과를 발표 시각(기본 2026-07-31 10:00, env로 override 가능) 이전에는 비공개 처리
- 예선 라이브 섹션을 "실시간 중계" → "다시보기"로 전환하고 종료된 예선 소개 영상 제거
- 심사 폼에서 백엔드 데이터로 재현 불가능한 부정확한 실시간 순위/통계 표시 제거, +/- 버튼 UI를 삼각형 아이콘으로 변경
- 필기 캔버스 펜 색상 선택 UI 제거 및 도구 버튼 정리

## 📋 작업 내용

**본선 진출팀 API 연동**
- `src/widgets/main/model/useGetTeams.ts` 추가 — `GET /team` 조회 훅
- `FinalsVenueSection`에서 하드코딩된 `LINEUP` 배열 제거, API 데이터를 성능 순서(`performOrder`) 기준으로 좌/우 2단 표에 렌더링
- 로딩 중 스켈레톤, 빈 목록일 때 안내 문구 처리
- `분야`·`신청자명` 컬럼은 `/team` API 응답에 아직 없는 필드라 공란으로 유지 (백엔드 필드 추가 예정)
- `src/shared/config/dateConfig.ts`에 `finalsLineupReleaseDate`/`isFinalsLineupReleased` 추가, 발표 시각 이전에는 표 대신 안내 메시지 노출

**심사 폼**
- 점수 증감 버튼을 텍스트(+5/-5)에서 삼각형 아이콘(`Triangle` 컴포넌트) + 숫자 조합으로 변경

**필기 캔버스**
- 펜 색상 선택 UI 제거, 도구 버튼 레이아웃 정리

## 🤝 리뷰 시 참고사항

- `분야`·`신청자명`은 백엔드 필드 추가 후 후속 PR에서 채울 예정입니다.
