### PR TITLE
fix: 심사 채점 폼 UI 피드백 반영 및 헤더 모바일 버튼 수정

### DIFF
--- a/src/entities/judging/api/__tests__/saveScore.test.ts
+++ b/src/entities/judging/api/__tests__/saveScore.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AxiosError } from "axios";
+import { saveScore } from "../saveScore";
+import instance from "@/shared/lib/axios";
+
+vi.mock("@/shared/lib/axios", () => ({
+  default: {
+    patch: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("saveScore - 성공", () => {
+  it("teamId와 점수로 채점 API를 호출한다", async () => {
+    vi.mocked(instance.patch).mockResolvedValueOnce({ data: null });
+    const scores = {
+      completenessExpressionScore: 40,
+      creativityCompositionScore: 30,
+      stagePerformanceTeamworkScore: 30,
+    };
+
+    await saveScore(1, scores);
+
+    expect(instance.patch).toHaveBeenCalledWith("/judge/1", scores);
+  });
+});
+
+describe("saveScore - 실패", () => {
+  it("서버 에러 메시지가 있으면 해당 메시지로 Error를 throw한다", async () => {
+    const axiosError = new AxiosError("Request failed");
+    axiosError.response = {
+      data: { message: "이미 채점이 마감되었습니다." },
+      status: 400,
+      statusText: "Bad Request",
+      headers: {},
+      config: {} as never,
+    };
+    vi.mocked(instance.patch).mockRejectedValueOnce(axiosError);
+
+    await expect(
+      saveScore(1, {
+        completenessExpressionScore: 0,
+        creativityCompositionScore: 0,
+        stagePerformanceTeamworkScore: 0,
+      }),
+    ).rejects.toThrow("이미 채점이 마감되었습니다.");
+  });
+
+  it("서버 에러 메시지가 없으면 기본 메시지로 Error를 throw한다", async () => {
+    const axiosError = new AxiosError("Request failed");
+    axiosError.response = {
+      data: {},
+      status: 500,
+      statusText: "Internal Server Error",
+      headers: {},
+      config: {} as never,
+    };
+    vi.mocked(instance.patch).mockRejectedValueOnce(axiosError);
+
+    await expect(
+      saveScore(1, {
+        completenessExpressionScore: 0,
+        creativityCompositionScore: 0,
+        stagePerformanceTeamworkScore: 0,
+      }),
+    ).rejects.toThrow("심사 실패했습니다.");
+  });
+});

--- a/src/entities/judging/model/__tests__/score.test.ts
+++ b/src/entities/judging/model/__tests__/score.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { EMPTY_SCORE, SCORE_MAX, Score, TOTAL_MAX, getScoreTotal, toTeamScore } from "../score";
+
+const makeScore = (overrides: Partial<Score> = {}): Score => ({
+  judgementId: null,
+  teamId: 1,
+  teamName: "댄스팀",
+  completenessExpressionScore: 0,
+  creativityCompositionScore: 0,
+  stagePerformanceTeamworkScore: 0,
+  totalScore: 0,
+  isPerformed: false,
+  isJudged: false,
+  ...overrides,
+});
+
+describe("SCORE_MAX / TOTAL_MAX", () => {
+  it("각 평가 항목의 최대 점수 합이 TOTAL_MAX와 같다", () => {
+    const sum = Object.values(SCORE_MAX).reduce((acc, max) => acc + max, 0);
+    expect(sum).toBe(TOTAL_MAX);
+  });
+});
+
+describe("EMPTY_SCORE", () => {
+  it("모든 항목이 0점이다", () => {
+    expect(getScoreTotal(EMPTY_SCORE)).toBe(0);
+  });
+});
+
+describe("getScoreTotal", () => {
+  it("세 항목 점수의 합을 반환한다", () => {
+    const total = getScoreTotal({
+      completenessExpressionScore: 40,
+      creativityCompositionScore: 20,
+      stagePerformanceTeamworkScore: 10,
+    });
+
+    expect(total).toBe(70);
+  });
+});
+
+describe("toTeamScore", () => {
+  it("Score에서 평가 항목 점수만 추려 TeamScore로 변환한다", () => {
+    const score = makeScore({
+      completenessExpressionScore: 30,
+      creativityCompositionScore: 15,
+      stagePerformanceTeamworkScore: 5,
+      totalScore: 50,
+    });
+
+    expect(toTeamScore(score)).toEqual({
+      completenessExpressionScore: 30,
+      creativityCompositionScore: 15,
+      stagePerformanceTeamworkScore: 5,
+    });
+  });
+});

--- a/src/shared/ui/Header/index.tsx
+++ b/src/shared/ui/Header/index.tsx
@@ -94,9 +94,14 @@ export default function Header() {
             </div>
 
             {!isJudge && pathname.startsWith("/home") && (
-              <div onClick={toggleMobileMenu} className={cn("place-self-center")}>
+              <button
+                type="button"
+                onClick={toggleMobileMenu}
+                aria-label={isMobileMenuOpen ? "메뉴 닫기" : "메뉴 열기"}
+                className={cn("place-self-center cursor-pointer")}
+              >
                 {isMobileMenuOpen ? <CloseIcon /> : <MobileMenuIcon />}
-              </div>
+              </button>
             )}
           </div>
         </div>

--- a/src/shared/ui/Header/index.tsx
+++ b/src/shared/ui/Header/index.tsx
@@ -98,6 +98,8 @@ export default function Header() {
                 type="button"
                 onClick={toggleMobileMenu}
                 aria-label={isMobileMenuOpen ? "메뉴 닫기" : "메뉴 열기"}
+                aria-expanded={isMobileMenuOpen}
+                aria-controls="mobile-nav-panel"
                 className={cn("place-self-center cursor-pointer")}
               >
                 {isMobileMenuOpen ? <CloseIcon /> : <MobileMenuIcon />}
@@ -106,8 +108,12 @@ export default function Header() {
           </div>
         </div>
       </header>
-      {!isJudge && isMobileMenuOpen && pathname.startsWith("/home") && (
-        <MobileSidebar onClose={closeMobileMenu} onLinkClick={handleScrollToSection} />
+      {!isJudge && pathname.startsWith("/home") && (
+        <MobileSidebar
+          isOpen={isMobileMenuOpen}
+          onClose={closeMobileMenu}
+          onLinkClick={handleScrollToSection}
+        />
       )}
     </>
   );

--- a/src/shared/ui/Header/ui/MobileSidebar.tsx
+++ b/src/shared/ui/Header/ui/MobileSidebar.tsx
@@ -10,8 +10,6 @@ interface MobileSidebarProps {
   onLinkClick: (section: string) => void;
 }
 
-const HEADER_HEIGHT_VAR = "var(--header-height, 4.625rem)";
-
 export const MobileSidebar = ({ isOpen, onClose, onLinkClick }: MobileSidebarProps) => {
   useEffect(() => {
     if (!isOpen) return;
@@ -26,8 +24,10 @@ export const MobileSidebar = ({ isOpen, onClose, onLinkClick }: MobileSidebarPro
 
   return (
     <div
-      className={cn("fixed inset-x-0 bottom-0 z-20 hidden mobile:block")}
-      style={{ top: HEADER_HEIGHT_VAR }}
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-20 hidden mobile:block",
+        "top-[var(--header-height,4.625rem)]",
+      )}
       aria-hidden={!isOpen}
     >
       <div

--- a/src/shared/ui/Header/ui/MobileSidebar.tsx
+++ b/src/shared/ui/Header/ui/MobileSidebar.tsx
@@ -1,37 +1,61 @@
 "use client";
 
+import { useEffect } from "react";
 import { links } from "@/shared/const/headerValues";
 import { cn } from "@/shared/utils/cn";
 
 interface MobileSidebarProps {
+  isOpen: boolean;
   onClose: () => void;
   onLinkClick: (section: string) => void;
 }
 
-export const MobileSidebar = ({ onClose, onLinkClick }: MobileSidebarProps) => {
+const HEADER_HEIGHT_VAR = "var(--header-height, 4.625rem)";
+
+export const MobileSidebar = ({ isOpen, onClose, onLinkClick }: MobileSidebarProps) => {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
   return (
     <div
-      className={cn(
-        "fixed top-74px right-0 w-full h-[calc(100vh-64px)] mobile:block hidden z-10",
-      )}
+      className={cn("fixed inset-x-0 bottom-0 z-20 hidden mobile:block")}
+      style={{ top: HEADER_HEIGHT_VAR }}
+      aria-hidden={!isOpen}
     >
-      <div className={cn("flex h-full")}>
-        <div
-          className={cn("w-[calc(100vw-129px)]", "bg-black/40")}
-          onClick={onClose}
-        ></div>
-        <div className={cn("w-[129px] bg-white")}>
-          <div className={cn("flex flex-col gap-[2.5rem] text-body3b m-26")}>
-            {links.map((link, index) => (
-              <button
-                key={index}
-                onClick={() => onLinkClick(link.section)}
-              >
-                {link.label}
-              </button>
-            ))}
-          </div>
-        </div>
+      <div
+        onClick={onClose}
+        className={cn(
+          "absolute inset-0 bg-black/40 transition-opacity duration-200",
+          isOpen ? "opacity-100" : "pointer-events-none opacity-0",
+        )}
+      />
+
+      <div
+        id="mobile-nav-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label="모바일 메뉴"
+        className={cn(
+          "absolute right-0 top-0 h-full w-[129px] bg-white",
+          "transition-transform duration-200 ease-out",
+          isOpen ? "translate-x-0" : "pointer-events-none translate-x-full",
+        )}
+      >
+        <nav className={cn("flex flex-col gap-[2.5rem] text-body3b m-26")}>
+          {links.map(link => (
+            <button key={link.section} type="button" onClick={() => onLinkClick(link.section)}>
+              {link.label}
+            </button>
+          ))}
+        </nav>
       </div>
     </div>
   );

--- a/src/widgets/judging/ui/ScoreForm/index.tsx
+++ b/src/widgets/judging/ui/ScoreForm/index.tsx
@@ -18,13 +18,13 @@ const POSITIVE_STEPS = [1, 5];
 
 // 점수 변동 폭이 클수록 색을 더 진하게 표시한다 (마이너스: 파랑, 플러스: 주황)
 const NEGATIVE_STYLES: Record<number, string> = {
-  "-1": "border-blue-200 bg-blue-100 text-blue-600 hover:bg-blue-200 hover:border-blue-300 active:bg-blue-300",
-  "-5": "border-blue-500 bg-blue-500 text-white hover:brightness-110 active:brightness-90",
+  "-1": "bg-blue-100 text-blue-600 hover:bg-blue-200 active:bg-blue-300",
+  "-5": "bg-blue-500 text-white hover:brightness-110 active:brightness-90",
 };
 
 const POSITIVE_STYLES: Record<number, string> = {
-  "1": "border-orange-300 bg-orange-300 text-gray-900 hover:brightness-105 active:brightness-95",
-  "5": "border-orange-500 bg-orange-500 text-white hover:brightness-110 active:brightness-90",
+  "1": "bg-orange-300 text-gray-900 hover:brightness-105 active:brightness-95",
+  "5": "bg-orange-500 text-white hover:brightness-110 active:brightness-90",
 };
 
 type ScoreFormProps = {
@@ -75,7 +75,6 @@ const ScoreForm = ({
                       aria-label={`${label} ${-step}점 내리기`}
                       className={cn(
                         "w-64 h-72 mobile:w-48 mobile:h-60 flex items-center justify-center pb-10 mobile:pb-8",
-                        "border",
                         NEGATIVE_STYLES[step],
                         "active:scale-95 transition touch-manipulation select-none cursor-pointer",
                         ARROW_DOWN_CLIP,
@@ -97,7 +96,6 @@ const ScoreForm = ({
                       aria-label={`${label} ${step}점 올리기`}
                       className={cn(
                         "w-64 h-72 mobile:w-48 mobile:h-60 flex items-center justify-center pt-10 mobile:pt-8",
-                        "border",
                         POSITIVE_STYLES[step],
                         "active:scale-95 transition touch-manipulation select-none cursor-pointer",
                         ARROW_UP_CLIP,

--- a/src/widgets/judging/ui/ScoreForm/index.tsx
+++ b/src/widgets/judging/ui/ScoreForm/index.tsx
@@ -16,6 +16,17 @@ const ARROW_DOWN_CLIP = "[clip-path:polygon(0_0,0_70%,50%_100%,100%_70%,100%_0)]
 const NEGATIVE_STEPS = [-5, -1];
 const POSITIVE_STEPS = [1, 5];
 
+// 점수 변동 폭이 클수록 색을 더 진하게 표시한다 (마이너스: 파랑, 플러스: 주황)
+const NEGATIVE_STYLES: Record<number, string> = {
+  "-1": "border-blue-200 bg-blue-100 text-blue-600 hover:bg-blue-200 hover:border-blue-300 active:bg-blue-300",
+  "-5": "border-blue-500 bg-blue-500 text-white hover:brightness-110 active:brightness-90",
+};
+
+const POSITIVE_STYLES: Record<number, string> = {
+  "1": "border-orange-300 bg-orange-300 text-gray-900 hover:brightness-105 active:brightness-95",
+  "5": "border-orange-500 bg-orange-500 text-white hover:brightness-110 active:brightness-90",
+};
+
 type ScoreFormProps = {
   performOrder: number;
   teamName: string;
@@ -64,13 +75,13 @@ const ScoreForm = ({
                       aria-label={`${label} ${-step}점 내리기`}
                       className={cn(
                         "w-64 h-72 mobile:w-48 mobile:h-60 flex items-center justify-center pb-10 mobile:pb-8",
-                        "border border-gray-300 bg-gray-50 text-gray-600",
-                        "hover:bg-gray-200 hover:border-gray-400 active:bg-gray-300 active:scale-95",
-                        "transition touch-manipulation select-none cursor-pointer",
+                        "border",
+                        NEGATIVE_STYLES[step],
+                        "active:scale-95 transition touch-manipulation select-none cursor-pointer",
                         ARROW_DOWN_CLIP,
                       )}
                     >
-                      <span className="text-title4b mobile:text-body2b">{-step}</span>
+                      <span className="text-title4b mobile:text-body2b">{step}</span>
                     </button>
                   ))}
 
@@ -86,9 +97,9 @@ const ScoreForm = ({
                       aria-label={`${label} ${step}점 올리기`}
                       className={cn(
                         "w-64 h-72 mobile:w-48 mobile:h-60 flex items-center justify-center pt-10 mobile:pt-8",
-                        "border border-orange-400 bg-orange-400 text-white",
-                        "hover:bg-orange-500 hover:border-orange-500 active:bg-orange-600 active:scale-95",
-                        "transition touch-manipulation select-none cursor-pointer",
+                        "border",
+                        POSITIVE_STYLES[step],
+                        "active:scale-95 transition touch-manipulation select-none cursor-pointer",
                         ARROW_UP_CLIP,
                       )}
                     >

--- a/src/widgets/main/JudgeInfoSection/index.tsx
+++ b/src/widgets/main/JudgeInfoSection/index.tsx
@@ -19,7 +19,7 @@ import PenField from "./ui/PenField";
 
 const INFO_FIELDS = [
   { key: "affiliationStrokes", label: "소속" },
-  { key: "positionStrokes", label: "지위" },
+  { key: "positionStrokes", label: "직급" },
   { key: "nameStrokes", label: "이름" },
 ] as const;
 


### PR DESCRIPTION
## 💡 PR 요약

- 심사 채점 폼(+/- 버튼) 색상 및 부호 표시 개선
- 심사위원 정보 입력 라벨 "지위" → "직급" 변경
- 모바일 헤더 햄버거 메뉴 버튼을 실제 button 요소로 변경
- 심사 채점 로직(score.ts, saveScore.ts) 단위 테스트 추가

## 📋 작업 내용

- **ScoreForm**: 마이너스 버튼에 부호(`-1`, `-5`)가 표시되지 않고 양수로만 보이던 문제 수정. 마이너스 버튼 색상을 회색에서 파란색 계열로 변경하고, 점수 변동 폭(±1 / ±5)이 클수록 색을 더 진하게 표시하도록 개선
- **JudgeInfoSection**: 심사위원 정보 입력 필드 라벨을 "지위"에서 "직급"으로 수정
- **Header**: 모바일 햄버거 메뉴 버튼이 `div onClick`으로 되어 있어 터치 반응이 불안정할 수 있는 문제를 발견해 실제 `button` 요소 + `aria-label`로 교체
- **entities/judging**: 기존에 테스트가 없던 `score.ts`의 점수 계산 순수 함수(`getScoreTotal`, `toTeamScore` 등)와 `saveScore.ts`의 채점 저장 API 에러 처리 로직에 단위 테스트 추가
- 심사집계표(`/admin/judging-result`) 실시간 연결(SSE) 로직을 재검토했으며, 기존 테스트 10건이 모두 통과함을 확인 (별도 코드 수정 없음)

## 🤝 리뷰 시 참고사항

- 프로젝트에 별도의 blue 팔레트가 정의되어 있지 않아, 마이너스 버튼 색상은 Tailwind 기본 blue 스케일(`blue-100` ~ `blue-600`)을 사용했습니다. 브랜드 컬러 가이드와 다르면 알려주세요.
