### PR TITLE
fix: SSE 프록시 응답 헤드 플러시 및 토큰 재발급

### DIFF
--- a/src/app/api/judge/changes/route.ts
+++ b/src/app/api/judge/changes/route.ts
@@ -1,78 +1,10 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import { proxySSE } from "@/shared/lib/sseProxy";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+// ponytail: 서버리스 함수 실행 상한. SSE는 5분마다 끊기고 EventSource가 자동 재연결한다.
+// 무중단 연결이 필요하면 Edge runtime 전환 또는 폴링으로
+export const maxDuration = 300;
 
-export async function GET(request: NextRequest) {
-  try {
-    const backendUrl = `${process.env.NEXT_PUBLIC_API_URL}/judge/changes`;
-
-    const origin = request.headers.get("origin") || "http://localhost:3000";
-
-    // 백엔드 JwtFilter는 Authorization 헤더만 읽고 쿠키는 인증에 쓰지 않는다 —
-    // 브라우저 EventSource는 커스텀 헤더를 못 보내므로, 이 서버 라우트에서 쿠키의
-    // accessToken을 꺼내 Authorization 헤더로 변환해 백엔드에 전달한다
-    const token = request.cookies.get("accessToken")?.value ?? "";
-
-    const response = await fetch(backendUrl, {
-      headers: {
-        Accept: "text/event-stream",
-        Authorization: "Bearer " + token,
-      },
-      signal: request.signal,
-    });
-
-    if (!response.ok) {
-      return new NextResponse(
-        `Backend connection failed: ${response.status} ${response.statusText}`,
-        {
-          status: response.status,
-        },
-      );
-    }
-
-    const responseHeaders = new Headers();
-    responseHeaders.set("Content-Type", "text/event-stream; charset=utf-8");
-    responseHeaders.set("Cache-Control", "no-cache, no-transform");
-    responseHeaders.set("Connection", "keep-alive");
-    responseHeaders.set("Transfer-Encoding", "chunked");
-    responseHeaders.set("Access-Control-Allow-Origin", origin);
-    responseHeaders.set("Access-Control-Allow-Methods", "GET");
-    responseHeaders.set("Access-Control-Allow-Headers", "Cache-Control, Cookie");
-    responseHeaders.set("Access-Control-Allow-Credentials", "true");
-
-    const stream = new ReadableStream({
-      async start(controller) {
-        const reader = response.body?.getReader();
-        if (!reader) {
-          controller.close();
-          return;
-        }
-
-        try {
-          while (true) {
-            const { done, value } = await reader.read();
-            // 클라이언트(브라우저) 쪽 연결이 이미 끊겼으면 컨트롤러도 닫혀있어
-            // enqueue/close를 호출하면 예외가 나므로 조용히 루프만 종료한다
-            if (request.signal.aborted) break;
-            if (done) {
-              controller.close();
-              break;
-            }
-            controller.enqueue(value);
-          }
-        } catch (error) {
-          if (!request.signal.aborted) {
-            console.error(error);
-          }
-        } finally {
-          reader.releaseLock();
-        }
-      },
-    });
-
-    return new NextResponse(stream, { headers: responseHeaders });
-  } catch (error) {
-    console.error(error);
-    return new NextResponse("Internal Server Error", { status: 500 });
-  }
-}
+export const GET = (request: NextRequest) => proxySSE(request, "/judge/changes");

--- a/src/app/api/judge/monitor/changes/route.ts
+++ b/src/app/api/judge/monitor/changes/route.ts
@@ -1,82 +1,10 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import { proxySSE } from "@/shared/lib/sseProxy";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+// ponytail: 서버리스 함수 실행 상한. SSE는 5분마다 끊기고 EventSource가 자동 재연결한다.
+// 무중단 연결이 필요하면 Edge runtime 전환 또는 폴링으로
+export const maxDuration = 300;
 
