### PR TITLE
fix: 예매 확정 흐름 정리 및 관람일자·장소 수정

### DIFF
--- a/src/entities/booking/ui/BookingInfoDisplay/index.tsx
+++ b/src/entities/booking/ui/BookingInfoDisplay/index.tsx
@@ -39,8 +39,8 @@ export const BookingInfoDisplay = memo<BookingInfoDisplayProps>(
                 ? formatSeatLabel(mySeat)
                 : "좌석이 없습니다"}
           </InfoRow>
-          <InfoRow label="관람일자">2025.9.27.(토)</InfoRow>
-          <InfoRow label="장소">광주광역시 동구 조선대길 146 조선대학교 해오름관</InfoRow>
+          <InfoRow label="관람일자">2026.9.5.(토)</InfoRow>
+          <InfoRow label="장소">광주광역시 북구 필문대로 55 광주교육대학교 풍향문화관</InfoRow>
         </div>
       </div>
     );

--- a/src/shared/config/dateConfig.ts
+++ b/src/shared/config/dateConfig.ts
@@ -6,7 +6,7 @@ export const performerTicketOpenDate = new Date(
 );
 export const isTicketOpen = (role?: string | null) =>
   new Date() >= (role === "PERFORMER" ? performerTicketOpenDate : ticketOpenDate);
-export const festivalDate = new Date("2025-09-27T00:00:00");
+export const festivalDate = new Date("2026-09-05T00:00:00+09:00");
 export const sloganStartDate = new Date(
   process.env.NEXT_PUBLIC_SLOGAN_START_DATE ?? "2026-05-18T00:00:00+09:00",
 );

--- a/src/views/booking/ui/BookingPage/index.tsx
+++ b/src/views/booking/ui/BookingPage/index.tsx
@@ -173,7 +173,7 @@ const BookingPage = () => {
         }
         return `좌석을 선택해주세요 (최대 ${remainingSlots}개 추가 가능)`;
       }
