### PR TITLE
fix: A열 출연팀 좌석 예매 차단 및 예매 취소 버튼 폭 수정

### DIFF
--- a/src/entities/booking/model/__tests__/reservedSeats.test.ts
+++ b/src/entities/booking/model/__tests__/reservedSeats.test.ts
@@ -21,10 +21,22 @@ describe("isReservedSeat - 확보석 판별", () => {
     expect(isReservedSeat({ section: "PURPLE", row: "S" })).toBe(false)
   })
 
-  it("확보석은 좌석배치도 기준 48석이다", () => {
+  it("무대 최전열 A열은 출연팀 좌석이라 예매 불가다", () => {
+    ;(["RED", "YELLOW", "TEAL"] as const).forEach(section => {
+      expect(isReservedSeat({ section, row: "A" })).toBe(true)
+    })
+  })
+
+  it("A열 다음 B열부터는 예매 가능석이다", () => {
+    ;(["RED", "YELLOW", "TEAL"] as const).forEach(section => {
+      expect(isReservedSeat({ section, row: "B" })).toBe(false)
+    })
+  })
+
+  it("확보석은 좌석배치도 기준 74석이다", () => {
     const reserved = SECTIONS.flatMap(section =>
       SEAT_LAYOUTS[section].seats.filter(isReservedSeat),
     )
-    expect(reserved).toHaveLength(48)
+    expect(reserved).toHaveLength(74)
   })
 })

--- a/src/entities/booking/model/reservedSeats.ts
+++ b/src/entities/booking/model/reservedSeats.ts
@@ -1,7 +1,11 @@
 import { Section } from "./types";
 
-// 심사위원·스텝·내빈용으로 미리 확보된 좌석. 서버가 available로 내려줘도 예매 대상에서 제외한다
+// 심사위원·스텝·내빈·출연팀용으로 미리 확보된 좌석. 서버가 available로 내려줘도 예매 대상에서 제외한다
+// A열(무대 최전열)은 출연팀 좌석 — 일반·공연자 모두 예매 불가, 예매는 B열부터 시작한다
 const RESERVED_ROWS: Partial<Record<Section, readonly string[]>> = {
+  RED: ["A"],
+  YELLOW: ["A"],
+  TEAL: ["A"],
   GREEN: ["L", "M", "R", "S"],
 };
 