-export async function GET(request: NextRequest) {
-  try {
-    const backendUrl = `${process.env.NEXT_PUBLIC_API_URL}/judge/monitor/changes`;
-
-    const origin = request.headers.get("origin") || "http://localhost:3000";
-
-    // 백엔드 JwtFilter는 Authorization 헤더만 읽고 쿠키는 인증에 쓰지 않는다 —
-    // 브라우저 EventSource는 커스텀 헤더를 못 보내므로, 이 서버 라우트에서 쿠키의
-    // accessToken을 꺼내 Authorization 헤더로 변환해 백엔드에 전달한다
-    const token = request.cookies.get("accessToken")?.value ?? "";
-
-    const response = await fetch(backendUrl, {
-      headers: {
-        Accept: "text/event-stream",
-        Authorization: "Bearer " + token,
-      },
-      signal: request.signal,
-    });
-
-    if (!response.ok) {
-      return new NextResponse(
-        `Backend connection failed: ${response.status} ${response.statusText}`,
-        {
-          status: response.status,
-        },
-      );
-    }
-
-    const responseHeaders = new Headers();
-    responseHeaders.set("Content-Type", "text/event-stream; charset=utf-8");
-    responseHeaders.set("Cache-Control", "no-cache, no-transform");
-    responseHeaders.set("Connection", "keep-alive");
-    responseHeaders.set("Transfer-Encoding", "chunked");
-    // 프록시(nginx 등)가 스트림을 버퍼링하면 첫 바이트가 도달하지 않아
-    // EventSource가 CONNECTING에서 멈춘다
-    responseHeaders.set("X-Accel-Buffering", "no");
-    responseHeaders.set("Access-Control-Allow-Origin", origin);
-    responseHeaders.set("Access-Control-Allow-Methods", "GET");
-    responseHeaders.set("Access-Control-Allow-Headers", "Cache-Control, Cookie");
-    responseHeaders.set("Access-Control-Allow-Credentials", "true");
-
-    const stream = new ReadableStream({
-      async start(controller) {
-        const reader = response.body?.getReader();
-        if (!reader) {
-          controller.close();
-          return;
-        }
-
-        try {
-          while (true) {
-            const { done, value } = await reader.read();
-            // 클라이언트(브라우저) 쪽 연결이 이미 끊겼으면 컨트롤러도 닫혀있어
-            // enqueue/close를 호출하면 예외가 나므로 조용히 루프만 종료한다
-            if (request.signal.aborted) break;
-            if (done) {
-              controller.close();
-              break;
-            }
-            controller.enqueue(value);
-          }
-        } catch (error) {
-          if (!request.signal.aborted) {
-            console.error(error);
-          }
-        } finally {
-          reader.releaseLock();
-        }
-      },
-    });
-
-    return new NextResponse(stream, { headers: responseHeaders });
-  } catch (error) {
-    console.error(error);
-    return new NextResponse("Internal Server Error", { status: 500 });
-  }
-}
+export const GET = (request: NextRequest) => proxySSE(request, "/judge/monitor/changes");

--- a/src/app/api/seat/changes/route.ts
+++ b/src/app/api/seat/changes/route.ts
@@ -1,81 +1,10 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import { proxySSE } from "@/shared/lib/sseProxy";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+// ponytail: 서버리스 함수 실행 상한. SSE는 5분마다 끊기고 EventSource가 자동 재연결한다.
+// 무중단 연결이 필요하면 Edge runtime 전환 또는 폴링으로
+export const maxDuration = 300;
 
