### PR TITLE
feat: 공연자 예매하기 CTA 및 헤더 링크 추가

### DIFF
--- a/src/shared/config/dateConfig.ts
+++ b/src/shared/config/dateConfig.ts
@@ -4,6 +4,8 @@ export const ticketOpenDate = new Date(
 export const performerTicketOpenDate = new Date(
   process.env.NEXT_PUBLIC_PERFORMER_TICKET_OPEN_DATE ?? "2026-08-15T00:00:00+09:00",
 );
+export const isTicketOpen = (role?: string | null) =>
+  new Date() >= (role === "PERFORMER" ? performerTicketOpenDate : ticketOpenDate);
 export const festivalDate = new Date("2025-09-27T00:00:00");
 export const sloganStartDate = new Date(
   process.env.NEXT_PUBLIC_SLOGAN_START_DATE ?? "2026-05-18T00:00:00+09:00",

--- a/src/shared/const/headerValues.ts
+++ b/src/shared/const/headerValues.ts
@@ -12,7 +12,8 @@ export const isHiddenPath = (pathname: string): boolean => {
 export type SectionId =
   | "SloganSecondSection"
   | "PreliminaryLiveSection"
-  | "FinalsVenueSection";
+  | "FinalsVenueSection"
+  | "JudgingCtaSection";
 
 export interface HeaderLink {
   section: SectionId;
@@ -24,3 +25,5 @@ export const links: HeaderLink[] = [
   { section: "PreliminaryLiveSection", label: "2026 광탈페 예선" },
   { section: "FinalsVenueSection", label: "2026 광탈페 본선" },
 ];
+
+export const bookingLink: HeaderLink = { section: "JudgingCtaSection", label: "예매하기" };

--- a/src/shared/ui/Header/index.tsx
+++ b/src/shared/ui/Header/index.tsx
@@ -3,7 +3,8 @@
 import { Logo } from "@/shared/asset/svg/Logo";
 import { MobileMenuIcon } from "@/shared/asset/svg/MobileMenuIcon";
 import { CloseIcon } from "@/shared/asset/svg/CloseIcon";
-import { isHiddenPath, links } from "@/shared/const/headerValues";
+import { bookingLink, isHiddenPath, links } from "@/shared/const/headerValues";
+import { isTicketOpen } from "@/shared/config/dateConfig";
 import { cn } from "@/shared/utils/cn";
 import { getTokenFromCookie } from "@/shared/utils/auth";
 import { scrollToElement } from "@/shared/utils/scroll";
@@ -31,6 +32,9 @@ export default function Header() {
   }, []);
 
   const isJudge = userRole === "JUDGE";
+  // 스크롤 대상인 홈 CTA가 PERFORMER에게만 예매 버튼을 띄우므로 헤더도 동일 조건으로 맞춘다
+  const showBooking = mounted && userRole === "PERFORMER" && isTicketOpen(userRole);
+  const navLinks = showBooking ? [...links, bookingLink] : links;
 
   const handleClick = useCallback(() => {
     if (isUserLoggedIn) {
@@ -60,7 +64,7 @@ export default function Header() {
         </Link>
         {!isJudge && (
           <div className={cn("flex gap-[2.5rem] text-body3b mobile:hidden")}>
-            {links.map((link, index) => (
+            {navLinks.map((link, index) => (
               <button key={index} onClick={() => handleScrollToSection(link.section)}>
                 {link.label}
               </button>
@@ -113,6 +117,7 @@ export default function Header() {
           isOpen={isMobileMenuOpen}
           onClose={closeMobileMenu}
           onLinkClick={handleScrollToSection}
+          links={navLinks}
         />
       )}
     </>

--- a/src/shared/ui/Header/ui/MobileSidebar.tsx
+++ b/src/shared/ui/Header/ui/MobileSidebar.tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import { useEffect } from "react";
-import { links } from "@/shared/const/headerValues";
+import { HeaderLink } from "@/shared/const/headerValues";
 import { cn } from "@/shared/utils/cn";
 
 interface MobileSidebarProps {
   isOpen: boolean;
   onClose: () => void;
   onLinkClick: (section: string) => void;
+  links: HeaderLink[];
 }
 
-export const MobileSidebar = ({ isOpen, onClose, onLinkClick }: MobileSidebarProps) => {
+export const MobileSidebar = ({ isOpen, onClose, onLinkClick, links }: MobileSidebarProps) => {
   useEffect(() => {
     if (!isOpen) return;
 

--- a/src/views/home/ui/HomePage/index.tsx
+++ b/src/views/home/ui/HomePage/index.tsx
@@ -58,6 +58,7 @@ const HomePage = () => {
     <>
       {/* <SloganPosterPopup /> */}
       <IntroFirstSection />
+      <JudgingCtaSection />
       <JudgeInfoSection />
       <SloganSecondSection />
 
@@ -80,8 +81,6 @@ const HomePage = () => {
       <LazySection fallback={<SectionPlaceholder height="500px" />} rootMargin="300px">
         <SeventhSection />
       </LazySection>
-
-      <JudgingCtaSection />
 
       <LazySection fallback={<SectionPlaceholder height="500px" />} rootMargin="500px">
         <Footer />

--- a/src/widgets/main/JudgingCtaSection/__tests__/JudgingCtaSection.test.tsx
+++ b/src/widgets/main/JudgingCtaSection/__tests__/JudgingCtaSection.test.tsx
@@ -45,6 +45,19 @@ describe("JudgingCtaSection - 노출 및 이동 경로", () => {
     expect(push).toHaveBeenCalledWith("/admin/evaluation");
   });
 
+  it("PERFORMER role이면 예매하러 가기 버튼을 보여주고 예매 페이지로 이동한다", async () => {
+    const push = vi.fn();
+    vi.mocked(useRouter).mockReturnValue({ push } as unknown as ReturnType<typeof useRouter>);
+    vi.mocked(getTokenFromCookie).mockReturnValue("PERFORMER");
+    const user = userEvent.setup();
+
+    render(<JudgingCtaSection />);
+    const button = await screen.findByText("예매하러 가기");
+    await user.click(button);
+
+    expect(push).toHaveBeenCalledWith("/booking");
+  });
+
   it("USER role이면 버튼을 보여주지 않는다", () => {
     vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as unknown as ReturnType<
       typeof useRouter

--- a/src/widgets/main/JudgingCtaSection/index.tsx
+++ b/src/widgets/main/JudgingCtaSection/index.tsx
@@ -11,6 +11,7 @@ import { getTokenFromCookie } from "@/shared/utils/auth";
 const ROLE_CTA: Record<string, { label: string; href: string }> = {
   ADMIN: { label: "심사 모니터링", href: "/admin/judging-result" },
   JUDGE: { label: "심사하러 가기", href: "/admin/evaluation" },
+  PERFORMER: { label: "예매하러 가기", href: "/booking" },
 };
 
 const JudgingCtaSection = () => {


### PR DESCRIPTION
## 💡 PR 요약

- 공연자(PERFORMER) 계정에 홈 예매하기 CTA 버튼과 헤더 링크를 추가했습니다.

## 📋 작업 내용

- `JudgingCtaSection`에 `PERFORMER` 역할 추가 — 라벨 `예매하기`, 이동 경로 `/booking`
- 홈에서 `JudgingCtaSection` 위치를 메인 영상(`IntroFirstSection`) 바로 아래로 이동
- `dateConfig`에 `isTicketOpen(role)` 추가 — PERFORMER는 `performerTicketOpenDate`, 그 외는 `ticketOpenDate` 기준 (미들웨어 게이팅 규칙과 동일)
- 헤더에 `예매하기` 링크 추가 — 기존 헤더 링크들과 동일한 텍스트 형태이며, 클릭 시 홈의 예매하기 버튼 위치로 스크롤
- `MobileSidebar`가 링크 목록을 prop으로 받도록 변경해 모바일 메뉴에도 동일하게 노출
- 테스트: PERFORMER 역할일 때 예매하기 버튼 노출 및 `/booking` 이동 검증 추가

## 🤝 리뷰 시 참고사항

- 헤더 `예매하기`는 PERFORMER + 티켓 오픈 시점 이후에만 노출됩니다. 스크롤 대상인 홈 CTA가 현재 PERFORMER에게만 예매 버튼을 띄우기 때문에 조건을 맞췄습니다. 일반 USER에게도 노출하려면 홈 CTA에 USER 케이스를 먼저 추가해야 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)