### PR TITLE
fix: SSE 연결 타임아웃으로 인한 재연결 반복 문제 해결

### DIFF
--- a/src/app/api/judge/monitor/changes/route.ts
+++ b/src/app/api/judge/monitor/changes/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 export async function GET(request: NextRequest) {
   try {
@@ -35,6 +36,9 @@ export async function GET(request: NextRequest) {
     responseHeaders.set("Cache-Control", "no-cache, no-transform");
     responseHeaders.set("Connection", "keep-alive");
     responseHeaders.set("Transfer-Encoding", "chunked");
+    // 프록시(nginx 등)가 스트림을 버퍼링하면 첫 바이트가 도달하지 않아
+    // EventSource가 CONNECTING에서 멈춘다
+    responseHeaders.set("X-Accel-Buffering", "no");
     responseHeaders.set("Access-Control-Allow-Origin", origin);
     responseHeaders.set("Access-Control-Allow-Methods", "GET");
     responseHeaders.set("Access-Control-Allow-Headers", "Cache-Control, Cookie");

--- a/src/app/api/seat/changes/route.ts
+++ b/src/app/api/seat/changes/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 export async function GET(request: NextRequest) {
   try {
@@ -17,6 +18,7 @@ export async function GET(request: NextRequest) {
     const response = await fetch(backendUrl, {
       headers: requestHeaders,
       credentials: "include",
+      signal: request.signal,
     });
 
     if (!response.ok) {
@@ -33,6 +35,9 @@ export async function GET(request: NextRequest) {
     responseHeaders.set("Cache-Control", "no-cache, no-transform");
     responseHeaders.set("Connection", "keep-alive");
     responseHeaders.set("Transfer-Encoding", "chunked");
+    // 프록시(nginx 등)가 스트림을 버퍼링하면 첫 바이트가 도달하지 않아
+    // EventSource가 CONNECTING에서 멈춘다
+    responseHeaders.set("X-Accel-Buffering", "no");
     responseHeaders.set("Access-Control-Allow-Origin", origin);
     responseHeaders.set("Access-Control-Allow-Methods", "GET");
     responseHeaders.set("Access-Control-Allow-Headers", "Cache-Control, Cookie");
@@ -49,6 +54,9 @@ export async function GET(request: NextRequest) {
         try {
           while (true) {
             const { done, value } = await reader.read();
+            // 클라이언트(브라우저) 쪽 연결이 이미 끊겼으면 컨트롤러도 닫혀있어
+            // enqueue/close를 호출하면 예외가 나므로 조용히 루프만 종료한다
+            if (request.signal.aborted) break;
             if (done) {
               controller.close();
               break;
@@ -56,8 +64,9 @@ export async function GET(request: NextRequest) {
             controller.enqueue(value);
           }
         } catch (error) {
-          console.error(error);
-          controller.error(error);
+          if (!request.signal.aborted) {
+            console.error(error);
+          }
         } finally {
           reader.releaseLock();
         }

--- a/src/entities/booking/lib/__tests__/useSeatChangeSSE.test.ts
+++ b/src/entities/booking/lib/__tests__/useSeatChangeSSE.test.ts
@@ -158,7 +158,7 @@ describe("useSeatChangeSSE", () => {
   });
 
   describe("연결 오류 처리", () => {
-    it("onerror에서 readyState가 CONNECTING이면 연결을 닫고 재연결을 스케줄한다", () => {
+    it("onerror에서 readyState가 CONNECTING이면 브라우저 자동 재연결에 맡긴다", () => {
       renderHook(() => useSeatChangeSSE());
       const instance = mockInstances[0];
 
@@ -166,14 +166,14 @@ describe("useSeatChangeSSE", () => {
         instance.simulateError(MockEventSource.CONNECTING);
       });
 
-      expect(toast.error).toHaveBeenCalledWith("실시간 좌석 정보 연결에 실패했습니다.", { id: "sse-error" });
-      expect(instance.closeCalled).toBe(true);
+      expect(toast.error).not.toHaveBeenCalled();
+      expect(instance.closeCalled).toBe(false);
 
       act(() => {
-        vi.advanceTimersByTime(1000);
+        vi.advanceTimersByTime(30000);
       });
 
-      expect(mockInstances).toHaveLength(2);
+      expect(mockInstances).toHaveLength(1);
     });
 
     it("onerror에서 readyState가 CLOSED이면 에러 토스트를 표시한다", () => {

--- a/src/entities/booking/lib/useSeatChangeSSE.ts
+++ b/src/entities/booking/lib/useSeatChangeSSE.ts
@@ -31,6 +31,8 @@ export function useSeatChangeSSE(options: UseSeatChangeSSEOptions = {}) {
         retryTimerRef.current = null;
       }
 
+      eventSourceRef.current?.close();
+
       const eventSource = new EventSource("/api/seat/changes", {
         withCredentials: true,
       });
@@ -78,15 +80,17 @@ export function useSeatChangeSSE(options: UseSeatChangeSSEOptions = {}) {
       };
 
       eventSource.onerror = () => {
+        // 에러 후 CONNECTING이면 브라우저가 스스로 재연결하는 중이므로 건드리지 않는다.
+        // CLOSED는 네이티브 재연결이 없으므로 백오프로 직접 다시 붙는다
+        if (eventSource.readyState !== EventSource.CLOSED) {
+          return;
+        }
         toast.error("실시간 좌석 정보 연결에 실패했습니다.", { id: "sse-error" });
-        if (eventSource.readyState !== EventSource.OPEN) {
-          eventSource.close();
-          if (eventSourceRef.current === eventSource) {
-            eventSourceRef.current = null;
-          }
-          if (!retryTimerRef.current) {
-            scheduleReconnect();
-          }
+        if (eventSourceRef.current === eventSource) {
+          eventSourceRef.current = null;
+        }
+        if (!retryTimerRef.current) {
+          scheduleReconnect();
         }
       };
     };

--- a/src/views/judgingResult/model/__tests__/useJudgeMonitoring.test.ts
+++ b/src/views/judgingResult/model/__tests__/useJudgeMonitoring.test.ts
@@ -223,35 +223,31 @@ describe("useJudgeMonitoring", () => {
     expect(mockInstances[0].closeCalled).toBe(true);
   });
 
-  it("연결이 열리지도 실패하지도 않은 채 pending 상태로 타임아웃되면 재연결을 시도한다", () => {
-    const { result } = renderHook(() => useJudgeMonitoring());
-
-    act(() => {
-      vi.advanceTimersByTime(8000);
-    });
-
-    expect(mockInstances[0].closeCalled).toBe(true);
-    expect(result.current.isConnected).toBe(false);
-    expect(toast.error).toHaveBeenCalledWith(
-      "실시간 심사 모니터링 연결이 지연되고 있습니다. 다시 연결을 시도합니다.",
-      { id: "judge-monitoring-sse-error" },
-    );
-
-    act(() => {
-      vi.advanceTimersByTime(1000);
-    });
-    expect(mockInstances).toHaveLength(2);
-  });
-
-  it("타임아웃 전에 연결이 열리면 재연결을 시도하지 않는다", () => {
+  it("CONNECTING 상태 에러는 브라우저 자동 재연결에 맡기고 연결을 닫지 않는다", () => {
     renderHook(() => useJudgeMonitoring());
 
     act(() => {
-      mockInstances[0].simulateOpen();
-      vi.advanceTimersByTime(8000);
+      mockInstances[0].simulateError(MockEventSource.CONNECTING);
+    });
+
+    expect(mockInstances[0].closeCalled).toBe(false);
+    expect(toast.error).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(30000);
+    });
+    expect(mockInstances).toHaveLength(1);
+  });
+
+  it("연결이 열리지 않은 채 시간이 흘러도 강제로 연결을 끊지 않는다", () => {
+    renderHook(() => useJudgeMonitoring());
+
+    act(() => {
+      vi.advanceTimersByTime(30000);
     });
 
     expect(mockInstances[0].closeCalled).toBe(false);
     expect(mockInstances).toHaveLength(1);
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/src/views/judgingResult/model/useJudgeMonitoring.ts
+++ b/src/views/judgingResult/model/useJudgeMonitoring.ts
@@ -11,7 +11,6 @@ import { parsePartialJson } from "@/shared/utils/partialJson";
 
 const MAX_RETRIES = 5;
 const BASE_DELAY = 1000;
-const CONNECT_TIMEOUT = 8000;
 const SSE_ERROR_TOAST_ID = "judge-monitoring-sse-error";
 
 export const useJudgeMonitoring = () => {
@@ -20,7 +19,6 @@ export const useJudgeMonitoring = () => {
   const eventSourceRef = useRef<EventSource | null>(null);
   const retryCountRef = useRef(0);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const connectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const connect = () => {
@@ -29,28 +27,12 @@ export const useJudgeMonitoring = () => {
         retryTimerRef.current = null;
       }
 
+      eventSourceRef.current?.close();
+
       const eventSource = new EventSource("/api/judge/monitor/changes", {
         withCredentials: true,
       });
       eventSourceRef.current = eventSource;
-
-      // 서버가 응답 헤더 자체를 보내지 않아 pending 상태로 멈추면 onopen/onerror 둘 다
-      // 발동하지 않으므로, 별도 타임아웃으로 그 상태를 감지해 재연결을 시도한다
-      connectTimeoutRef.current = setTimeout(() => {
-        if (eventSource.readyState !== EventSource.OPEN) {
-          eventSource.close();
-          if (eventSourceRef.current === eventSource) {
-            eventSourceRef.current = null;
-          }
-          setIsConnected(false);
-          toast.error("실시간 심사 모니터링 연결이 지연되고 있습니다. 다시 연결을 시도합니다.", {
-            id: SSE_ERROR_TOAST_ID,
-          });
-          if (!retryTimerRef.current) {
-            scheduleReconnect();
-          }
-        }
-      }, CONNECT_TIMEOUT);
 
       eventSource.addEventListener("judge-monitoring", event => {
         const parsed = parsePartialJson<unknown>(event.data);
@@ -65,30 +47,24 @@ export const useJudgeMonitoring = () => {
       });
 
       eventSource.onopen = () => {
-        if (connectTimeoutRef.current) {
-          clearTimeout(connectTimeoutRef.current);
-          connectTimeoutRef.current = null;
-        }
         retryCountRef.current = 0;
         setIsConnected(true);
         toast.dismiss(SSE_ERROR_TOAST_ID);
       };
 
       eventSource.onerror = () => {
-        if (connectTimeoutRef.current) {
-          clearTimeout(connectTimeoutRef.current);
-          connectTimeoutRef.current = null;
-        }
         setIsConnected(false);
+        // 에러 후 CONNECTING이면 브라우저가 스스로 재연결하는 중이므로 건드리지 않는다.
+        // CLOSED는 네이티브 재연결이 없으므로 백오프로 직접 다시 붙는다
+        if (eventSource.readyState !== EventSource.CLOSED) {
+          return;
+        }
         toast.error("실시간 심사 모니터링 연결에 실패했습니다.", { id: SSE_ERROR_TOAST_ID });
-        if (eventSource.readyState !== EventSource.OPEN) {
-          eventSource.close();
-          if (eventSourceRef.current === eventSource) {
-            eventSourceRef.current = null;
-          }
-          if (!retryTimerRef.current) {
-            scheduleReconnect();
-          }
+        if (eventSourceRef.current === eventSource) {
+          eventSourceRef.current = null;
+        }
+        if (!retryTimerRef.current) {
+          scheduleReconnect();
         }
       };
     };
@@ -134,10 +110,6 @@ export const useJudgeMonitoring = () => {
       if (retryTimerRef.current) {
         clearTimeout(retryTimerRef.current);
         retryTimerRef.current = null;
-      }
-      if (connectTimeoutRef.current) {
-        clearTimeout(connectTimeoutRef.current);
-        connectTimeoutRef.current = null;
       }
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       window.removeEventListener("online", handleOnline);


### PR DESCRIPTION
## 💡 PR 요약

Closes #293

- 심사 모니터링 SSE의 8초 강제 타임아웃을 제거하고, `EventSource`의 브라우저 네이티브 재연결에 위임했다
- 정상 연결도 8초 안에 `OPEN`이 되지 않으면 사살되어 백엔드에 `Broken pipe`가 반복 발생하던 문제를 해결한다
- 좌석 SSE 훅과 SSE 프록시 라우트에도 동일한 원인이 있어 함께 고쳤다

## 📋 작업 내용

### 1. 8초 강제 타임아웃 제거 (`useJudgeMonitoring.ts`)

`CONNECT_TIMEOUT`, `connectTimeoutRef`와 이를 참조하던 4곳을 모두 제거했다.

### 2. `onerror` 기반 재연결로 변경 (`useJudgeMonitoring.ts`, `useSeatChangeSSE.ts`)

기존에는 `readyState !== OPEN`이면 `close()`를 호출했다. 에러 직후 브라우저는 `CONNECTING` 상태로 **스스로 재연결하는 중**인데, 이 `close()`가 네이티브 재연결을 무력화하고 수동 백오프로 새 연결을 또 만들었다. 연결 churn과 토스트 스팸의 직접 원인이다.

`readyState === CLOSED`일 때만 백오프 재연결하도록 바꿨다.

```ts
eventSource.onerror = () => {
  setIsConnected(false);
  // 에러 후 CONNECTING이면 브라우저가 스스로 재연결하는 중이므로 건드리지 않는다.
  // CLOSED는 네이티브 재연결이 없으므로 백오프로 직접 다시 붙는다
  if (eventSource.readyState !== EventSource.CLOSED) {
    return;
  }
  toast.error("실시간 심사 모니터링 연결에 실패했습니다.", { id: SSE_ERROR_TOAST_ID });
  ...
};
```

토스트도 `CLOSED` 분기 안으로 옮겨 일시적 에러마다 뜨던 스팸을 없앴다.

### 3. 연결·타이머 정리 로직 점검

`connect()` 진입 시 이전 `EventSource`를 닫도록 했다. `visibilitychange` / `online` 핸들러가 네이티브 재연결 중인 인스턴스를 남겨둔 채 새 연결을 만드는 중복 연결 경로를 차단한다.

### 4. SSE 라우트 버퍼링 해제

두 라우트에 `export const dynamic = "force-dynamic"`과 `X-Accel-Buffering: no`를 추가했다. 프록시가 스트림을 버퍼링하면 첫 바이트가 도달하지 않아 `EventSource`가 `CONNECTING`에서 멈춘다. 8초 타임아웃이 원래 이 증상을 덮고 있었으므로 타임아웃을 제거하려면 함께 고쳐야 한다.

`src/app/api/seat/changes/route.ts`에는 클라이언트 연결이 끊긴 뒤 `controller.error()`를 호출해 불필요한 에러 로그를 남기던 문제도 있었다. 심사 라우트에 이미 적용된 `signal: request.signal` + abort 시 조용한 종료 패턴을 동일하게 적용했다.

### 5. 테스트

- 8초 타임아웃 테스트 2개 삭제 (검증 대상 동작 자체가 없어짐)
- `CONNECTING` 상태 에러에서 연결을 닫지 않고 브라우저 자동 재연결에 맡기는지 검증하는 테스트 추가 (양쪽 훅)
- 전체 371개 통과, lint 신규 경고 없음

## 🤝 리뷰 시 참고사항

### 수정의 근거

네이티브 재연결은 **같은 `EventSource` 객체를 재사용**한다. 따라서 `addEventListener`로 붙인 리스너와 `onopen` / `onerror`가 그대로 살아있고, 재연결 성공 시 `onopen`이 다시 발동해 `isConnected`와 `retryCount`가 정상 복구된다. 직접 `close()`하지 않아도 되는 이유다.

### 동작 변화 2가지

1. `MAX_RETRIES = 5` 예산은 이제 `CLOSED` 경로(백엔드 non-200, 잘못된 Content-Type)만 소비한다. 네트워크 단절 같은 `CONNECTING` 에러는 브라우저가 무제한 재시도한다. 이슈의 "연결 유지" 목적에는 부합하지만 예산 의미가 좁아졌다.
2. `scheduleReconnect`의 `document.hidden || !navigator.onLine` 가드는 `CLOSED` 경로에서만 도달한다. 탭 백그라운드 중 네이티브 재시도는 브라우저 정책에 맡긴다.

### 남은 리스크

백엔드가 `await fetch`에 아예 응답하지 않으면 라우트가 매달리고 `EventSource`는 `CONNECTING`에 영구 정지한다. `onerror`가 발동하지 않으므로 복구 경로가 없고 "연결 중..." 상태에 갇힌다. `force-dynamic` + `X-Accel-Buffering`은 프록시 버퍼링만 잡고 무응답 백엔드는 못 잡는다.

필요하다면 라우트 `fetch`에 `AbortSignal.timeout(15000)`을 추가하는 게 클라이언트 워치독보다 싼 대안이라 판단했는데, 이번 PR에는 넣지 않았습니다. 백엔드 무응답 이력이 있다면 추가하는 게 맞을지 의견 부탁드립니다.

### 범위에서 제외한 것

- 두 SSE 훅을 공용 `useSSE`로 통합하는 리팩터링 — 훅 2개 + 테스트 40개를 흔들어 이슈 범위 밖으로 판단
- 연결은 열렸으나 데이터가 끊긴 스톨 감지 워치독
- 미참조 라우트 `src/app/api/judge/changes/route.ts` 삭제 — 별도 chore로 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)