-export async function GET(request: NextRequest) {
-  try {
-    const backendUrl = `${process.env.NEXT_PUBLIC_API_URL}/seat/changes`;
-
-    const origin = request.headers.get("origin") || "http://localhost:3000";
-
-    const token = request.cookies.get("accessToken")?.value ?? "";
-    const requestHeaders: HeadersInit = {
-      Accept: "text/event-stream",
-      Authorization: `Bearer ${token}`,
-    };
-
-    const response = await fetch(backendUrl, {
-      headers: requestHeaders,
-      credentials: "include",
-      signal: request.signal,
-    });
-
-    if (!response.ok) {
-      return new NextResponse(
-        `Backend connection failed: ${response.status} ${response.statusText}`,
-        {
-          status: response.status,
-        },
-      );
-    }
-
-    const responseHeaders = new Headers();
-    responseHeaders.set("Content-Type", "text/event-stream; charset=utf-8");
-    responseHeaders.set("Cache-Control", "no-cache, no-transform");
-    responseHeaders.set("Connection", "keep-alive");
-    responseHeaders.set("Transfer-Encoding", "chunked");
-    // 프록시(nginx 등)가 스트림을 버퍼링하면 첫 바이트가 도달하지 않아
-    // EventSource가 CONNECTING에서 멈춘다
-    responseHeaders.set("X-Accel-Buffering", "no");
-    responseHeaders.set("Access-Control-Allow-Origin", origin);
-    responseHeaders.set("Access-Control-Allow-Methods", "GET");
-    responseHeaders.set("Access-Control-Allow-Headers", "Cache-Control, Cookie");
-    responseHeaders.set("Access-Control-Allow-Credentials", "true");
-
-    const stream = new ReadableStream({
-      async start(controller) {
-        const reader = response.body?.getReader();
-        if (!reader) {
-          controller.close();
-          return;
-        }
-
-        try {
-          while (true) {
-            const { done, value } = await reader.read();
-            // 클라이언트(브라우저) 쪽 연결이 이미 끊겼으면 컨트롤러도 닫혀있어
-            // enqueue/close를 호출하면 예외가 나므로 조용히 루프만 종료한다
-            if (request.signal.aborted) break;
-            if (done) {
-              controller.close();
-              break;
-            }
-            controller.enqueue(value);
-          }
-        } catch (error) {
-          if (!request.signal.aborted) {
-            console.error(error);
-          }
-        } finally {
-          reader.releaseLock();
-        }
-      },
-    });
-
-    return new NextResponse(stream, { headers: responseHeaders });
-  } catch (error) {
-    console.error(error);
-    return new NextResponse("Internal Server Error", { status: 500 });
-  }
-}
+export const GET = (request: NextRequest) => proxySSE(request, "/seat/changes");

