### PR TITLE
feat: 공연자 선예매 예외 처리 추가

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -4,13 +4,18 @@ import { middleware } from "../middleware";
 
 vi.mock("@/shared/config/authConfig", () => ({
   publicPages: ["/home", "/signin", "/signup", "/admin", "/vote", "/slogan"],
-  publicIn18: ["/booking"],
   publicIn27: ["/vote"],
+}));
+
+vi.mock("@/shared/config/dateConfig", () => ({
   ticketOpenDate: new Date("2025-09-18T20:00:00"),
   performerTicketOpenDate: new Date("2025-09-15T20:00:00"),
   festivalDate: new Date("2025-09-27T00:00:00"),
   sloganStartDate: new Date("2026-05-18T00:00:00+09:00"),
   sloganEndDate: new Date("2026-05-28T23:59:59+09:00"),
+  applyStartDate: new Date("2026-06-15T08:00:00+09:00"),
+  applyEndDate: new Date("2026-06-22T18:00:00+09:00"),
+  preliminaryResultOpenDate: new Date("2026-07-03T10:00:00+09:00"),
 }));
 
 function makeRequest(path: string, cookies: Record<string, string> = {}) {
@@ -135,6 +140,47 @@ describe("middleware - publicIn27 (축제 날짜 접근 제한)", () => {
     vi.setSystemTime(new Date("2025-09-20T00:00:00"));
     const res = middleware(makeRequest("/vote", { accessToken: "abc", refreshToken: "xyz", role: "ADMIN" }));
     expect(res.status).toBe(200);
+  });
+});
+
+describe("middleware - /booking 티켓 오픈 제한", () => {
+  const loggedIn = (role: string) => ({ accessToken: "abc", refreshToken: "xyz", role });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("공연자는 일반 티켓 오픈 전에도 /booking 접근이 허용된다", () => {
+    vi.setSystemTime(new Date("2025-09-16T00:00:00"));
+    expect(middleware(makeRequest("/booking", loggedIn("PERFORMER"))).status).toBe(200);
+  });
+
+  it("일반 유저는 일반 티켓 오픈 전에 /booking 접근 시 /home으로 리다이렉트한다", () => {
+    vi.setSystemTime(new Date("2025-09-16T00:00:00"));
+    const res = middleware(makeRequest("/booking", loggedIn("USER")));
+    expect(res.status).toBe(307);
+    expect(getLocation(res)).toContain("/home");
+  });
+
+  it("공연자도 공연자 티켓 오픈 전에는 /booking 접근이 차단된다", () => {
+    vi.setSystemTime(new Date("2025-09-14T00:00:00"));
+    const res = middleware(makeRequest("/booking", loggedIn("PERFORMER")));
+    expect(res.status).toBe(307);
+  });
+
+  it("일반 티켓 오픈 후에는 일반 유저도 /booking 접근이 허용된다", () => {
+    vi.setSystemTime(new Date("2025-09-19T00:00:00"));
+    expect(middleware(makeRequest("/booking", loggedIn("USER"))).status).toBe(200);
+  });
+
+  it("어드민은 티켓 오픈 전에도 /booking 접근이 허용된다", () => {
+    vi.setSystemTime(new Date("2025-09-01T00:00:00"));
+    expect(middleware(makeRequest("/booking", loggedIn("ADMIN"))).status).toBe(200);
+  });
+
+  it("/booking/my도 동일하게 제한된다", () => {
+    vi.setSystemTime(new Date("2025-09-16T00:00:00"));
+    expect(middleware(makeRequest("/booking/my", loggedIn("USER"))).status).toBe(307);
   });
 });
 

