### PR TITLE
fix: 예매 성공 및 SSE 재연결 시 좌석 상태 동기화

### DIFF
--- a/src/entities/booking/lib/__tests__/useSeatChangeSSE.test.ts
+++ b/src/entities/booking/lib/__tests__/useSeatChangeSSE.test.ts
@@ -266,6 +266,39 @@ describe("useSeatChangeSSE", () => {
       act(() => { vi.advanceTimersByTime(1); });
       expect(mockInstances).toHaveLength(3);
     });
+
+    it("첫 연결에서는 onReconnect를 호출하지 않는다", () => {
+      const onReconnect = vi.fn();
+      renderHook(() => useSeatChangeSSE({ onReconnect }));
+
+      act(() => { mockInstances[0].simulateOpen(); });
+
+      expect(onReconnect).not.toHaveBeenCalled();
+    });
+
+    it("재연결에 성공하면 onReconnect를 호출한다", () => {
+      const onReconnect = vi.fn();
+      renderHook(() => useSeatChangeSSE({ onReconnect }));
+
+      act(() => { mockInstances[0].simulateOpen(); });
+      act(() => { mockInstances[0].simulateError(MockEventSource.CLOSED); });
+      act(() => { vi.advanceTimersByTime(1000); });
+      act(() => { mockInstances[1].simulateOpen(); });
+
+      expect(onReconnect).toHaveBeenCalledOnce();
+    });
+
+    it("브라우저 자동 재연결로 다시 열려도 onReconnect를 호출한다", () => {
+      const onReconnect = vi.fn();
+      renderHook(() => useSeatChangeSSE({ onReconnect }));
+
+      act(() => { mockInstances[0].simulateOpen(); });
+      act(() => { mockInstances[0].simulateError(MockEventSource.CONNECTING); });
+      act(() => { mockInstances[0].simulateOpen(); });
+
+      expect(onReconnect).toHaveBeenCalledOnce();
+      expect(mockInstances).toHaveLength(1);
+    });
   });
 
   describe("네트워크 복구 (online 이벤트) 연동", () => {

--- a/src/entities/booking/lib/useSeatChangeSSE.ts
+++ b/src/entities/booking/lib/useSeatChangeSSE.ts
@@ -8,19 +8,23 @@ const BASE_DELAY = 1000;
 
 interface UseSeatChangeSSEOptions {
   onSeatChange?: (event: SeatChangeEvent) => void;
+  onReconnect?: () => void;
   enabled?: boolean;
 }
 
 export function useSeatChangeSSE(options: UseSeatChangeSSEOptions = {}) {
-  const { onSeatChange, enabled = true } = options;
+  const { onSeatChange, onReconnect, enabled = true } = options;
   const eventSourceRef = useRef<EventSource | null>(null);
   const onSeatChangeRef = useRef(onSeatChange);
+  const onReconnectRef = useRef(onReconnect);
+  const hasConnectedRef = useRef(false);
   const retryCountRef = useRef(0);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     onSeatChangeRef.current = onSeatChange;
-  }, [onSeatChange]);
+    onReconnectRef.current = onReconnect;
+  }, [onSeatChange, onReconnect]);
 
   useEffect(() => {
     if (!enabled) return;
@@ -77,6 +81,11 @@ export function useSeatChangeSSE(options: UseSeatChangeSSEOptions = {}) {
       eventSource.onopen = () => {
         retryCountRef.current = 0;
         toast.dismiss("sse-error");
+        // 끊긴 동안 놓친 SEAT_CHANGE는 다시 오지 않으므로 재연결 때 좌석 상태를 다시 받아온다
+        if (hasConnectedRef.current) {
+          onReconnectRef.current?.();
+        }
+        hasConnectedRef.current = true;
       };
 
       eventSource.onerror = () => {

--- a/src/views/booking/ui/BookingPage/index.tsx
+++ b/src/views/booking/ui/BookingPage/index.tsx
@@ -68,7 +68,12 @@ const BookingPage = () => {
     [queryClient, isPerformer, removeOccupiedSeat],
   );
 
-  useSeatChangeSSE({ onSeatChange: handleSeatChange });
+  const handleReconnect = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["seatState"] });
+    queryClient.invalidateQueries({ queryKey: ["allSectionsSeatState"] });
+  }, [queryClient]);
+
+  useSeatChangeSSE({ onSeatChange: handleSeatChange, onReconnect: handleReconnect });
 
   const handleSectionSelect = useCallback(
     (section: SectionType) => {

--- a/src/widgets/booking/lib/__tests__/useSeatBooking.test.tsx
+++ b/src/widgets/booking/lib/__tests__/useSeatBooking.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { useSeatBooking, useMultipleSeatBooking } from "../useSeatBooking";
+import { bookSeatWithRetry } from "../bookSeatWithRetry";
+import { seatQueryKeys } from "@/entities/booking/lib/useSeatState";
+import { Seat, SEAT_STATUS } from "@/entities/booking/model/types";
+
+vi.mock("../bookSeatWithRetry", () => ({
+  bookSeatWithRetry: vi.fn(),
+}));
+
+vi.mock("@/entities/booking/api/getMySeat", () => ({
+  getMySeats: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const createWrapper = (queryClient: QueryClient) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+const seat = (section: Seat["section"], row: string, seatNumber: string): Seat => ({
+  section,
+  row,
+  seatNumber,
+  status: SEAT_STATUS.AVAILABLE,
+});
+
+let queryClient: QueryClient;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+});
+
+const findSeat = (seats: Seat[] | undefined, row: string, seatNumber: string) =>
+  seats?.find(item => item.row === row && item.seatNumber === seatNumber);
+
+describe("useSeatBooking", () => {
+  it("예매에 성공하면 재조회를 기다리지 않고 해당 좌석을 즉시 occupied로 반영한다", async () => {
+    vi.mocked(bookSeatWithRetry).mockResolvedValueOnce(undefined as never);
+    queryClient.setQueryData<Seat[]>(seatQueryKeys.seatState("RED"), [
+      seat("RED", "B", "1"),
+      seat("RED", "B", "2"),
+    ]);
+
+    const { result } = renderHook(() => useSeatBooking(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate({ section: "RED", row: "B", seatNumber: "1" });
+    });
+
+    await waitFor(() => {
+      const seats = queryClient.getQueryData<Seat[]>(seatQueryKeys.seatState("RED"));
+      expect(findSeat(seats, "B", "1")?.status).toBe(SEAT_STATUS.OCCUPIED);
+    });
+    const seats = queryClient.getQueryData<Seat[]>(seatQueryKeys.seatState("RED"));
+    expect(findSeat(seats, "B", "2")?.status).toBe(SEAT_STATUS.AVAILABLE);
+  });
+
+  it("예매에 성공하면 전체 구역 캐시에도 occupied로 반영한다", async () => {
+    vi.mocked(bookSeatWithRetry).mockResolvedValueOnce(undefined as never);
+    queryClient.setQueryData<Seat[]>(["allSectionsSeatState"], [seat("BLUE", "C", "3")]);
+
+    const { result } = renderHook(() => useSeatBooking(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate({ section: "BLUE", row: "C", seatNumber: "3" });
+    });
+
+    await waitFor(() => {
+      const seats = queryClient.getQueryData<Seat[]>(["allSectionsSeatState"]);
+      expect(findSeat(seats, "C", "3")?.status).toBe(SEAT_STATUS.OCCUPIED);
+    });
+  });
+});
+
+describe("useMultipleSeatBooking", () => {
+  it("다중 예매에 성공하면 선택한 좌석 전부를 즉시 occupied로 반영한다", async () => {
+    vi.mocked(bookSeatWithRetry).mockResolvedValue(undefined as never);
+    queryClient.setQueryData<Seat[]>(seatQueryKeys.seatState("RED"), [
+      seat("RED", "B", "1"),
+      seat("RED", "B", "2"),
+      seat("RED", "B", "3"),
+    ]);
+    queryClient.setQueryData<Seat[]>(seatQueryKeys.seatState("GREEN"), [seat("GREEN", "C", "5")]);
+
+    const { result } = renderHook(() => useMultipleSeatBooking(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate([
+        { section: "RED", row: "B", seatNumber: "1" },
+        { section: "RED", row: "B", seatNumber: "3" },
+        { section: "GREEN", row: "C", seatNumber: "5" },
+      ]);
+    });
+
+    await waitFor(() => {
+      const redSeats = queryClient.getQueryData<Seat[]>(seatQueryKeys.seatState("RED"));
+      expect(findSeat(redSeats, "B", "1")?.status).toBe(SEAT_STATUS.OCCUPIED);
+      expect(findSeat(redSeats, "B", "3")?.status).toBe(SEAT_STATUS.OCCUPIED);
+    });
+
+    const redSeats = queryClient.getQueryData<Seat[]>(seatQueryKeys.seatState("RED"));
+    expect(findSeat(redSeats, "B", "2")?.status).toBe(SEAT_STATUS.AVAILABLE);
+
+    const greenSeats = queryClient.getQueryData<Seat[]>(seatQueryKeys.seatState("GREEN"));
+    expect(findSeat(greenSeats, "C", "5")?.status).toBe(SEAT_STATUS.OCCUPIED);
+  });
+
+  it("일부 좌석 예매가 실패하면 캐시를 occupied로 바꾸지 않는다", async () => {
+    vi.mocked(bookSeatWithRetry)
+      .mockResolvedValueOnce(undefined as never)
+      .mockRejectedValueOnce(new Error("이미 예매된 좌석입니다."));
+    const { getMySeats } = await import("@/entities/booking/api/getMySeat");
+    vi.mocked(getMySeats).mockResolvedValueOnce([]);
+    queryClient.setQueryData<Seat[]>(seatQueryKeys.seatState("RED"), [
+      seat("RED", "B", "1"),
+      seat("RED", "B", "2"),
+    ]);
+
+    const { result } = renderHook(() => useMultipleSeatBooking(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate([
+        { section: "RED", row: "B", seatNumber: "1" },
+        { section: "RED", row: "B", seatNumber: "2" },
+      ]);
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    const seats = queryClient.getQueryData<Seat[]>(seatQueryKeys.seatState("RED"));
+    expect(findSeat(seats, "B", "1")?.status).toBe(SEAT_STATUS.AVAILABLE);
+  });
+});

--- a/src/widgets/booking/lib/useSeatBooking.ts
+++ b/src/widgets/booking/lib/useSeatBooking.ts
@@ -4,7 +4,22 @@ import { bookSeatWithRetry } from "@/widgets/booking/lib/bookSeatWithRetry";
 import { getMySeats } from "@/entities/booking/api/getMySeat";
 import { Seat, formatSeatLabel } from "@/entities/booking/model/types";
 import { useQueryClient } from "@tanstack/react-query";
-import { seatQueryKeys } from "@/entities/booking/lib/useSeatState";
+import { seatQueryKeys, applySeatChange } from "@/entities/booking/lib/useSeatState";
+
+// 재조회·SSE를 기다리지 않고 캐시를 먼저 갱신 — 예매 직후 좌석이 즉시 회색으로 전환된다
+const markSeatsOccupied = (
+  queryClient: ReturnType<typeof useQueryClient>,
+  seats: Array<Omit<Seat, "status">>,
+) => {
+  seats.forEach(seat => {
+    applySeatChange(queryClient, {
+      seat_section: seat.section,
+      seat_row: seat.row,
+      seat_number: Number(seat.seatNumber),
+      is_available: false,
+    });
+  });
+};
 
 export function useSeatBooking() {
   const queryClient = useQueryClient();
@@ -12,6 +27,7 @@ export function useSeatBooking() {
   return useMutation({
     mutationFn: (data: Omit<Seat, "status">) => bookSeatWithRetry(data),
     onSuccess: (_result, vars) => {
+      markSeatsOccupied(queryClient, [vars]);
       queryClient.invalidateQueries({ queryKey: seatQueryKeys.seatState(vars.section) });
       queryClient.invalidateQueries({ queryKey: ["mySeat"] });
       queryClient.invalidateQueries({ queryKey: ["mySeats"] });
@@ -70,6 +86,8 @@ export function useMultipleSeatBooking() {
       };
     },
     onSuccess: (result, vars) => {
+      markSeatsOccupied(queryClient, vars);
+
       const sections = [...new Set(vars.map(seat => seat.section))];
       sections.forEach(section => {
         queryClient.invalidateQueries({ queryKey: seatQueryKeys.seatState(section) });


### PR DESCRIPTION
## 💡 PR 요약

> 해당 PR의 변경사항, 해당 이슈 등에 대한 간략한 설명을 작성해주세요.

- 단일·다중 예매 성공 시 해당 좌석을 프론트 캐시에서 즉시 `OCCUPIED`로 반영
- SSE 재연결 성공 시 좌석 목록을 다시 조회해 끊긴 동안 누락된 상태 복구
- 예매 성공 및 SSE 재연결 상태 동기화 테스트 추가

Closes #303

## 📋 작업 내용

> 해당 PR에서 작업한 내용을 자세히 설명해주세요.

**1. 예매 성공 시 즉시 회색 전환 (`useSeatBooking.ts`)**

기존에는 예매 성공 후 `invalidateQueries`로 재조회하거나 SSE 이벤트가 도착할 때까지 좌석이 흰색으로 남아 있었습니다. 관리자 밴 기능에서 이미 쓰고 있던 `applySeatChange`를 재사용해, `onSuccess` 시점에 캐시를 먼저 `OCCUPIED`로 갱신하도록 `markSeatsOccupied` 헬퍼를 추가했습니다. 단일 예매(`useSeatBooking`)와 다중 예매(`useMultipleSeatBooking`) 양쪽에 적용했고, 기존 재조회는 서버 상태 확인용으로 그대로 뒀습니다.

**2. SSE 재연결 시 누락 상태 복구 (`useSeatChangeSSE.ts`, `BookingPage`)**

연결이 끊긴 동안 발생한 `SEAT_CHANGE`는 다시 전달되지 않아, 재연결 후에도 좌석 상태가 낡은 채로 남았습니다. `onReconnect` 옵션을 추가하고 `hasConnectedRef`로 첫 연결과 재연결을 구분해, `onopen`이 두 번째 이후 발생할 때만 호출합니다. 백오프 재연결뿐 아니라 브라우저 네이티브 자동 재연결(`CONNECTING` 후 재개)도 함께 잡힙니다. `BookingPage`에서는 `onReconnect`로 `seatState`(전 구역 prefix) / `allSectionsSeatState` 쿼리를 무효화합니다.

**3. 테스트**

- `useSeatBooking.test.tsx` (신규): 단일 예매 시 해당 좌석만 `OCCUPIED`가 되는지, 전체 구역 캐시에도 반영되는지, 다중 예매 시 선택 좌석 전부(구역이 섞여도) 반영되는지, 일부 실패 시에는 캐시를 바꾸지 않는지 검증
- `useSeatChangeSSE.test.ts`: 첫 연결에서는 `onReconnect`를 호출하지 않고, 백오프 재연결·브라우저 자동 재연결에서만 호출되는지 검증

## 🤝 리뷰 시 참고사항

> 리뷰어분들이 리뷰를 할 때 참고하면 좋을 사항이나 질문사항을 작성해주세요.

- 예매 실패 시 낙관적 롤백은 넣지 않았습니다. 실패 경로는 기존처럼 `invalidateQueries`로 서버 상태를 다시 받아오므로 캐시가 잘못된 상태로 남지 않습니다.
- 전체 테스트 411개 통과, 린트 통과했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)