-      return `${selectedSeats.length}개 좌석 예매하기`;
+      return "완료";
     } else {
       if (seatBookingMutation.isPending) {
         return "예매 중...";

--- a/src/views/booking/ui/MyBookingPage/index.tsx
+++ b/src/views/booking/ui/MyBookingPage/index.tsx
@@ -44,7 +44,8 @@ const MyBookingPage = () => {
 
       const originalSeats = seats;
       const updatedSeats = seats.filter(
-        s => !(s.section === seat.section && s.row === seat.row && s.seatNumber === seat.seatNumber),
+        s =>
+          !(s.section === seat.section && s.row === seat.row && s.seatNumber === seat.seatNumber),
       );
 
       queryClient.setQueryData(["mySeats"], updatedSeats);
@@ -108,7 +109,7 @@ const MyBookingPage = () => {
   }, [seats, isMultiple, router, queryClient]);
 
   return (
-    <div className={cn("w-full max-w-4xl mx-auto p-4 space-y-6")}>
+    <div className={cn("w-full max-w-4xl mx-auto p-16 pb-32 space-y-24")}>
       <BackHeader text="좌석 예매" goto="/home" />
       <div className="w-full">
         <SeatGrid
@@ -129,9 +130,17 @@ const MyBookingPage = () => {
         />
       </div>
 
-      <div className="w-full space-y-2">
+      <div className="w-full space-y-12">
+        <Button className="w-full h-[48px]" onClick={() => router.push("/home")}>
+          예매 확정하기
+        </Button>
+
         {canBookMore && (
-          <Button className="w-full h-[48px]" onClick={() => router.push("/booking")}>
+          <Button
+            variant="outline"
+            className="w-full h-[48px]"
+            onClick={() => router.push("/booking")}
+          >
             좌석 추가로 예매하기
           </Button>
         )}
@@ -140,7 +149,7 @@ const MyBookingPage = () => {
           <>
             <div
               className={cn(
-                "grid gap-2",
+                "grid gap-12",
                 seats.length === 2
                   ? "grid-cols-2"
                   : seats.length === 3
@@ -151,6 +160,7 @@ const MyBookingPage = () => {
               {seats.map(seat => (
                 <Button
                   key={`${seat.section}-${seat.row}-${seat.seatNumber}`}
+                  variant="outline"
                   className="h-[40px] text-sm"
                   onClick={() => handleIndividualSeatCancel(seat)}
                   disabled={seats.length === 0}
@@ -161,7 +171,8 @@ const MyBookingPage = () => {
             </div>
 
             <Button
-              className="w-full h-[48px] text-white"
+              variant="outline"
+              className="w-full h-[48px]"
               onClick={handleAllCancelClick}
               disabled={seats.length === 0}
             >
@@ -170,6 +181,7 @@ const MyBookingPage = () => {
           </>
         ) : (
           <Button
+            variant="outline"
             className="w-full h-[48px]"
             onClick={handleAllCancelClick}
             disabled={seats.length === 0}

--- a/src/widgets/main/JudgingCtaSection/__tests__/JudgingCtaSection.test.tsx
+++ b/src/widgets/main/JudgingCtaSection/__tests__/JudgingCtaSection.test.tsx
@@ -11,11 +11,22 @@ vi.mock("@/shared/utils/auth", () => ({
   getTokenFromCookie: vi.fn(),
 }));
 
+vi.mock("@/entities/booking/lib/useMySeat", () => ({
+  useMyBookedSeats: vi.fn(),
+}));
+
 import { useRouter } from "next/navigation";
 import { getTokenFromCookie } from "@/shared/utils/auth";
+import { useMyBookedSeats } from "@/entities/booking/lib/useMySeat";
+
+const mockBookedSeats = (seats: unknown[]) =>
+  vi.mocked(useMyBookedSeats).mockReturnValue({ seats } as unknown as ReturnType<
+    typeof useMyBookedSeats
+  >);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockBookedSeats([]);
 });
 
 describe("JudgingCtaSection - 노출 및 이동 경로", () => {
@@ -56,6 +67,32 @@ describe("JudgingCtaSection - 노출 및 이동 경로", () => {
     await user.click(button);
 
     expect(push).toHaveBeenCalledWith("/booking");
+  });
+
+  it("PERFORMER가 예매한 좌석이 있으면 내 좌석 확인하기 버튼으로 내 좌석 페이지로 이동한다", async () => {
+    const push = vi.fn();
+    vi.mocked(useRouter).mockReturnValue({ push } as unknown as ReturnType<typeof useRouter>);
+    vi.mocked(getTokenFromCookie).mockReturnValue("PERFORMER");
+    mockBookedSeats([{ section: "A", row: "D", seatNumber: "7" }]);
+    const user = userEvent.setup();
+
+    render(<JudgingCtaSection />);
+    const button = await screen.findByText("내 좌석 확인하기");
+    await user.click(button);
+
+    expect(push).toHaveBeenCalledWith("/booking/my");
+  });
+
+  it("PERFORMER가 예매한 좌석이 없으면 내 좌석 확인하기 버튼을 보여주지 않는다", async () => {
+    vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as unknown as ReturnType<
+      typeof useRouter
+    >);
+    vi.mocked(getTokenFromCookie).mockReturnValue("PERFORMER");
+
+    render(<JudgingCtaSection />);
+    await screen.findByText("예매하러 가기");
+
+    expect(screen.queryByText("내 좌석 확인하기")).toBeNull();
   });
 
   it("USER role이면 버튼을 보여주지 않는다", () => {

--- a/src/widgets/main/JudgingCtaSection/index.tsx
+++ b/src/widgets/main/JudgingCtaSection/index.tsx
@@ -6,6 +6,7 @@ import Button from "@/shared/ui/Button";
 import { RightArrow } from "@/shared/asset/svg/RightArrow";
 import { cn } from "@/shared/utils/cn";
 import { getTokenFromCookie } from "@/shared/utils/auth";
+import { useMyBookedSeats } from "@/entities/booking/lib/useMySeat";
 
 // ADMIN은 채점 API(JUDGE 전용) 접근 권한이 없어 모니터링 페이지로, JUDGE는 채점 페이지로 안내한다
 const ROLE_CTA: Record<string, { label: string; href: string }> = {
@@ -21,6 +22,9 @@ const JudgingCtaSection = () => {
   useEffect(() => {
     setUserRole(getTokenFromCookie("role"));
   }, []);
+
+  const { seats } = useMyBookedSeats();
+  const hasBookedSeats = userRole === "PERFORMER" && seats.length > 0;
 
   const cta = userRole ? ROLE_CTA[userRole] : undefined;
   if (!cta) return null;
@@ -43,16 +47,29 @@ const JudgingCtaSection = () => {
           </p>
         </>
       )}
-      <Button
-        type="button"
-        onClick={() => router.push(cta.href)}
-        className="px-28 rounded-lg mt-8 mobile:mt-4 mobile:w-full"
-      >
-        <span className="text-body3b flex items-center justify-center gap-10 px-[60px] mobile:px-0 mobile:w-full">
-          {cta.label}
-          <RightArrow color="white" />
-        </span>
-      </Button>
+      <div className="flex flex-col items-stretch gap-8 mt-8 mobile:mt-4 mobile:w-full">
+        <Button
+          type="button"
+          onClick={() => router.push(cta.href)}
+          className="w-full px-[88px] rounded-lg mobile:px-28"
+        >
+          <span className="text-body3b flex items-center justify-center gap-10">
+            {cta.label}
+            <RightArrow color="white" />
+          </span>
+        </Button>
+
+        {hasBookedSeats && (
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => router.push("/booking/my")}
+            className="w-full px-[88px] rounded-lg bg-white mobile:px-28"
+          >
+            <span className="text-body3b">내 좌석 확인하기</span>
+          </Button>
+        )}
+      </div>
     </section>
   );
 };

--- a/src/widgets/performer/lib/__tests__/handlePerformerVerifySubmit.test.ts
+++ b/src/widgets/performer/lib/__tests__/handlePerformerVerifySubmit.test.ts
@@ -42,6 +42,15 @@ describe("handlePerformerVerifySubmit - 유효성 검사", () => {
     expect(mockVerifyPerformer).not.toHaveBeenCalled();
   });
 
+  it("소문자로 입력한 인증코드를 대문자로 변환해 요청한다", async () => {
+    mockVerifyPerformer.mockResolvedValue(MOCK_RESPONSE);
+    await handlePerformerVerifySubmit(
+      INITIAL_STATE,
+      makeFormData({ name: "홍길동", code: "abc123" }),
+    );
+    expect(mockVerifyPerformer).toHaveBeenCalledWith({ name: "홍길동", code: "ABC123" });
+  });
+
   it("인증코드가 공백뿐이면 API를 호출하지 않는다", async () => {
     const result = await handlePerformerVerifySubmit(
       INITIAL_STATE,

--- a/src/widgets/performer/lib/handlePerformerVerifySubmit.ts
+++ b/src/widgets/performer/lib/handlePerformerVerifySubmit.ts
@@ -9,7 +9,8 @@ export const handlePerformerVerifySubmit = async (
 ): Promise<AuthFormState> => {
   const values = {
     name: formData.get("name")?.toString() || "",
-    code: formData.get("code")?.toString() || "",
+    // 인증코드는 대문자로 발급되므로 소문자로 입력해도 통과시킨다
+    code: formData.get("code")?.toString().toUpperCase() || "",
   };
 
   const result = performerVerifySchema.safeParse(values);

--- a/src/widgets/performer/ui/PerformerVerifyFormContainer/index.tsx
+++ b/src/widgets/performer/ui/PerformerVerifyFormContainer/index.tsx
@@ -53,6 +53,9 @@ const PerformerVerifyFormContainer = () => {
           name="code"
           disabled={isPending}
           defaultValue={state.values.code}
+          className="uppercase placeholder:normal-case"
+          autoCapitalize="characters"
+          autoComplete="off"
           hideErrorSpace
         />
       </div>


### PR DESCRIPTION
## 💡 PR 요약

- 예매 정보의 관람일자·장소가 3회(2025 조선대 해오름관) 기준으로 남아 있어 최신 정보로 수정
- 내 좌석 화면이 취소 버튼만 있어 "확정하고 나가기" 경로가 없던 문제 해결
- 홈에서 예매 페이지를 거치지 않고 바로 내 좌석으로 갈 수 있는 버튼 추가

## 📋 작업 내용

**1. 관람일자·장소 수정**
- `BookingInfoDisplay`: `2025.9.27.(토) / 조선대학교 해오름관` → `2026.9.5.(토) / 광주교육대학교 풍향문화관` (본선 안내 섹션 값 기준)
- `dateConfig.festivalDate`: `2025-09-27` → `2026-09-05+09:00`. 이미 지난 날짜라 미들웨어의 결과 페이지 게이트가 미리 열려 있었음

**2. 예매 완료 흐름 정리**
- 예매 화면 참가자 버튼 문구: `N개 좌석 예매하기` → `완료`
- 내 좌석 화면 최상단에 주황 `예매 확정하기` 버튼 추가 (→ `/home`)
- 나머지 취소/추가예매 버튼은 `outline` 변형으로 격하 — 취소 버튼만 가득해 혼란스러운 문제 해결
- 버튼 간격 보정: 이 프로젝트 Tailwind spacing 스케일이 px 기반(`2` = 2px)이라 `space-y-2`가 2px로 붙어 있었음 → `space-y-12`, 컨테이너 `p-16 pb-32 space-y-24`

**3. 홈 CTA에 내 좌석 확인하기 추가**
- `JudgingCtaSection`: PERFORMER이고 예매 좌석이 1석 이상일 때만 `내 좌석 확인하기`(→ `/booking/my`) 노출
- 두 버튼 폭이 달라 보이던 문제도 함께 수정 (`items-stretch` + 패딩을 span에서 버튼으로 이동)
- 노출 조건 테스트 2개 추가, 전체 406개 통과

## 🤝 리뷰 시 참고사항

- 장소 주소는 `광주광역시 북구 필문대로 55 광주교육대학교 풍향문화관`으로 넣었습니다. 실제 티켓/안내 문구와 일치하는지 확인 부탁드립니다.
- `festivalDate` 변경은 미들웨어의 `/result` 접근 게이트에 영향이 있습니다. 결과 페이지를 본선 전에 열어둘 계획이라면 알려주세요.
