### PR TITLE
fix: 좌석 예매 429 대응과 내 좌석 구분 표시

### DIFF
--- a/src/entities/booking/api/getMySeat.ts
+++ b/src/entities/booking/api/getMySeat.ts
@@ -20,7 +20,14 @@ export const getMySeats = async (): Promise<Seat[]> => {
   try {
     const response = await axios.get<PerformerSeatsApiResponse>("/seat/myself/performer");
 
-    return response.data.map(toSeat).filter((seat): seat is Seat => seat !== null);
+    const seats = response.data.map(toSeat).filter((seat): seat is Seat => seat !== null);
+
+    // 좌석 좌표 변환에 실패하면 조용히 사라져 "예약된 좌석 없음"으로 보이므로 남긴다
+    if (seats.length !== response.data.length) {
+      console.warn("좌석 좌표로 변환하지 못한 응답이 있습니다", response.data);
+    }
+
+    return seats;
   } catch (error: unknown) {
     const axiosError = error as AxiosError;
     const errorMessage =

--- a/src/entities/booking/api/seatBooking.ts
+++ b/src/entities/booking/api/seatBooking.ts
@@ -16,6 +16,13 @@ export const seatBooking = async (data: Omit<Seat, "status">) => {
       "message" in axiosError.response.data
         ? (axiosError.response.data as { message: string }).message
         : "좌석 예매에 실패했습니다.";
-    throw new Error(errorMessage);
+
+    // 호출부가 429(rate limit)를 재시도 대상으로 구분할 수 있게 상태 코드와 대기 시간을 실어 보낸다
+    const retryAfter = Number(axiosError?.response?.headers?.["retry-after"]);
+
+    throw Object.assign(new Error(errorMessage), {
+      status: axiosError?.response?.status,
+      retryAfterMs: Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : undefined,
+    });
   }
 };

--- a/src/entities/booking/lib/useMySeat.ts
+++ b/src/entities/booking/lib/useMySeat.ts
@@ -102,7 +102,9 @@ export const useMyBookedSeats = () => {
     enabled: isClient && !!role && isPerformer,
   });
 