--- a/src/shared/lib/__tests__/sseProxy.test.ts
+++ b/src/shared/lib/__tests__/sseProxy.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { proxySSE } from "../sseProxy";
+
+const API_URL = "https://backend.test";
+const decoder = new TextDecoder();
+
+const makeRequest = (cookie = "accessToken=token-abc") =>
+  new NextRequest("http://localhost/api/judge/monitor/changes", { headers: { cookie } });
+
+const mockUpstream = (body: BodyInit | null, init?: ResponseInit) => {
+  const fetchMock = vi.fn().mockResolvedValue(new Response(body, { status: 200, ...init }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("NEXT_PUBLIC_API_URL", API_URL);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("proxySSE", () => {
+  it("백엔드가 아무것도 보내지 않아도 SSE 헤더와 첫 바이트를 즉시 내보낸다", async () => {
+    // 이벤트를 하나도 보내지 않는 백엔드 — 실제 장애 상황
+    mockUpstream(new ReadableStream());
+
+    const response = await proxySSE(makeRequest(), "/judge/monitor/changes");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/event-stream; charset=utf-8");
+
+    const { value } = await response.body!.getReader().read();
+    expect(decoder.decode(value)).toBe(": connected\n\n");
+  });
+
+  it("hop-by-hop 헤더를 응답에 붙이지 않는다", async () => {
+    mockUpstream(new ReadableStream());
+
+    const response = await proxySSE(makeRequest(), "/judge/monitor/changes");
+
+    expect(response.headers.get("Connection")).toBeNull();
+    expect(response.headers.get("Transfer-Encoding")).toBeNull();
+  });
+
+  it("쿠키의 accessToken을 Authorization 헤더로 변환해 백엔드에 전달한다", async () => {
+    const fetchMock = mockUpstream(new ReadableStream());
+
+    await proxySSE(makeRequest(), "/judge/monitor/changes");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${API_URL}/judge/monitor/changes`,
+      expect.objectContaining({
+        headers: { Accept: "text/event-stream", Authorization: "Bearer token-abc" },
+      }),
+    );
+  });
+
+  it("백엔드가 보낸 이벤트를 그대로 전달한다", async () => {
+    mockUpstream("event: judge-monitoring\ndata: {}\n\n");
+
+    const response = await proxySSE(makeRequest(), "/judge/monitor/changes");
+    const reader = response.body!.getReader();
+
+    await reader.read();
+    const { value } = await reader.read();
+    expect(decoder.decode(value)).toBe("event: judge-monitoring\ndata: {}\n\n");
+  });
+
+  it("브라우저가 연결을 끊으면 백엔드 연결도 취소한다", async () => {
+    let upstreamCancelled = false;
+    mockUpstream(
+      new ReadableStream({
+        cancel() {
+          upstreamCancelled = true;
+        },
+      }),
+    );
+
+    const response = await proxySSE(makeRequest(), "/judge/monitor/changes");
+    const reader = response.body!.getReader();
+    await reader.read();
+
+    await reader.cancel();
+
+    expect(upstreamCancelled).toBe(true);
+  });
+
+  it("백엔드가 스트림을 닫으면 응답 스트림도 닫는다", async () => {
+    mockUpstream("data: last\n\n");
+
+    const response = await proxySSE(makeRequest(), "/judge/monitor/changes");
+    const reader = response.body!.getReader();
+
+    await reader.read();
+    await reader.read();
+    const { done } = await reader.read();
+    expect(done).toBe(true);
+  });
+
+  it("백엔드가 실패하면 상태 코드를 그대로 반환한다", async () => {
+    mockUpstream(null, { status: 401, statusText: "Unauthorized" });
+
+    const response = await proxySSE(makeRequest(), "/judge/monitor/changes");
+
+    expect(response.status).toBe(401);
+  });
+
+  it("백엔드에 연결하지 못하면 502를 반환한다", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("aborted")));
+
+    const response = await proxySSE(makeRequest(), "/judge/monitor/changes");
+
+    expect(response.status).toBe(502);
+  });
+});
+
+describe("proxySSE 토큰 재발급", () => {
+  const TOKENS = {
+    accessToken: "new-access",
+    accessTokenExpiresAt: "2099-01-01T00:00:00Z",
+    refreshToken: "new-refresh",
+    refreshTokenExpiresAt: "2099-01-01T00:00:00Z",
+  };
+
+  // 만료된 accessToken -> 401 -> 재발급 -> 재시도 순서로 응답하는 백엔드
+  const mockExpiredThenRefreshed = () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(TOKENS), { status: 200 }))
+      .mockResolvedValueOnce(new Response(new ReadableStream(), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  };
+
+  it("accessToken이 만료되면 재발급 후 SSE에 다시 연결한다", async () => {
+    const fetchMock = mockExpiredThenRefreshed();
+
+    const response = await proxySSE(
+      makeRequest("accessToken=expired; refreshToken=refresh-abc"),
+      "/judge/monitor/changes",
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      `${API_URL}/auth/refresh`,
+      expect.objectContaining({ method: "PATCH", headers: { "Refresh-Token": "refresh-abc" } }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      `${API_URL}/judge/monitor/changes`,
+      expect.objectContaining({
+        headers: { Accept: "text/event-stream", Authorization: "Bearer new-access" },
+      }),
+    );
+  });
+
+  it("재발급한 토큰을 응답 쿠키로 내려보낸다", async () => {
+    mockExpiredThenRefreshed();
+
+    const response = await proxySSE(
+      makeRequest("accessToken=expired; refreshToken=refresh-abc"),
+      "/judge/monitor/changes",
+    );
+
+    expect(response.cookies.get("accessToken")?.value).toBe("new-access");
+    expect(response.cookies.get("refreshToken")?.value).toBe("new-refresh");
+  });
+
+  it("refreshToken이 없으면 재발급을 시도하지 않고 401을 그대로 반환한다", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 401 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await proxySSE(makeRequest("accessToken=expired"), "/judge/monitor/changes");
+
+    expect(response.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("재발급도 실패하면 401을 그대로 반환한다", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(new Response(null, { status: 401 }))
+        .mockResolvedValueOnce(new Response(null, { status: 401 })),
+    );
+
+    const response = await proxySSE(
+      makeRequest("accessToken=expired; refreshToken=dead"),
+      "/judge/monitor/changes",
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/src/shared/lib/sseProxy.ts
+++ b/src/shared/lib/sseProxy.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const HEARTBEAT_MS = 15_000;
+const ENCODER = new TextEncoder();
+const CONNECTED = ENCODER.encode(": connected\n\n");
+const PING = ENCODER.encode(": ping\n\n");
+
+const SSE_HEADERS = {
+  "Content-Type": "text/event-stream; charset=utf-8",
+  "Cache-Control": "no-cache, no-transform",
+  // 자체 nginx를 거칠 때만 유효하고 Vercel에서는 무해
+  "X-Accel-Buffering": "no",
+};
+
+// 백엔드 JwtFilter는 Authorization 헤더만 읽고 쿠키는 인증에 쓰지 않는다 —
+// 브라우저 EventSource는 커스텀 헤더를 못 보내므로, 이 서버 라우트에서 쿠키의
+// accessToken을 꺼내 Authorization 헤더로 변환해 백엔드에 전달한다
+export async function proxySSE(request: NextRequest, path: string) {
+  const token = request.cookies.get("accessToken")?.value ?? "";
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${process.env.NEXT_PUBLIC_API_URL}${path}`, {
+      headers: { Accept: "text/event-stream", Authorization: `Bearer ${token}` },
+      signal: request.signal,
+    });
+  } catch {
+    // 헤더 도착 전에 브라우저가 끊으면 request.signal이 fetch를 abort한다 — 재연결에서 흔한 정상 경로
+    return new NextResponse("Backend unreachable", { status: 502 });
+  }
+
+  if (!upstream.ok) {
+    return new NextResponse(
+      `Backend connection failed: ${upstream.status} ${upstream.statusText}`,
+      { status: upstream.status },
+    );
+  }
+  if (!upstream.body) {
+    return new NextResponse("Backend sent no body", { status: 502 });
+  }
+
+  const reader = upstream.body.getReader();
+  let heartbeat: ReturnType<typeof setInterval>;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      // 첫 바이트가 나가야 응답 헤드가 플러시된다. 백엔드의 첫 이벤트를 기다리면
+      // 이벤트가 없는 동안 서버리스 함수가 그대로 타임아웃된다
+      controller.enqueue(CONNECTED);
+
+      heartbeat = setInterval(() => {
+        try {
+          controller.enqueue(PING);
+        } catch {
+          clearInterval(heartbeat);
+        }
+      }, HEARTBEAT_MS);
+    },
+
+    // pull 기반이라 소비자가 읽을 때만 업스트림을 당긴다 (백프레셔)
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          clearInterval(heartbeat);
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (error) {
+        clearInterval(heartbeat);
+        controller.error(error);
+      }
+    },
+
+    // 브라우저가 끊으면 즉시 호출된다. releaseLock과 달리 업스트림 연결을 실제로 닫는다
+    async cancel() {
+      clearInterval(heartbeat);
+      await reader.cancel().catch(() => {});
+    },
+  });
+
+  return new NextResponse(stream, { headers: SSE_HEADERS });
+}