--- a/src/views/booking/ui/MyBookingPage/index.tsx
+++ b/src/views/booking/ui/MyBookingPage/index.tsx
@@ -126,7 +126,7 @@ const MyBookingPage = () => {
         />
       </div>
 
-      <div className="absolute bottom-[0px] pb-4 left-[50%] -translate-x-1/2 w-[98%] space-y-2">
+      <div className="w-full space-y-2">
         {canSelectIndividualSeats ? (
           <>
             <div

--- a/src/widgets/booking/lib/__tests__/useSeatSelection.test.ts
+++ b/src/widgets/booking/lib/__tests__/useSeatSelection.test.ts
@@ -6,7 +6,7 @@ import { Seat, Section, SeatStatus, SEAT_STATUS } from "@/entities/booking/model
 const makeSeat = (
   seatNumber: string,
   status: SeatStatus = SEAT_STATUS.AVAILABLE,
-  row: string = "A",
+  row: string = "B",
 ): Seat => ({
   seatNumber,
   row,
@@ -102,8 +102,8 @@ describe("useSeatSelection - canSelectSeat", () => {
 describe("useSeatSelection - 좌석 선택 엣지 케이스", () => {
   it("같은 번호지만 다른 섹션의 좌석은 토글되지 않고 교체된다", () => {
     const { result } = renderHook(() => useSeatSelection())
-    const seatA: Seat = { seatNumber: "1", row: "A", status: SEAT_STATUS.AVAILABLE, section: "RED" as Section }
-    const seatB: Seat = { seatNumber: "1", row: "A", status: SEAT_STATUS.AVAILABLE, section: "YELLOW" as Section }
+    const seatA: Seat = { seatNumber: "1", row: "B", status: SEAT_STATUS.AVAILABLE, section: "RED" as Section }
+    const seatB: Seat = { seatNumber: "1", row: "B", status: SEAT_STATUS.AVAILABLE, section: "YELLOW" as Section }
 
     act(() => { result.current.selectSeat(seatA) })
     act(() => { result.current.selectSeat(seatB) })
@@ -113,13 +113,21 @@ describe("useSeatSelection - 좌석 선택 엣지 케이스", () => {
 
   it("같은 번호·섹션이지만 다른 열의 좌석은 토글되지 않고 교체된다", () => {
     const { result } = renderHook(() => useSeatSelection())
-    const seatA = makeSeat("1", SEAT_STATUS.AVAILABLE, "A")
     const seatB = makeSeat("1", SEAT_STATUS.AVAILABLE, "B")
+    const seatC = makeSeat("1", SEAT_STATUS.AVAILABLE, "C")
 
-    act(() => { result.current.selectSeat(seatA) })
     act(() => { result.current.selectSeat(seatB) })
+    act(() => { result.current.selectSeat(seatC) })
 
-    expect(result.current.selectedSeat).toEqual(seatB)
+    expect(result.current.selectedSeat).toEqual(seatC)
+  })
+
+  it("출연팀 좌석인 A열은 선택되지 않는다", () => {
+    const { result } = renderHook(() => useSeatSelection())
+
+    act(() => { result.current.selectSeat(makeSeat("1", SEAT_STATUS.AVAILABLE, "A")) })
+
+    expect(result.current.selectedSeat).toBeNull()
   })
 
   it("섹션을 같은 값으로 다시 설정해도 선택 좌석이 초기화된다", () => {


### PR DESCRIPTION
## 💡 PR 요약

- 무대 최전열 A열(RED·YELLOW·TEAL)을 출연팀 전용 좌석으로 지정해 예매 대상에서 제외
- 예매 취소 버튼이 화면 전체 폭으로 늘어나던 문제 수정

## 📋 작업 내용

### A열 출연팀 좌석 예매 차단

좌석배치도상 무대 최전열(회색 영역)은 출연팀 좌석이라 예매가 열리면 안 됩니다. `RESERVED_ROWS`에 RED·YELLOW·TEAL의 A열을 추가했습니다.

`isReservedSeat`가 단일 게이트라 세 경로를 한 번에 막습니다.

- 일반 예매 — `useSeatSelection`에서 선택 자체를 차단
- 어드민 — 밴 해제로 예매가 열리는 사고 방지 (기존 로직 그대로 적용됨)
- 공연자 — `resolveSeatStatus`가 OCCUPIED로 내려서 `usePerformerSeatSelection`도 차단

남은좌석 카운트는 OCCUPIED 기준이라 별도 수정 없이 반영됩니다.

확보석 총계: 48석(심사위원·스텝·내빈) → **74석** (+A열 26석)

### 예매 취소 버튼 폭 수정

원인은 버튼 길이가 아니라 포지셔닝이었습니다. 부모에 `relative`가 없어 `absolute`가 뷰포트 기준으로 잡혔고, `w-[98%]`가 컨테이너(`max-w-4xl`)가 아닌 화면 전체 폭으로 계산됐습니다.

```diff
- <div className="absolute bottom-[0px] pb-4 left-[50%] -translate-x-1/2 w-[98%] space-y-2">
+ <div className="w-full space-y-2">
```

일반 흐름으로 되돌려 위쪽 좌석 그리드·예매정보와 폭이 맞습니다.

### 테스트

- 확보석 총계 74석으로 갱신, A열 차단 / B열 예매 가능 검증 추가
- `useSeatSelection` 픽스처 기본 열이 `RED A`였습니다. A열을 막으면 10개 테스트가 깨지고, 그중 `다른 열 좌석은 교체된다`는 A열이 차단당한 덕에 **우연히 통과**하는 상태가 됩니다. 픽스처를 B열로 옮기고 A열 차단은 별도 케이스로 분리했습니다.

전체 395개 통과, lint 클린입니다.

## 🤝 리뷰 시 참고사항

**출연팀 좌석 10석이 아직 반영되지 않았습니다.** 기획상 출연팀석은 36석인데 A열 전체는 26석입니다 (RED 4–10 = 7, YELLOW 11–22 = 12, TEAL 23–29 = 7).

배치도상 TEAL B열(23–30, 8석)도 회색으로 보이지만 그래도 34석이라 2석이 맞지 않아, 추측으로 막지 않고 A열까지만 반영했습니다. 잘못 막으면 그만큼 예매 가능 좌석이 사라지는 쪽이라 확인 후 넣는 게 안전하다고 판단했습니다.

나머지 10석 좌표(구역+열+번호)가 확정되면 `RESERVED_ROWS`에 이어서 추가하겠습니다. 행 일부만 해당한다면 좌석번호 범위까지 받도록 구조를 확장해야 합니다.

취소 버튼을 원래 하단 고정(sticky bar)으로 의도하신 거라면 `sticky bottom-0`으로 바꾸면 폭 안 깨지고 고정됩니다. 현재는 일반 흐름으로 두었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