-  if (!isClient) {
+  // role을 못 읽으면 두 쿼리 모두 비활성인데 isLoading은 false라,
+  // 호출부가 "예약된 좌석 없음"으로 오판한다 (미들웨어가 막지만 이중 안전장치)
+  if (!isClient || !role) {
     return {
       data: [],
       seats: [],

--- a/src/entities/booking/ui/SeatGrid/index.tsx
+++ b/src/entities/booking/ui/SeatGrid/index.tsx
@@ -25,6 +25,7 @@ export interface SeatGridProps {
   isSeatSelected?: (seat: Seat) => boolean;
   isPerformerMode?: boolean;
   myAllSeats?: Seat[];
+  myBookedSeats?: Seat[];
   selectedSeatsForCancel?: Set<string>;
   allowOccupiedSelect?: boolean;
   onSectionSelect?: (section: (typeof SECTIONS)[number]) => void;
@@ -41,6 +42,7 @@ export const SeatGrid = memo<SeatGridProps>(
     isSeatSelected,
     isPerformerMode = false,
     myAllSeats,
+    myBookedSeats,
     selectedSeatsForCancel,
     allowOccupiedSelect = false,
     onSectionSelect,
@@ -125,6 +127,18 @@ export const SeatGrid = memo<SeatGridProps>(
       [mySeat, myAllSeats, isPerformerMode, isSeatSelected, selectedSeat, selectedSeatsForCancel],
     );
 
+    // 예매 화면에서 내가 이미 잡아둔 좌석을 구분해 보여준다 (선택 가능 여부는 그대로 유지)
+    const isMyBookedSeat = useCallback(
+      (seat: Seat) =>
+        myBookedSeats?.some(
+          mine =>
+            mine.section === seat.section &&
+            mine.row === seat.row &&
+            mine.seatNumber === seat.seatNumber,
+        ) ?? false,
+      [myBookedSeats],
+    );
+
     const renderSingleSectionGrid = () => (
       <div className="w-max mx-auto flex flex-col justify-start">
         {seatGrid.map((row, rowIndex) => (
@@ -135,6 +149,7 @@ export const SeatGrid = memo<SeatGridProps>(
                   <SeatItem
                     seat={seat}
                     isSelected={getSeatSelectedState(seat)}
+                    isMine={isMyBookedSeat(seat)}
                     onSelect={mySeat ? NOOP_SEAT_SELECT : handleSeatSelect}
                     allowOccupiedSelect={allowOccupiedSelect}
                     className={cellSize}
@@ -205,6 +220,7 @@ export const SeatGrid = memo<SeatGridProps>(
                         <SeatItem
                           seat={seat}
                           isSelected={getSeatSelectedState(seat)}
+                          isMine={isMyBookedSeat(seat)}
                           onSelect={mySeat ? NOOP_SEAT_SELECT : handleSeatSelect}
                           className={cn(cellSize, "text-transparent")}
                         />

--- a/src/entities/booking/ui/SeatItem/index.tsx
+++ b/src/entities/booking/ui/SeatItem/index.tsx
@@ -10,10 +10,11 @@ export interface SeatItemProps {
   onSelect: (seat: Seat) => void;
   className?: string;
   allowOccupiedSelect?: boolean;
+  isMine?: boolean;
 }
 
 export const SeatItem = memo<SeatItemProps>(
-  ({ seat, isSelected, onSelect, className, allowOccupiedSelect = false }) => {
+  ({ seat, isSelected, onSelect, className, allowOccupiedSelect = false, isMine = false }) => {
     const isOccupied = seat.status === SEAT_STATUS.OCCUPIED;
     const isDisabled = isOccupied && !allowOccupiedSelect;
 
@@ -28,6 +29,11 @@ export const SeatItem = memo<SeatItemProps>(
 
       if (isSelected) {
         return cn(baseStyles, "bg-orange-500 text-white shadow-lg scale-110 cursor-pointer");
+      }
+
+      // 내가 이미 예매한 좌석은 서버가 occupied로 내려주므로 회색보다 먼저 판정해야 한다
+      if (isMine) {
+        return cn(baseStyles, "bg-orange-500 text-white cursor-not-allowed");
       }
 
       if (isOccupied) {
@@ -50,7 +56,7 @@ export const SeatItem = memo<SeatItemProps>(
         className={cn(getSeatStyles(), className)}
         onClick={handleClick}
         disabled={isDisabled}
-        title={`좌석 ${seat.seatNumber} - ${isDisabled ? "선택불가" : "선택가능"}`}
+        title={`좌석 ${seat.seatNumber} - ${isMine ? "내 좌석" : isDisabled ? "선택불가" : "선택가능"}`}
         aria-label={`좌석 ${seat.seatNumber}`}
       >
         {getSeatNumber()}

--- a/src/views/booking/ui/MyBookingPage/index.tsx
+++ b/src/views/booking/ui/MyBookingPage/index.tsx
@@ -14,6 +14,7 @@ import { cancelPerformerSeats } from "@/entities/booking/api/cancelPerformerSeat
 import { useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { Seat, formatSeatLabel } from "@/entities/booking/model/types";
+import { MAX_PERFORMER_SEATS } from "@/widgets/booking/lib/usePerformerSeatSelection";
 
 const MyBookingPage = () => {
   const { seats, isMultiple, isLoading, error } = useMyBookedSeats();
@@ -23,6 +24,8 @@ const MyBookingPage = () => {
   const layout = null;
 
   const canSelectIndividualSeats = isMultiple && seats.length >= 2;
+  // 참가자는 2석까지라 아직 여유가 있을 때만 추가 예매를 안내한다
+  const canBookMore = isMultiple && !isLoading && seats.length < MAX_PERFORMER_SEATS;
 
   useEffect(() => {
     if (error) toast.error(stringifyError(error));
@@ -127,6 +130,12 @@ const MyBookingPage = () => {
       </div>
 
       <div className="w-full space-y-2">
+        {canBookMore && (
+          <Button className="w-full h-[48px]" onClick={() => router.push("/booking")}>
+            좌석 추가로 예매하기
+          </Button>
+        )}
+
         {canSelectIndividualSeats ? (
           <>
             <div

--- a/src/widgets/booking/lib/__tests__/bookSeatWithRetry.test.ts
+++ b/src/widgets/booking/lib/__tests__/bookSeatWithRetry.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { bookSeatWithRetry, RATE_LIMIT_RETRY_DELAYS_MS } from "../bookSeatWithRetry";
+
+vi.mock("@/entities/booking/api/seatBooking", () => ({ seatBooking: vi.fn() }));
+
+import { seatBooking } from "@/entities/booking/api/seatBooking";
+
+const mockSeatBooking = vi.mocked(seatBooking);
+
+const SEAT = { section: "RED", row: "B", seatNumber: "16" } as Parameters<
+  typeof bookSeatWithRetry
+>[0];
+
+const rateLimitError = () => Object.assign(new Error("요청이 너무 잦습니다."), { status: 429 });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("bookSeatWithRetry", () => {
+  it("성공하면 재시도하지 않는다", async () => {
+    mockSeatBooking.mockResolvedValue({ data: {} });
+
+    await bookSeatWithRetry(SEAT);
+
+    expect(mockSeatBooking).toHaveBeenCalledTimes(1);
+  });
+
+  it("429면 대기 후 재시도해 성공을 반환한다", async () => {
+    mockSeatBooking.mockRejectedValueOnce(rateLimitError()).mockResolvedValue({ data: {} });
+
+    const promise = bookSeatWithRetry(SEAT);
+    await vi.advanceTimersByTimeAsync(RATE_LIMIT_RETRY_DELAYS_MS[0]);
+    await promise;
+
+    expect(mockSeatBooking).toHaveBeenCalledTimes(2);
+  });
+
+  it("429가 재시도 횟수를 넘기면 에러를 던진다", async () => {
+    mockSeatBooking.mockRejectedValue(rateLimitError());
+
+    const promise = bookSeatWithRetry(SEAT);
+    const assertion = expect(promise).rejects.toThrow("요청이 너무 잦습니다.");
+    await vi.advanceTimersByTimeAsync(RATE_LIMIT_RETRY_DELAYS_MS.reduce((a, b) => a + b, 0));
+    await assertion;
+
+    expect(mockSeatBooking).toHaveBeenCalledTimes(RATE_LIMIT_RETRY_DELAYS_MS.length + 1);
+  });
+
+  it("429가 아닌 오류는 즉시 던지고 재시도하지 않는다", async () => {
+    mockSeatBooking.mockRejectedValue(
+      Object.assign(new Error("이미 예매된 좌석입니다."), { status: 409 }),
+    );
+
+    await expect(bookSeatWithRetry(SEAT)).rejects.toThrow("이미 예매된 좌석입니다.");
+    expect(mockSeatBooking).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/widgets/booking/lib/bookSeatWithRetry.ts
+++ b/src/widgets/booking/lib/bookSeatWithRetry.ts
@@ -1,0 +1,20 @@
+import { seatBooking } from "@/entities/booking/api/seatBooking";
+import { Seat } from "@/entities/booking/model/types";
+
+export const RATE_LIMIT_RETRY_DELAYS_MS = [1500, 4000, 8000];
+
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+// 429는 서버가 요청을 처리하지 않은 상태라 같은 좌석을 다시 보내도 중복 예매가 되지 않는다.
+// 거부된 요청까지 카운트하는 limiter도 있어서 간격을 넉넉히 두고, 서버가 Retry-After를 주면 그 값을 따른다
+export const bookSeatWithRetry = async (seat: Omit<Seat, "status">) => {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await seatBooking(seat);
+    } catch (error) {
+      const { status, retryAfterMs } = error as { status?: number; retryAfterMs?: number };
+      if (status !== 429 || attempt >= RATE_LIMIT_RETRY_DELAYS_MS.length) throw error;
+      await wait(Math.max(retryAfterMs ?? 0, RATE_LIMIT_RETRY_DELAYS_MS[attempt]));
+    }
+  }
+};

--- a/src/widgets/booking/lib/useSeatBooking.ts
+++ b/src/widgets/booking/lib/useSeatBooking.ts
@@ -1,7 +1,8 @@
 import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { seatBooking } from "@/entities/booking/api/seatBooking";
-import { Seat, getSectionLabel } from "@/entities/booking/model/types";
+import { bookSeatWithRetry } from "@/widgets/booking/lib/bookSeatWithRetry";
+import { getMySeats } from "@/entities/booking/api/getMySeat";
+import { Seat, formatSeatLabel } from "@/entities/booking/model/types";
 import { useQueryClient } from "@tanstack/react-query";
 import { seatQueryKeys } from "@/entities/booking/lib/useSeatState";
 
@@ -9,7 +10,7 @@ export function useSeatBooking() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: Omit<Seat, "status">) => seatBooking(data),
+    mutationFn: (data: Omit<Seat, "status">) => bookSeatWithRetry(data),
     onSuccess: (_result, vars) => {
       queryClient.invalidateQueries({ queryKey: seatQueryKeys.seatState(vars.section) });
       queryClient.invalidateQueries({ queryKey: ["mySeat"] });
@@ -26,30 +27,45 @@ export function useMultipleSeatBooking() {
   const queryClient = useQueryClient();
 
   return useMutation({
+    // 좌석을 동시에 요청하면 서버 rate limit(429)에 걸리므로 한 건씩 순차로 보내고, 429는 재시도한다
     mutationFn: async (seats: Array<Omit<Seat, "status">>) => {
-      const bookingPromises = seats.map(seat => seatBooking(seat));
-      const results = await Promise.allSettled(bookingPromises);
+      const failures: Array<{ seat: Omit<Seat, "status">; detail: string }> = [];
 
-      const successful = results.filter(result => result.status === "fulfilled");
-      const failed = results.filter(result => result.status === "rejected");
+      for (const seat of seats) {
+        try {
+          await bookSeatWithRetry(seat);
+        } catch (error) {
+          const detail = error instanceof Error ? error.message : "예매에 실패했습니다.";
+          failures.push({ seat, detail });
+        }
+      }
 
-      if (failed.length > 0) {
-        const errorMessages = failed
-          .map((result, index) => {
-            if (result.status === "rejected") {
-              const seat = seats[index];
-              return `${getSectionLabel(seat.section)}${seat.row}${seat.seatNumber} 좌석 예매 실패`;
-            }
-            return "";
-          })
-          .filter(Boolean);
+      // 429가 예매를 처리한 뒤에 떨어지는 경우가 있어 에러만 믿으면 성공을 실패로 알린다.
+      // 실패로 잡힌 좌석은 서버 상태로 한 번 더 확인한다
+      let unbooked = failures;
+      if (failures.length > 0) {
+        const bookedSeats = await getMySeats().catch(() => null);
+        if (bookedSeats) {
+          unbooked = failures.filter(
+            ({ seat }) =>
+              !bookedSeats.some(
+                booked =>
+                  booked.section === seat.section &&
+                  booked.row === seat.row &&
+                  booked.seatNumber === seat.seatNumber,
+              ),
+          );
+        }
+      }
 
+      if (unbooked.length > 0) {
+        const errorMessages = unbooked.map(({ seat, detail }) => `${formatSeatLabel(seat)} ${detail}`);
         throw new Error(`일부 좌석 예매에 실패했습니다: ${errorMessages.join(", ")}`);
       }
 
       return {
         success: true,
-        message: `${successful.length}개 좌석이 성공적으로 예매되었습니다.`,
+        message: `${seats.length}개 좌석이 성공적으로 예매되었습니다.`,
         bookedSeats: seats,
       };
     },
@@ -64,7 +80,16 @@ export function useMultipleSeatBooking() {
 
       toast.success(result.message);
     },
-    onError: error => {
+    // 일부만 실패해도 성공한 좌석은 이미 예매됐으므로 좌석 상태를 다시 불러온다
+    onError: (error, vars) => {
+      const sections = [...new Set(vars.map(seat => seat.section))];
+      sections.forEach(section => {
+        queryClient.invalidateQueries({ queryKey: seatQueryKeys.seatState(section) });
+      });
+
+      queryClient.invalidateQueries({ queryKey: ["mySeat"] });
+      queryClient.invalidateQueries({ queryKey: ["mySeats"] });
+
       console.error(error);
       toast.error(error.message ?? "알 수 없는 오류가 발생했습니다.");
     },

--- a/src/widgets/booking/ui/SeatSection/index.tsx
+++ b/src/widgets/booking/ui/SeatSection/index.tsx
@@ -105,6 +105,7 @@ export const SeatSection = memo<SeatSectionProps>(
           isPerformerMode={isPerformerMode}
           mySeat={!isPerformerMode && !allowOccupiedSelect ? (myBookedSeats?.[0] ?? null) : null}
           myAllSeats={myBookedSeats}
+          myBookedSeats={myBookedSeats}
           allowOccupiedSelect={allowOccupiedSelect}
           onSectionSelect={onSectionSelect}
         />


### PR DESCRIPTION
## 💡 PR 요약

> 해당 PR의 변경사항, 해당 이슈 등에 대한 간략한 설명을 작성해주세요.

- 참가자 다중 좌석 예매가 서버 rate limit(429)에 걸려 실패하던 문제 수정
- 실제로 예매된 좌석을 실패로 알리던 오탐 제거
- 예매 화면에서 내가 이미 예매한 좌석을 주황색으로 구분
- 내 좌석 페이지에 추가 예매 진입 버튼 추가

## 📋 작업 내용

> 해당 PR에서 작업한 내용을 자세히 설명해주세요.

**좌석 예매 rate limit 대응**
- 기존에는 선택한 좌석 전부를 `Promise.allSettled`로 동시에 요청해 서버 rate limiter가 두 번째 요청부터 429로 거부했습니다. 한 건씩 순차 전송으로 변경
- `bookSeatWithRetry` 추가 — 429만 1.5초 / 4초 / 8초 백오프로 재시도. 429는 서버가 요청을 처리하지 않은 상태라 같은 좌석 재전송이 중복 예매로 이어지지 않습니다
- `seatBooking`이 던지는 에러에 `status`와 `Retry-After` 기반 대기 시간을 실어 보내, 서버가 헤더를 주면 그 값을 우선 사용

**실패 판정 보정**
- 서버가 좌석을 예매한 뒤에 429를 반환하는 경우가 있어, 에러만 믿으면 성공을 실패로 알립니다. 실패로 잡힌 좌석은 `GET /seat/myself/performer`로 실제 예매 여부를 대조하고 정말 안 된 좌석만 에러로 올립니다
- 실패 좌석 이름이 어긋나던 버그 수정 — 필터링된 배열의 인덱스로 원본 `seats`를 참조하고 있어서, 두 번째 좌석이 실패해도 첫 번째 좌석 이름이 표시됐습니다
- 서버가 준 실패 메시지를 그대로 노출 (기존에는 버려서 원인을 알 수 없었습니다)
- `onError`에서도 좌석 상태를 무효화 — 일부만 성공한 경우 화면이 갱신되지 않았습니다

**내 좌석 구분 표시**
- `SeatItem`에 `isMine` 추가. 내 좌석은 서버가 `occupied`로 내려주므로 회색 판정보다 먼저 검사합니다
- `SeatGrid`에 `myBookedSeats` 추가 — 기존 `mySeat`(전체 클릭 차단하는 읽기 전용 모드)과 분리해서, 예매 화면에서 나머지 좌석 선택은 그대로 됩니다
- `BookingPage`가 이미 넘기던 `myBookedSeats`가 `SeatSection`에서 `SeatGrid`로 전달되지 않아 참가자 화면에서 무시되고 있었습니다

**내 좌석 페이지**
- 예매한 좌석이 `MAX_PERFORMER_SEATS`(2석)보다 적을 때만 `좌석 추가로 예매하기` 버튼 노출
- role을 아직 못 읽은 상태에서 두 쿼리가 비활성이면 `isLoading`이 false여서 "예약된 좌석이 없습니다" 토스트가 잘못 뜨던 문제 수정
- 좌석 좌표 변환에 실패한 응답이 조용히 사라져 좌석이 없는 것처럼 보이던 부분에 경고 로그 추가

## 🤝 리뷰 시 참고사항

> 리뷰어분들이 리뷰를 할 때 참고하면 좋을 사항이나 질문사항을 작성해주세요.

- **백엔드 확인 필요 2건**
  1. `POST /seat`가 좌석을 예매한 뒤에 429를 반환합니다. limiter가 핸들러 실행 이후에 걸리는 것으로 보여 순서 조정이 필요합니다
  2. 429 응답에 `Retry-After` 헤더가 없어 클라이언트가 대기 시간을 추측해야 합니다
- limiter가 거부된 요청까지 카운트하면 클라이언트 재시도로는 못 뚫습니다. 참가자는 2석이 기본이라 다중 좌석 단일 엔드포인트(`POST /seat/bulk`)가 근본 해결책입니다
- 백오프 총합 최대 13.5초입니다. 실제 limiter 창을 알려주시면 그 값에 맞춰 줄이겠습니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)