### PR TITLE
feat: 본선 진출팀 섹션에 공연 순서 아님 안내 메시지 추가

### DIFF
--- a/src/widgets/main/FinalsVenueSection/index.tsx
+++ b/src/widgets/main/FinalsVenueSection/index.tsx
@@ -81,6 +81,11 @@ const FinalsVenueSection = () => {
           />
           <div className={cn("flex min-w-0 flex-1 flex-col gap-12")}>
             <h3 className="text-body2b mobile:text-body3b text-black">본선 진출팀</h3>
+            {isLineupReleased && !isLoading && teams.length > 0 && (
+              <p className="text-caption2r mobile:text-caption2r text-gray-500">
+                * 번호는 공연 순서가 아닙니다
+              </p>
+            )}
             {!isLineupReleased ? (
               <div className="flex flex-col items-center gap-4 rounded-xl bg-gray-50 py-40 text-center">
                 <p className="text-body3b mobile:text-caption1b text-gray-700">


### PR DESCRIPTION
## 💡 PR 요약

> 해당 PR의 변경사항, 해당 이슈 등에 대한 간략한 설명을 작성해주세요.

- 본선 진출팀 표/리스트의 "번호" 컬럼이 공연 순서로 오해되지 않도록 안내 문구 추가

## 📋 작업 내용

> 해당 PR에서 작업한 내용을 자세히 설명해주세요. + 스크린샷

- `FinalsVenueSection`에 "본선 진출팀" 제목 아래 "* 번호는 공연 순서가 아닙니다" 안내 문구 추가
- 본선 진출팀 명단이 발표되고 로딩이 끝난 뒤(팀 목록이 있을 때)에만 노출되도록 조건 처리
- 데스크톱 표, 모바일 리스트 모두 동일하게 적용