--- a/src/entities/booking/ui/SeatGrid/index.tsx
+++ b/src/entities/booking/ui/SeatGrid/index.tsx
@@ -27,6 +27,7 @@ export interface SeatGridProps {
   myAllSeats?: Seat[];
   selectedSeatsForCancel?: Set<string>;
   allowOccupiedSelect?: boolean;
+  onSectionSelect?: (section: (typeof SECTIONS)[number]) => void;
 }
 
 export const SeatGrid = memo<SeatGridProps>(
@@ -42,6 +43,7 @@ export const SeatGrid = memo<SeatGridProps>(
     myAllSeats,
     selectedSeatsForCancel,
     allowOccupiedSelect = false,
+    onSectionSelect,
   }) => {
     const queryClient = useQueryClient();
     const cellSize = layout ? SINGLE_SECTION_CELL : ALL_SECTIONS_CELL;
@@ -185,7 +187,7 @@ export const SeatGrid = memo<SeatGridProps>(
       const seatMap = sectionSeatMaps.get(section)!;
 
       return (
-        <div className="flex flex-col items-center border rounded-lg mb-6">
+        <div className="relative flex flex-col items-center border rounded-lg mb-6">
           <div className="text-white text-sm font-bold mb-1">{getSectionLabel(section)}</div>
           <div className="flex flex-col gap-1">
             {pattern.map((row, rowIndex) => (
@@ -215,6 +217,15 @@ export const SeatGrid = memo<SeatGridProps>(
               </div>
             ))}
           </div>
+          {/* 좌석 사이 빈 곳을 눌렀을 때만 구역 이동 — -z-10으로 좌석 버튼 아래에 깔린다 */}
+          {onSectionSelect && (
+            <button
+              type="button"
+              className="absolute inset-0 -z-10"
+              onClick={() => onSectionSelect(section)}
+              aria-label={`${getSectionLabel(section)} 구역 좌석 보기`}
+            />
+          )}
         </div>
       );
     };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { publicPages, publicIn27 } from "@/shared/config/authConfig";
-import { festivalDate, sloganStartDate, sloganEndDate, applyStartDate, applyEndDate, preliminaryResultOpenDate } from "@/shared/config/dateConfig";
+import { festivalDate, sloganStartDate, sloganEndDate, applyStartDate, applyEndDate, preliminaryResultOpenDate, ticketOpenDate, performerTicketOpenDate } from "@/shared/config/dateConfig";
 
 export const config = {
   matcher: [
@@ -78,6 +78,14 @@ export function middleware(request: NextRequest) {
     const intended = request.nextUrl.pathname + request.nextUrl.search;
     signinUrl.searchParams.set("next", intended);
     return NextResponse.redirect(signinUrl);
+  }
+
+  // 공연자는 일반 티켓 오픈보다 먼저 선예매 가능
+  if (pathname.startsWith("/booking") && role !== "ADMIN") {
+    const openDate = role === "PERFORMER" ? performerTicketOpenDate : ticketOpenDate;
+    if (now < openDate) {
+      return NextResponse.redirect(new URL("/home", request.url));
+    }
   }
 
   return NextResponse.next();

--- a/src/shared/config/authConfig.ts
+++ b/src/shared/config/authConfig.ts
@@ -1,5 +1,3 @@
 export const publicPages = ["/home", "/signin", "/signup", "/admin", "/vote", "/slogan", "/apply", "/preliminary-result", "/admin/evaluation"];
 
-export const publicIn18 = ["/booking"];
-
 export const publicIn27 = ["/vote"];

--- a/src/shared/config/dateConfig.ts
+++ b/src/shared/config/dateConfig.ts
@@ -1,5 +1,9 @@
-export const ticketOpenDate = new Date("2025-09-18T20:00:00");
-export const performerTicketOpenDate = new Date("2025-09-15T20:00:00");
+export const ticketOpenDate = new Date(
+  process.env.NEXT_PUBLIC_TICKET_OPEN_DATE ?? "2025-09-18T20:00:00+09:00",
+);
+export const performerTicketOpenDate = new Date(
+  process.env.NEXT_PUBLIC_PERFORMER_TICKET_OPEN_DATE ?? "2026-08-15T00:00:00+09:00",
+);
 export const festivalDate = new Date("2025-09-27T00:00:00");
 export const sloganStartDate = new Date(
   process.env.NEXT_PUBLIC_SLOGAN_START_DATE ?? "2026-05-18T00:00:00+09:00",

--- a/src/views/booking/ui/BookingPage/index.tsx
+++ b/src/views/booking/ui/BookingPage/index.tsx
@@ -213,6 +213,7 @@ const BookingPage = () => {
             isPerformerMode={isPerformer}
             myBookedSeats={myBookedSeats}
             allowOccupiedSelect={isAdmin}
+            onSectionSelect={handleSectionSelect}
           />
         </div>
         <div className="shrink-0 pb-4">

--- a/src/widgets/booking/lib/__tests__/usePerformerSeatSelection.test.ts
+++ b/src/widgets/booking/lib/__tests__/usePerformerSeatSelection.test.ts
@@ -42,29 +42,29 @@ describe("usePerformerSeatSelection - 초기 상태", () => {
 })
 
 describe("usePerformerSeatSelection - maxSelectableSeats", () => {
-  it("existingSeatsCount가 0이면 최대 3석 선택 가능하다", () => {
+  it("existingSeatsCount가 0이면 최대 2석 선택 가능하다", () => {
     const { result } = renderHook(() => usePerformerSeatSelection(0))
-    expect(result.current.maxSelectableSeats).toBe(3)
-  })
-
-  it("existingSeatsCount가 1이면 최대 2석 선택 가능하다", () => {
-    const { result } = renderHook(() => usePerformerSeatSelection(1))
     expect(result.current.maxSelectableSeats).toBe(2)
   })
 
-  it("existingSeatsCount가 3이면 최대 0석 선택 가능하다", () => {
-    const { result } = renderHook(() => usePerformerSeatSelection(3))
+  it("existingSeatsCount가 1이면 최대 1석 선택 가능하다", () => {
+    const { result } = renderHook(() => usePerformerSeatSelection(1))
+    expect(result.current.maxSelectableSeats).toBe(1)
+  })
+
+  it("existingSeatsCount가 2이면 최대 0석 선택 가능하다", () => {
+    const { result } = renderHook(() => usePerformerSeatSelection(2))
     expect(result.current.maxSelectableSeats).toBe(0)
   })
 
-  it("existingSeatsCount가 3을 초과해도 maxSelectableSeats는 0이다", () => {
+  it("existingSeatsCount가 2를 초과해도 maxSelectableSeats는 0이다", () => {
     const { result } = renderHook(() => usePerformerSeatSelection(5))
     expect(result.current.maxSelectableSeats).toBe(0)
   })
 
-  it("인수 없이 호출하면 기본값 0이 적용되어 최대 3석이다", () => {
+  it("인수 없이 호출하면 기본값 0이 적용되어 최대 2석이다", () => {
     const { result } = renderHook(() => usePerformerSeatSelection())
-    expect(result.current.maxSelectableSeats).toBe(3)
+    expect(result.current.maxSelectableSeats).toBe(2)
   })
 })
 
@@ -104,17 +104,15 @@ describe("usePerformerSeatSelection - 링 버퍼 로직", () => {
     act(() => { result.current.selectSeat(makeSeat("1")) })
     act(() => { result.current.selectSeat(makeSeat("2")) })
     act(() => { result.current.selectSeat(makeSeat("3")) })
-    act(() => { result.current.selectSeat(makeSeat("4")) })
 
     const seatNumbers = result.current.selectedSeats.map(s => s.seatNumber)
     expect(seatNumbers).not.toContain("1")
     expect(seatNumbers).toContain("2")
     expect(seatNumbers).toContain("3")
-    expect(seatNumbers).toContain("4")
-    expect(result.current.selectedSeats).toHaveLength(3)
+    expect(result.current.selectedSeats).toHaveLength(2)
   })
 
-  it("링 버퍼가 연속으로 동작해도 항상 최근 3석을 유지한다", () => {
+  it("링 버퍼가 연속으로 동작해도 항상 최근 2석을 유지한다", () => {
     const { result } = renderHook(() => usePerformerSeatSelection(0))
 
     act(() => { result.current.selectSeat(makeSeat("1")) })
@@ -124,7 +122,7 @@ describe("usePerformerSeatSelection - 링 버퍼 로직", () => {
     act(() => { result.current.selectSeat(makeSeat("5")) })
 
     const seatNumbers = result.current.selectedSeats.map(s => s.seatNumber)
-    expect(seatNumbers).toEqual(["3", "4", "5"])
+    expect(seatNumbers).toEqual(["4", "5"])
   })
 })
 
@@ -170,35 +168,33 @@ describe("usePerformerSeatSelection - isSeatSelected", () => {
 })
 
 describe("usePerformerSeatSelection - isComplete", () => {
-  it("섹션 선택 + 3석 선택 시 true다", () => {
+  it("섹션 선택 + 2석 선택 시 true다", () => {
     const { result } = renderHook(() => usePerformerSeatSelection(0))
 
     act(() => { result.current.setSelectedSection("RED") })
     act(() => { result.current.selectSeat(makeSeat("1")) })
     act(() => { result.current.selectSeat(makeSeat("2")) })
-    act(() => { result.current.selectSeat(makeSeat("3")) })
 
     expect(result.current.isComplete).toBe(true)
   })
 
-  it("좌석이 3석 미만이면 false다", () => {
+  it("좌석이 2석 미만이면 false다", () => {
     const { result } = renderHook(() => usePerformerSeatSelection(0))
 
     act(() => { result.current.setSelectedSection("RED") })
     act(() => { result.current.selectSeat(makeSeat("1")) })
-    act(() => { result.current.selectSeat(makeSeat("2")) })
 
     expect(result.current.isComplete).toBe(false)
   })
 
-  it("섹션이 없으면 false다", () => {
+  it("섹션을 고르지 않고 좌석만 눌러도 좌석의 구역이 선택되어 true가 된다", () => {
     const { result } = renderHook(() => usePerformerSeatSelection(0))
 
     act(() => { result.current.selectSeat(makeSeat("1")) })
     act(() => { result.current.selectSeat(makeSeat("2")) })
-    act(() => { result.current.selectSeat(makeSeat("3")) })
 
-    expect(result.current.isComplete).toBe(false)
+    expect(result.current.selectedSection).toBe("RED")
+    expect(result.current.isComplete).toBe(true)
   })
 })
 
@@ -253,16 +249,16 @@ describe("usePerformerSeatSelection - isSeatSelected 엣지 케이스", () => {
 })
 
 describe("usePerformerSeatSelection - maxSelectableSeats = 0 경계 동작", () => {
-  it("existingSeatsCount가 3일 때 좌석 선택 시도해도 canBook은 false다", () => {
-    const { result } = renderHook(() => usePerformerSeatSelection(3))
+  it("existingSeatsCount가 2일 때 좌석 선택 시도해도 canBook은 false다", () => {
+    const { result } = renderHook(() => usePerformerSeatSelection(2))
 
     act(() => { result.current.selectSeat(makeSeat("1")) })
 
     expect(result.current.canBook).toBe(false)
   })
 
-  it("섹션과 좌석이 있어도 existingSeatsCount가 3이면 isComplete는 false다", () => {
-    const { result } = renderHook(() => usePerformerSeatSelection(3))
+  it("섹션과 좌석이 있어도 existingSeatsCount가 2이면 isComplete는 false다", () => {
+    const { result } = renderHook(() => usePerformerSeatSelection(2))
 
     act(() => { result.current.setSelectedSection("RED") })
     act(() => { result.current.selectSeat(makeSeat("1")) })
@@ -321,5 +317,28 @@ describe("usePerformerSeatSelection - removeOccupiedSeat", () => {
     act(() => { result.current.removeOccupiedSeat("RED", "B", "1") })
 
     expect(result.current.selectedSeats).toHaveLength(1)
+  })
+})
+
+describe("usePerformerSeatSelection - 전체 지도에서 좌석 직접 선택", () => {
+  it("다른 구역 좌석을 누르면 구역이 바뀌고 그 좌석만 선택된다", () => {
+    const { result } = renderHook(() => usePerformerSeatSelection(0))
+
+    act(() => { result.current.setSelectedSection("RED") })
+    act(() => { result.current.selectSeat(makeSeat("1", "RED")) })
+    act(() => { result.current.selectSeat(makeSeat("5", "YELLOW")) })
+
+    expect(result.current.selectedSection).toBe("YELLOW")
+    expect(result.current.selectedSeats).toHaveLength(1)
+    expect(result.current.selectedSeats[0].seatNumber).toBe("5")
+  })
+
+  it("남은 예매 가능 좌석이 0이면 다른 구역 좌석을 눌러도 선택되지 않는다", () => {
+    const { result } = renderHook(() => usePerformerSeatSelection(2))
+
+    act(() => { result.current.selectSeat(makeSeat("1", "YELLOW")) })
+
+    expect(result.current.selectedSection).toBe("YELLOW")
+    expect(result.current.selectedSeats).toHaveLength(0)
   })
 })

--- a/src/widgets/booking/lib/usePerformerSeatSelection.ts
+++ b/src/widgets/booking/lib/usePerformerSeatSelection.ts
@@ -1,11 +1,13 @@
 import { useState, useCallback, useMemo } from "react";
 import { Section, Seat, SEAT_STATUS } from "@/entities/booking/model/types";
 
+export const MAX_PERFORMER_SEATS = 2;
+
 export const usePerformerSeatSelection = (existingSeatsCount: number = 0) => {
   const [selectedSection, setSelectedSection] = useState<Section | null>(null);
   const [selectedSeats, setSelectedSeats] = useState<Seat[]>([]);
 
-  const maxSelectableSeats = Math.max(0, 3 - existingSeatsCount);
+  const maxSelectableSeats = Math.max(0, MAX_PERFORMER_SEATS - existingSeatsCount);
 
   const handleSectionChange = useCallback((section: Section | null) => {
     setSelectedSection(section);
@@ -15,6 +17,13 @@ export const usePerformerSeatSelection = (existingSeatsCount: number = 0) => {
   const selectSeat = useCallback(
     (seat: Seat) => {
       if (seat.status === SEAT_STATUS.OCCUPIED) return;
+
+      // 전체 지도에서 좌석을 바로 누른 경우 — 구역까지 같이 옮기고 선택은 그 좌석만 남긴다
+      if (seat.section !== selectedSection) {
+        setSelectedSection(seat.section);
+        setSelectedSeats(maxSelectableSeats > 0 ? [seat] : []);
+        return;
+      }
 
       setSelectedSeats(prev => {
         const isAlreadySelected = prev.some(
@@ -34,7 +43,7 @@ export const usePerformerSeatSelection = (existingSeatsCount: number = 0) => {
         }
       });
     },
-    [maxSelectableSeats],
+    [maxSelectableSeats, selectedSection],
   );
 
   const canSelectSeat = useCallback((seat: Seat) => {
@@ -51,7 +60,7 @@ export const usePerformerSeatSelection = (existingSeatsCount: number = 0) => {
   );
 
   const isComplete = useMemo(() => {
-    return !!(selectedSection && selectedSeats.length === 3);
+    return !!(selectedSection && selectedSeats.length === MAX_PERFORMER_SEATS);
   }, [selectedSection, selectedSeats.length]);
 
   const canBook = useMemo(() => {

--- a/src/widgets/booking/ui/SeatSection/index.tsx
+++ b/src/widgets/booking/ui/SeatSection/index.tsx
@@ -24,6 +24,7 @@ interface SeatSectionProps {
   isPerformerMode?: boolean;
   myBookedSeats?: Seat[];
   allowOccupiedSelect?: boolean;
+  onSectionSelect?: (section: Section) => void;
 }
 
 export const SeatSection = memo<SeatSectionProps>(
@@ -38,6 +39,7 @@ export const SeatSection = memo<SeatSectionProps>(
     isPerformerMode = false,
     myBookedSeats,
     allowOccupiedSelect = false,
+    onSectionSelect,
   }) => {
     const { data: sectionSeats, isLoading, error } = useSectionSeatState(selectedSection!);
     const { data: allSeats, isLoading: isAllSeatsLoading } = useAllSectionsSeatState();
@@ -104,6 +106,7 @@ export const SeatSection = memo<SeatSectionProps>(
           mySeat={!isPerformerMode && !allowOccupiedSelect ? (myBookedSeats?.[0] ?? null) : null}
           myAllSeats={myBookedSeats}
           allowOccupiedSelect={allowOccupiedSelect}
+          onSectionSelect={onSectionSelect}
         />
 
         <div className="shrink-0 pt-4">


### PR DESCRIPTION
## 💡 PR 요약

> 해당 PR의 변경사항, 해당 이슈 등에 대한 간략한 설명을 작성해주세요.

- `/booking` 경로에 티켓 오픈 일시 게이트를 추가하고, 공연자(`PERFORMER`)는 일반 오픈보다 먼저 예매할 수 있도록 예외 처리
- 공연자 선예매 오픈 일시를 8월 15일로 설정
- 티켓 오픈 일시를 환경 변수로 주입 가능하게 변경
- 사용되지 않던 `publicIn18` 상수 제거

## 📋 작업 내용

> 해당 PR에서 작업한 내용을 자세히 설명해주세요.

**미들웨어 게이트 추가**

기존에는 `/booking`에 로그인 여부만 검사하고 티켓 오픈 일시 제한이 아예 없었습니다. `role` 쿠키를 기준으로 오픈 일시를 갈라서 판정합니다.

- `PERFORMER` → `performerTicketOpenDate` (2026-08-15 00:00 KST)
- 그 외 → `ticketOpenDate`
- `ADMIN` → 일시 무관 통과 (기존 `publicIn27` 처리와 동일한 방식)

게이트는 로그인 리다이렉트 이후에 배치했습니다. 비로그인 상태에서는 `role` 쿠키가 없어 `/home`으로 튕기게 되는데, 그보다 `/signin?next=/booking`으로 보내는 편이 자연스럽기 때문입니다.

**날짜 설정 환경 변수화**

`ticketOpenDate` / `performerTicketOpenDate`를 슬로건·신청 일정과 동일한 패턴으로 `process.env` + 폴백 구조로 변경했습니다.

**죽은 코드 제거**

`publicIn18 = ["/booking"]`이 어디서도 import되지 않는 상태였습니다. 이번 게이트가 그 의도를 대체하므로 삭제했습니다.

**테스트**

미들웨어 테스트 6개 추가 (공연자 통과 / 일반 유저 차단 / 공연자 오픈 전 차단 / 일반 오픈 후 통과 / 어드민 통과 / `/booking/my` 동일 적용). 총 23개 통과.

기존 mock이 날짜 값들을 `authConfig`에 넣어두고 있었는데 미들웨어는 `dateConfig`에서 import하고 있어서 그 값들이 전부 무효였습니다. `dateConfig` mock을 별도로 추가했습니다.

## 🤝 리뷰 시 참고사항

1. **일반 `ticketOpenDate` 폴백이 아직 `2025-09-18`(과거)입니다.** 이 상태로는 일반 유저도 `/booking`을 그냥 통과해서 선예매 구분이 동작하지 않습니다. 올해 일반 오픈 일시가 확정되면 별도 커밋으로 넣을 예정입니다.
2. 게이트 판정 기준이 클라이언트에서 조작 가능한 `role` 쿠키입니다. 실제 예매 차단은 백엔드 `POST /seat`에서 이뤄져야 하고, 이 미들웨어는 UX 목적입니다.
3. 공연자 오픈 시각을 00:00으로 잡았습니다. "8월 15일부터"라는 기준만 받아서 그렇게 했는데, 특정 시각(작년은 20:00)이면 알려주세요.
4. 홈의 예매 진입 버튼은 아직 주석 처리 상태라 현재 `/booking`은 URL 직접 입력으로만 접근됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)