--- a/src/shared/lib/sseProxy.ts
+++ b/src/shared/lib/sseProxy.ts
@@ -12,6 +12,27 @@ const SSE_HEADERS = {
   "X-Accel-Buffering": "no",
 };
 
+type RefreshedTokens = {
+  accessToken: string;
+  accessTokenExpiresAt: string;
+  refreshToken: string;
+  refreshTokenExpiresAt: string;
+};
+
+const openUpstream = (path: string, token: string, signal: AbortSignal) =>
+  fetch(`${process.env.NEXT_PUBLIC_API_URL}${path}`, {
+    headers: { Accept: "text/event-stream", Authorization: `Bearer ${token}` },
+    signal,
+  });
+
+const refreshTokens = async (refreshToken: string): Promise<RefreshedTokens | null> => {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/refresh`, {
+    method: "PATCH",
+    headers: { "Refresh-Token": refreshToken },
+  });
+  return response.ok ? ((await response.json()) as RefreshedTokens) : null;
+};
+
 // 백엔드 JwtFilter는 Authorization 헤더만 읽고 쿠키는 인증에 쓰지 않는다 —
 // 브라우저 EventSource는 커스텀 헤더를 못 보내므로, 이 서버 라우트에서 쿠키의
 // accessToken을 꺼내 Authorization 헤더로 변환해 백엔드에 전달한다
@@ -20,13 +41,26 @@ export async function proxySSE(request: NextRequest, path: string) {
 
   let upstream: Response;
   try {
-    upstream = await fetch(`${process.env.NEXT_PUBLIC_API_URL}${path}`, {
-      headers: { Accept: "text/event-stream", Authorization: `Bearer ${token}` },
-      signal: request.signal,
-    });
+    upstream = await openUpstream(path, token, request.signal);
   } catch {
     // 헤더 도착 전에 브라우저가 끊으면 request.signal이 fetch를 abort한다 — 재연결에서 흔한 정상 경로
     return new NextResponse("Backend unreachable", { status: 502 });
+  }
+
+  // EventSource는 401 상태 코드를 노출하지 않아 클라이언트가 만료를 알 수 없고,
+  // axios 인터셉터의 재발급 경로도 SSE에는 닿지 않으므로 여기서 직접 재발급한다
+  let refreshed: RefreshedTokens | null = null;
+  const refreshToken = request.cookies.get("refreshToken")?.value;
+  if (upstream.status === 401 && refreshToken) {
+    refreshed = await refreshTokens(refreshToken).catch(() => null);
+    if (refreshed) {
+      await upstream.body?.cancel().catch(() => {});
+      try {
+        upstream = await openUpstream(path, refreshed.accessToken, request.signal);
+      } catch {
+        return new NextResponse("Backend unreachable", { status: 502 });
+      }
+    }
   }
 
   if (!upstream.ok) {
@@ -80,5 +114,22 @@ export async function proxySSE(request: NextRequest, path: string) {
     },
   });
 
-  return new NextResponse(stream, { headers: SSE_HEADERS });
+  const response = new NextResponse(stream, { headers: SSE_HEADERS });
+
+  // 재발급한 토큰을 클라이언트 쿠키에도 반영해야 axios 등 다른 요청도 갱신된 토큰을 쓴다.
+  // httpOnly를 켜면 getTokenFromCookie/isLoggedIn이 깨지므로 클라이언트 setCookie와 동일하게 맞춘다
+  if (refreshed) {
+    response.cookies.set("accessToken", refreshed.accessToken, {
+      path: "/",
+      expires: new Date(refreshed.accessTokenExpiresAt),
+      httpOnly: false,
+    });
+    response.cookies.set("refreshToken", refreshed.refreshToken, {
+      path: "/",
+      expires: new Date(refreshed.refreshTokenExpiresAt),
+      httpOnly: false,
+    });
+  }
+
+  return response;
 }

--- a/src/views/judgingResult/ui/JudgingResultPage/index.tsx
+++ b/src/views/judgingResult/ui/JudgingResultPage/index.tsx
@@ -15,6 +15,9 @@ import { useReorderTeams } from "../../model/useReorderTeams";
 
 const JudgingResultPage = () => {
   const { data, isConnected } = useJudgeMonitoring();
+  // 연결되기 전까지만 로딩이다. 연결됐는데 데이터가 없으면 아직 심사 전이라는 뜻이므로
+  // 표 자체의 빈 상태를 보여준다. data가 한 번 채워지면 재연결 중에도 표를 유지한다
+  const isMonitoringLoading = data === null && !isConnected;
   const { data: teamOrder = [], isLoading: isTeamOrderLoading } = useGetTeamOrder();
   const { reorderTeams } = useReorderTeams();
   const [downloadingSummary, setDownloadingSummary] = useState(false);
@@ -77,7 +80,7 @@ const JudgingResultPage = () => {
           <ResultTable
             judges={data?.judges ?? []}
             rows={data?.scoreRows ?? []}
-            isLoading={data === null}
+            isLoading={isMonitoringLoading}
           />
         </section>
 
@@ -86,7 +89,7 @@ const JudgingResultPage = () => {
           <CommentTable
             judges={data?.judges ?? []}
             rows={data?.commentRows ?? []}
-            isLoading={data === null}
+            isLoading={isMonitoringLoading}
           />
         </section>
       </div>


### PR DESCRIPTION
## 💡 PR 요약

- 심사 모니터링 SSE가 응답을 시작하지 못하고 5분 뒤 504(`FUNCTION_INVOCATION_TIMEOUT`)로 실패하던 문제를 수정합니다
- 라우트가 자기 바이트를 하나도 쓰지 않아 응답 헤드가 플러시되지 않는 것이 원인이었습니다
- 세 SSE 라우트에 중복돼 있던 프록시 로직을 공용 헬퍼로 통합했습니다

Closes #296

## 📋 작업 내용

### `src/shared/lib/sseProxy.ts` 신설

세 라우트(`/api/judge/monitor/changes`, `/api/judge/changes`, `/api/seat/changes`)가 동일한 프록시 코드를 복제하고 있어 한 곳으로 합쳤습니다. 각 라우트는 5줄이 됩니다.

- **프라이밍 청크(`: connected`)** — 연결 직후 첫 바이트를 보내 응답 헤드를 즉시 플러시합니다. 백엔드 첫 이벤트를 기다리면 심사가 진행되지 않는 동안 함수가 그대로 타임아웃됩니다
- **15초 하트비트(`: ping`)** — 중간 프록시의 유휴 타임아웃을 방지합니다
- **`reader.cancel()`** — 기존 `releaseLock()`은 락만 풀 뿐 업스트림 연결을 닫지 않아, 브라우저가 끊어도 백엔드 연결이 고아로 남았습니다
- **`controller.close()` / `error()` 보장** — 기존에는 `break`만 하고 스트림을 종료하지 않아 매달렸습니다
- **`pull` 기반 백프레셔** — 소비자가 읽을 때만 업스트림을 당깁니다
- **`Connection`, `Transfer-Encoding` 제거** — HTTP/2 금지 헤더이며 프레이밍은 런타임이 결정합니다
- **미사용 CORS 헤더 제거** — `/api/*`는 동일 출처라 적용되지 않았고, `origin` 폴백이 `http://localhost:3000`이었습니다
- **`maxDuration = 300` 명시** — 서버리스 SSE의 상한을 코드에 드러냅니다

### 토큰 만료 시 재발급

EventSource는 401 상태 코드를 노출하지 않고 axios 인터셉터의 재발급 경로도 SSE에는 닿지 않아, accessToken이 만료되면 SSE가 영구 실패했습니다. 라우트가 401을 받으면 `/auth/refresh`를 호출해 재발급하고 다시 연결한 뒤, 새 토큰을 `Set-Cookie`로 내려보내 다른 요청도 갱신된 토큰을 쓰게 합니다.

### 연결 후 빈 상태 표시

`isLoading={data === null}`이라 이벤트가 한 번도 오지 않으면 "실시간 연결됨"으로 표시되면서도 표는 무한 스켈레톤이었습니다. `data === null && !isConnected`로 바꿔, 연결된 뒤에는 이미 구현돼 있던 "집계된 심사 데이터가 없습니다" 빈 상태가 나오게 했습니다.

### 검증

장애 상황(200 + `text/event-stream` + 0바이트)을 재현하는 스텁 백엔드를 세우고 로컬 dev 서버로 수정 전후를 비교했습니다.

| | 수정 전 | 수정 후 |
|---|---|---|
| TTFB | 0.000000s (35초간 헤더 없음) | 0.112s |
| HTTP 코드 | 000 (타임아웃) | 200 |
| 수신 본문 | 0바이트 | `: connected` → `: ping`(+15s) → `: ping`(+30s) |

- 취소 전파: curl 종료와 백엔드의 연결 종료 감지가 같은 밀리초에 일어나는 것을 확인했습니다 (업스트림이 유휴인 상태에서)
- 토큰 재발급: 401 → `/auth/refresh` → 재연결 → `: connected`까지 5ms 안에 처리되는 것과 `Set-Cookie` 속성이 기존 `setCookie`와 동일한 것을 확인했습니다
- 세 라우트 모두 각자의 백엔드 경로로 정상 연결되는 것을 확인했습니다
- `npm run test:run` 383개 통과 (`sseProxy` 12개 신규), `npm run build` 통과

## 🤝 리뷰 시 참고사항

**프리뷰 배포에서 확인이 필요합니다.** 로컬 dev 서버는 스트리밍이 정상 동작하므로 로컬 통과가 Vercel 통과를 보장하지 않습니다. 다만 수정 전 코드가 Vercel 없이 로컬에서도 동일한 증상(TTFB=0)을 보였기 때문에 원인이 플랫폼이 아니라 코드에 있었다는 근거는 확보했습니다. 프리뷰 URL에서 5분 이상 연결이 유지되는지 확인 부탁드립니다.

**후속으로 백엔드 작업이 필요한 항목이 두 개 남습니다.** 이번 PR 범위 밖이라 별도 이슈로 다루면 좋겠습니다.

- 심사 시작 전에는 표에 팀 목록이 보이지 않습니다. `SseEmitter` 구독 즉시 현재 스냅샷을 보내주면 해결됩니다. 현재 백엔드에 스냅샷 REST가 없고 `/judge`의 `GetJudgementResponse`에는 `judgeId`, 코멘트 획, `rank`, `performOrder`가 없어 프론트에서 재구성할 수 없습니다
- 서버리스 함수 상한 때문에 5분마다 연결이 끊기고 EventSource가 자동 재연결하는데, 그 3초 구간의 이벤트가 유실됩니다. `Last-Event-ID` 처리가 필요합니다

**`X-Accel-Buffering: no`는 남겨뒀습니다.** Vercel에서는 무효지만 자체 nginx를 거치는 환경에서는 유효해서 무해하다고 판단했습니다.
