### PR TITLE
fix: 좌석 밴 요청 바디에서 role 필드 제거

### DIFF
--- a/src/entities/booking/api/banSeat.ts
+++ b/src/entities/booking/api/banSeat.ts
@@ -1,6 +1,5 @@
 import { Seat } from "../model/types";
 import { toApiSeat } from "../model/seatLayouts";
-import { getTokenFromCookie } from "@/shared/utils/auth";
 import axios from "@/shared/lib/axios";
 import { AxiosError } from "axios";
 
@@ -19,8 +18,7 @@ const toSeatBanError = (error: unknown, fallback: string): SeatBanError => {
 
 export const banSeat = async (seat: Pick<Seat, "section" | "row" | "seatNumber">) => {
   try {
-    const role = getTokenFromCookie("role") || "USER";
-    const response = await axios.post("/seat/ban", { ...toApiSeat(seat), role });
+    const response = await axios.post("/seat/ban", toApiSeat(seat));
     return { data: response.data };
   } catch (error: unknown) {
     throw toSeatBanError(error, "좌석 임시 저장에 실패했습니다.");


### PR DESCRIPTION
## 💡 PR 요약

- 백엔드 `POST /seat/ban` 요청 스펙에서 `role` 필드가 제거되어 프론트 요청 바디를 맞췄습니다.

## 📋 작업 내용

- `banSeat`에서 쿠키로 `role`을 읽어 바디에 넣던 로직 제거
- 사용하지 않게 된 `getTokenFromCookie` import 제거
- Swagger 기준 요청 바디 확인
  - `POST /seat/ban` → `BanSeatRequest { seatSection, seatNumber }`
  - `DELETE /seat/ban` → `CancelSeatBanRequest { seatSection, seatNumber }`
- `toApiSeat`가 이미 `{ seatSection, seatNumber }`를 반환하므로 그대로 바디로 전달

## 🤝 리뷰 시 참고사항

- `cancelSeatBan`은 원래 `role`을 보내지 않아 변경사항 없습니다.
- `getMySeat.ts` / `useMySeat.ts` / `BookingPage`의 `role`은 엔드포인트 분기용이라 요청 바디와 무관해 그대로 두었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)