### PR TITLE
refactor: 본선 진출팀 목록 모바일 레이아웃 개선

### DIFF
--- a/src/widgets/main/FinalsVenueSection/index.tsx
+++ b/src/widgets/main/FinalsVenueSection/index.tsx
@@ -70,60 +70,50 @@ const FinalsVenueSection = () => {
                 본선 진출팀은 7월 31일(금) 오전 10시에 발표됩니다
               </p>
             </div>
+          ) : isLoading ? (
+            <div className="flex flex-col gap-8">
+              {Array.from({ length: 5 }).map((_, index) => (
+                <div key={index} className="h-32 w-full rounded-lg bg-gray-100 animate-pulse" />
+              ))}
+            </div>
+          ) : teams.length === 0 ? (
+            <div className="py-24 text-center text-gray-400">본선 진출팀 정보가 없습니다.</div>
           ) : (
-            <div className="w-full overflow-x-auto">
-              <div className="min-w-[720px] overflow-hidden rounded-xl">
-                <table className="w-full border-collapse text-center text-caption1r">
-                  <thead className="bg-gray-50 text-caption1b text-gray-700">
-                    <tr>
-                      <th className="border border-t-0 border-l-0 border-solid border-gray-200 px-12 py-10">
-                        번호
-                      </th>
-                      <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
-                        분야
-                      </th>
-                      <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
-                        팀명(소속)
-                      </th>
-                      <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
-                        신청자명
-                      </th>
-                      <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
-                        번호
-                      </th>
-                      <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
-                        분야
-                      </th>
-                      <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
-                        팀명(소속)
-                      </th>
-                      <th className="border border-t-0 border-r-0 border-solid border-gray-200 px-12 py-10">
-                        신청자명
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {isLoading ? (
+            <>
+              {/* 데스크톱: 2열 표 */}
+              <div className="w-full overflow-x-auto mobile:hidden">
+                <div className="min-w-[720px] overflow-hidden rounded-xl">
+                  <table className="w-full border-collapse text-center text-caption1r">
+                    <thead className="bg-gray-50 text-caption1b text-gray-700">
                       <tr>
-                        <td colSpan={8} className="px-12 py-10">
-                          <div className="flex flex-col gap-8">
-                            {Array.from({ length: 5 }).map((_, index) => (
-                              <div
-                                key={index}
-                                className="h-32 w-full rounded-lg bg-gray-100 animate-pulse"
-                              />
-                            ))}
-                          </div>
-                        </td>
+                        <th className="border border-t-0 border-l-0 border-solid border-gray-200 px-12 py-10">
+                          번호
+                        </th>
+                        <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
+                          분야
+                        </th>
+                        <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
+                          팀명(소속)
+                        </th>
+                        <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
+                          신청자명
+                        </th>
+                        <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
+                          번호
+                        </th>
+                        <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
+                          분야
+                        </th>
+                        <th className="border border-t-0 border-solid border-gray-200 px-12 py-10">
+                          팀명(소속)
+                        </th>
+                        <th className="border border-t-0 border-r-0 border-solid border-gray-200 px-12 py-10">
+                          신청자명
+                        </th>
                       </tr>
-                    ) : teams.length === 0 ? (
-                      <tr>
-                        <td colSpan={8} className="py-24 text-gray-400">
-                          본선 진출팀 정보가 없습니다.
-                        </td>
-                      </tr>
-                    ) : (
-                      lineupLeft.map((left, index) => {
+                    </thead>
+                    <tbody>
+                      {lineupLeft.map((left, index) => {
                         const right = lineupRight[index];
                         return (
                           <tr key={left.teamId}>
@@ -156,9 +146,7 @@ const FinalsVenueSection = () => {
                             </td>
                           </tr>
                         );
-                      })
-                    )}
-                    {!isLoading && teams.length > 0 && (
+                      })}
                       <tr className="bg-gray-50 text-caption1b">
                         <td className="border border-b-0 border-l-0 border-solid border-gray-200 px-12 py-10">
                           계
@@ -173,11 +161,37 @@ const FinalsVenueSection = () => {
                           총 36명
                         </td>
                       </tr>
-                    )}
-                  </tbody>
-                </table>
+                    </tbody>
+                  </table>
+                </div>
               </div>
-            </div>
+
+              {/* 모바일: 1열 나열 */}
+              <div className="hidden mobile:flex flex-col overflow-hidden rounded-xl border border-solid border-gray-200">
+                {teams.map((team) => (
+                  <div
+                    key={team.teamId}
+                    className="flex items-center gap-8 border-b border-solid border-gray-100 px-14 py-10 text-caption1r last:border-b-0"
+                  >
+                    <span className="w-20 shrink-0 text-center text-gray-500">
+                      {team.performOrder}
+                    </span>
+                    <span className="w-36 shrink-0 text-center text-caption2b text-orange-500">
+                      {TEAM_GENRE_LABELS[team.teamGenre]}
+                    </span>
+                    <span className="flex-1 truncate text-left text-black">
+                      {team.school ? `${team.teamName}(${team.school})` : team.teamName}
+                    </span>
+                    <span className="shrink-0 text-gray-600">{team.applicantName}</span>
+                  </div>
+                ))}
+                <div className="flex items-center justify-between gap-8 bg-gray-50 px-14 py-10 text-caption1b">
+                  <span className="text-gray-700">계</span>
+                  <span className="text-gray-700">국악1, 밴드4, 댄스2, 보컬3</span>
+                  <span className="text-orange-500">총 36명</span>
+                </div>
+              </div>
+            </>
           )}
         </div>
 


### PR DESCRIPTION
## 💡 PR 요약

- 모바일 화면에서 본선 진출팀 표가 가로 스크롤 없이 보이도록 1열 리스트 레이아웃 추가

## 📋 작업 내용

- 데스크톱(2열 표)과 모바일(1열 리스트)을 분리해 각 브레이크포인트에 맞는 레이아웃으로 렌더링
- 로딩 스켈레톤, 빈 상태("본선 진출팀 정보가 없습니다") 처리를 `<td>` 내부에서 공통 영역으로 옮겨 두 레이아웃에서 재사용
- 모바일 리스트에도 번호·분야·팀명(소속)·신청자명과 하단 합계를 동일하게 표시

## 🤝 리뷰 시 참고사항

- 하단 "계" 합계(국악1, 밴드4, 댄스2, 보컬3 / 총 36명)는 기존 코드처럼 여전히 하드코딩 값입니다. 이번에 모바일 레이아웃이 추가되면서 동일한 하드코딩 값이 두 곳(데스크톱/모바일)에 중복되는데, 팀 데이터가 바뀌면 두 곳 다 수정해야 하는 점을 인지해주세요. 이 PR 범위에서는 기존 동작을 유지하는 것으로 처리했습니다.
