### PR TITLE
fix: 참가자 다중 좌석 예매를 bulk API로 전환

### DIFF
--- a/src/entities/booking/api/seatBooking.ts
+++ b/src/entities/booking/api/seatBooking.ts
@@ -3,26 +3,40 @@ import { toApiSeat } from "../model/seatLayouts";
 import axios from "@/shared/lib/axios";
 import { AxiosError } from "axios";
 
+const toSeatBookingError = (error: unknown) => {
+  const axiosError = error as AxiosError;
+  const errorMessage =
+    axiosError?.response?.data &&
+    typeof axiosError.response.data === "object" &&
+    "message" in axiosError.response.data
+      ? (axiosError.response.data as { message: string }).message
+      : "좌석 예매에 실패했습니다.";
+
+  // 호출부가 429(rate limit)를 재시도 대상으로 구분할 수 있게 상태 코드와 대기 시간을 실어 보낸다
+  const retryAfter = Number(axiosError?.response?.headers?.["retry-after"]);
+
+  return Object.assign(new Error(errorMessage), {
+    status: axiosError?.response?.status,
+    retryAfterMs: Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : undefined,
+  });
+};
+
 export const seatBooking = async (data: Omit<Seat, "status">) => {
   try {
     const response = await axios.post("/seat", toApiSeat(data));
 
     return { data: response.data };
   } catch (error: unknown) {
-    const axiosError = error as AxiosError;
-    const errorMessage =
-      axiosError?.response?.data &&
-      typeof axiosError.response.data === "object" &&
-      "message" in axiosError.response.data
-        ? (axiosError.response.data as { message: string }).message
-        : "좌석 예매에 실패했습니다.";
+    throw toSeatBookingError(error);
+  }
+};
 
-    // 호출부가 429(rate limit)를 재시도 대상으로 구분할 수 있게 상태 코드와 대기 시간을 실어 보낸다
-    const retryAfter = Number(axiosError?.response?.headers?.["retry-after"]);
+export const bulkSeatBooking = async (seats: Array<Omit<Seat, "status">>) => {
+  try {
+    const response = await axios.post("/seat/bulk", { seats: seats.map(toApiSeat) });
 
-    throw Object.assign(new Error(errorMessage), {
-      status: axiosError?.response?.status,
-      retryAfterMs: Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : undefined,
-    });
+    return { data: response.data };
+  } catch (error: unknown) {
+    throw toSeatBookingError(error);
   }
 };

--- a/src/entities/booking/lib/__tests__/useSeatChangeSSE.test.ts
+++ b/src/entities/booking/lib/__tests__/useSeatChangeSSE.test.ts
@@ -266,6 +266,39 @@ describe("useSeatChangeSSE", () => {
       act(() => { vi.advanceTimersByTime(1); });
       expect(mockInstances).toHaveLength(3);
     });
+
+    it("첫 연결에서는 onReconnect를 호출하지 않는다", () => {
+      const onReconnect = vi.fn();
+      renderHook(() => useSeatChangeSSE({ onReconnect }));
+
+      act(() => { mockInstances[0].simulateOpen(); });
+
+      expect(onReconnect).not.toHaveBeenCalled();
+    });
+
+    it("재연결에 성공하면 onReconnect를 호출한다", () => {
+      const onReconnect = vi.fn();
+      renderHook(() => useSeatChangeSSE({ onReconnect }));
+
+      act(() => { mockInstances[0].simulateOpen(); });
+      act(() => { mockInstances[0].simulateError(MockEventSource.CLOSED); });
+      act(() => { vi.advanceTimersByTime(1000); });
+      act(() => { mockInstances[1].simulateOpen(); });
+
+      expect(onReconnect).toHaveBeenCalledOnce();
+    });
+
+    it("브라우저 자동 재연결로 다시 열려도 onReconnect를 호출한다", () => {
+      const onReconnect = vi.fn();
+      renderHook(() => useSeatChangeSSE({ onReconnect }));
+
+      act(() => { mockInstances[0].simulateOpen(); });
+      act(() => { mockInstances[0].simulateError(MockEventSource.CONNECTING); });
+      act(() => { mockInstances[0].simulateOpen(); });
+
+      expect(onReconnect).toHaveBeenCalledOnce();
+      expect(mockInstances).toHaveLength(1);
+    });
   });
 
   describe("네트워크 복구 (online 이벤트) 연동", () => {

--- a/src/entities/booking/lib/useSeatChangeSSE.ts
+++ b/src/entities/booking/lib/useSeatChangeSSE.ts
@@ -8,19 +8,23 @@ const BASE_DELAY = 1000;
 
 interface UseSeatChangeSSEOptions {
   onSeatChange?: (event: SeatChangeEvent) => void;
+  onReconnect?: () => void;
   enabled?: boolean;
 }
 
 export function useSeatChangeSSE(options: UseSeatChangeSSEOptions = {}) {
-  const { onSeatChange, enabled = true } = options;
+  const { onSeatChange, onReconnect, enabled = true } = options;
   const eventSourceRef = useRef<EventSource | null>(null);
   const onSeatChangeRef = useRef(onSeatChange);
+  const onReconnectRef = useRef(onReconnect);
+  const hasConnectedRef = useRef(false);
   const retryCountRef = useRef(0);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     onSeatChangeRef.current = onSeatChange;
-  }, [onSeatChange]);
+    onReconnectRef.current = onReconnect;
+  }, [onSeatChange, onReconnect]);
 
   useEffect(() => {
     if (!enabled) return;
@@ -77,6 +81,11 @@ export function useSeatChangeSSE(options: UseSeatChangeSSEOptions = {}) {
       eventSource.onopen = () => {
         retryCountRef.current = 0;
         toast.dismiss("sse-error");
+        // 끊긴 동안 놓친 SEAT_CHANGE는 다시 오지 않으므로 재연결 때 좌석 상태를 다시 받아온다
+        if (hasConnectedRef.current) {
+          onReconnectRef.current?.();
+        }
+        hasConnectedRef.current = true;
       };
 
       eventSource.onerror = () => {

--- a/src/views/booking/ui/BookingPage/index.tsx
+++ b/src/views/booking/ui/BookingPage/index.tsx
@@ -118,6 +118,8 @@ const BookingPage = () => {
 
   const handleBookingClick = useCallback(() => {
     if (isPerformer) {
+      // bulk 요청이 진행 중인 동안의 재클릭은 같은 좌석을 다시 보내게 되므로 막는다
+      if (multipleSeatBookingMutation.isPending) return;
       if (canBook && selectedSeats.length > 0) {
         multipleSeatBookingMutation.mutate(selectedSeats, {
           onSuccess: () => router.push("/booking/my"),
@@ -228,8 +230,8 @@ const BookingPage = () => {
               onClick={handleBookingClick}
               disabled={
                 isPerformer
-                  ? !canBook || maxSelectableSeats === 0
-                  : !isComplete || isSelectedSeatOccupied
+                  ? !canBook || maxSelectableSeats === 0 || multipleSeatBookingMutation.isPending
+                  : !isComplete || isSelectedSeatOccupied || seatBookingMutation.isPending
               }
             >
               {getButtonText()}

--- a/src/views/booking/ui/BookingPage/index.tsx
+++ b/src/views/booking/ui/BookingPage/index.tsx
@@ -68,7 +68,12 @@ const BookingPage = () => {
     [queryClient, isPerformer, removeOccupiedSeat],
   );
 
-  useSeatChangeSSE({ onSeatChange: handleSeatChange });
+  const handleReconnect = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["seatState"] });
+    queryClient.invalidateQueries({ queryKey: ["allSectionsSeatState"] });
+  }, [queryClient]);
+
+  useSeatChangeSSE({ onSeatChange: handleSeatChange, onReconnect: handleReconnect });
 
   const handleSectionSelect = useCallback(
     (section: SectionType) => {

--- a/src/widgets/booking/lib/__tests__/bookSeatWithRetry.test.ts
+++ b/src/widgets/booking/lib/__tests__/bookSeatWithRetry.test.ts
@@ -1,11 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { bookSeatWithRetry, RATE_LIMIT_RETRY_DELAYS_MS } from "../bookSeatWithRetry";
+import {
+  bookSeatWithRetry,
+  bookSeatsBulkWithRetry,
+  RATE_LIMIT_RETRY_DELAYS_MS,
+} from "../bookSeatWithRetry";
 
-vi.mock("@/entities/booking/api/seatBooking", () => ({ seatBooking: vi.fn() }));
+vi.mock("@/entities/booking/api/seatBooking", () => ({
+  seatBooking: vi.fn(),
+  bulkSeatBooking: vi.fn(),
+}));
 
-import { seatBooking } from "@/entities/booking/api/seatBooking";
+import { seatBooking, bulkSeatBooking } from "@/entities/booking/api/seatBooking";
 
 const mockSeatBooking = vi.mocked(seatBooking);
+const mockBulkSeatBooking = vi.mocked(bulkSeatBooking);
 
 const SEAT = { section: "RED", row: "B", seatNumber: "16" } as Parameters<
   typeof bookSeatWithRetry
@@ -59,5 +67,29 @@ describe("bookSeatWithRetry", () => {
 
     await expect(bookSeatWithRetry(SEAT)).rejects.toThrow("이미 예매된 좌석입니다.");
     expect(mockSeatBooking).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("bookSeatsBulkWithRetry", () => {
+  const SEATS = [SEAT, { section: "GREEN", row: "C", seatNumber: "5" } as typeof SEAT];
+
+  it("좌석을 bulk API 한 번으로 보낸다", async () => {
+    mockBulkSeatBooking.mockResolvedValue({ data: {} });
+
+    await bookSeatsBulkWithRetry(SEATS);
+
+    expect(mockBulkSeatBooking).toHaveBeenCalledTimes(1);
+    expect(mockBulkSeatBooking).toHaveBeenCalledWith(SEATS);
+    expect(mockSeatBooking).not.toHaveBeenCalled();
+  });
+
+  it("429면 대기 후 같은 bulk 요청을 재시도한다", async () => {
+    mockBulkSeatBooking.mockRejectedValueOnce(rateLimitError()).mockResolvedValue({ data: {} });
+
+    const promise = bookSeatsBulkWithRetry(SEATS);
+    await vi.advanceTimersByTimeAsync(RATE_LIMIT_RETRY_DELAYS_MS[0]);
+    await promise;
+
+    expect(mockBulkSeatBooking).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/widgets/booking/lib/__tests__/useSeatBooking.test.tsx
+++ b/src/widgets/booking/lib/__tests__/useSeatBooking.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { useSeatBooking, useMultipleSeatBooking } from "../useSeatBooking";
+import { bookSeatWithRetry } from "../bookSeatWithRetry";
+import { seatQueryKeys } from "@/entities/booking/lib/useSeatState";
+import { Seat, SEAT_STATUS } from "@/entities/booking/model/types";
+
+vi.mock("../bookSeatWithRetry", () => ({
+  bookSeatWithRetry: vi.fn(),
+}));
+
+vi.mock("@/entities/booking/api/getMySeat", () => ({
+  getMySeats: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const createWrapper = (queryClient: QueryClient) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+const seat = (section: Seat["section"], row: string, seatNumber: string): Seat => ({
+  section,
+  row,
+  seatNumber,
+  status: SEAT_STATUS.AVAILABLE,
+});
+
+let queryClient: QueryClient;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+});
+
+const findSeat = (seats: Seat[] | undefined, row: string, seatNumber: string) =>
+  seats?.find(item => item.row === row && item.seatNumber === seatNumber);
+
+describe("useSeatBooking", () => {
+  it("예매에 성공하면 재조회를 기다리지 않고 해당 좌석을 즉시 occupied로 반영한다", async () => {
+    vi.mocked(bookSeatWithRetry).mockResolvedValueOnce(undefined as never);
+    queryClient.setQueryData<Seat[]>(seatQueryKeys.seatState("RED"), [
+      seat("RED", "B", "1"),
+      seat("RED", "B", "2"),
+    ]);
+
+    const { result } = renderHook(() => useSeatBooking(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate({ section: "RED", row: "B", seatNumber: "1" });
+    });
+
+    await waitFor(() => {
+      const seats = queryClient.getQueryData<Seat[]>(seatQueryKeys.seatState("RED"));
+      expect(findSeat(seats, "B", "1")?.status).toBe(SEAT_STATUS.OCCUPIED);
+    });
+    const seats = queryClient.getQueryData<Seat[]>(seatQueryKeys.seatState("RED"));
+    expect(findSeat(seats, "B", "2")?.status).toBe(SEAT_STATUS.AVAILABLE);
+  });
+
+  it("예매에 성공하면 전체 구역 캐시에도 occupied로 반영한다", async () => {
+    vi.mocked(bookSeatWithRetry).mockResolvedValueOnce(undefined as never);
+    queryClient.setQueryData<Seat[]>(["allSectionsSeatState"], [seat("BLUE", "C", "3")]);
+
+    const { result } = renderHook(() => useSeatBooking(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate({ section: "BLUE", row: "C", seatNumber: "3" });
+    });
+
+    await waitFor(() => {
+      const seats = queryClient.getQueryData<Seat[]>(["allSectionsSeatState"]);
+      expect(findSeat(seats, "C", "3")?.status).toBe(SEAT_STATUS.OCCUPIED);
+    });
+  });
+});
+
+describe("useMultipleSeatBooking", () => {
+  it("다중 예매에 성공하면 선택한 좌석 전부를 즉시 occupied로 반영한다", async () => {
+    vi.mocked(bookSeatWithRetry).mockResolvedValue(undefined as never);
+    queryClient.setQueryData<Seat[]>(seatQueryKeys.seatState("RED"), [
+      seat("RED", "B", "1"),
+      seat("RED", "B", "2"),
+      seat("RED", "B", "3"),
+    ]);
+    queryClient.setQueryData<Seat[]>(seatQueryKeys.seatState("GREEN"), [seat("GREEN", "C", "5")]);
+
+    const { result } = renderHook(() => useMultipleSeatBooking(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate([
+        { section: "RED", row: "B", seatNumber: "1" },
+        { section: "RED", row: "B", seatNumber: "3" },
+        { section: "GREEN", row: "C", seatNumber: "5" },
+      ]);
+    });
+
+    await waitFor(() => {
+      const redSeats = queryClient.getQueryData<Seat[]>(seatQueryKeys.seatState("RED"));
+      expect(findSeat(redSeats, "B", "1")?.status).toBe(SEAT_STATUS.OCCUPIED);
+      expect(findSeat(redSeats, "B", "3")?.status).toBe(SEAT_STATUS.OCCUPIED);
+    });
+
+    const redSeats = queryClient.getQueryData<Seat[]>(seatQueryKeys.seatState("RED"));
+    expect(findSeat(redSeats, "B", "2")?.status).toBe(SEAT_STATUS.AVAILABLE);
+
+    const greenSeats = queryClient.getQueryData<Seat[]>(seatQueryKeys.seatState("GREEN"));
+    expect(findSeat(greenSeats, "C", "5")?.status).toBe(SEAT_STATUS.OCCUPIED);
+  });
+
+  it("일부 좌석 예매가 실패하면 캐시를 occupied로 바꾸지 않는다", async () => {
+    vi.mocked(bookSeatWithRetry)
+      .mockResolvedValueOnce(undefined as never)
+      .mockRejectedValueOnce(new Error("이미 예매된 좌석입니다."));
+    const { getMySeats } = await import("@/entities/booking/api/getMySeat");
+    vi.mocked(getMySeats).mockResolvedValueOnce([]);
+    queryClient.setQueryData<Seat[]>(seatQueryKeys.seatState("RED"), [
+      seat("RED", "B", "1"),
+      seat("RED", "B", "2"),
+    ]);
+
+    const { result } = renderHook(() => useMultipleSeatBooking(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.mutate([
+        { section: "RED", row: "B", seatNumber: "1" },
+        { section: "RED", row: "B", seatNumber: "2" },
+      ]);
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    const seats = queryClient.getQueryData<Seat[]>(seatQueryKeys.seatState("RED"));
+    expect(findSeat(seats, "B", "1")?.status).toBe(SEAT_STATUS.AVAILABLE);
+  });
+});

--- a/src/widgets/booking/lib/__tests__/useSeatBooking.test.tsx
+++ b/src/widgets/booking/lib/__tests__/useSeatBooking.test.tsx
@@ -3,16 +3,13 @@ import { renderHook, waitFor, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
 import { useSeatBooking, useMultipleSeatBooking } from "../useSeatBooking";
-import { bookSeatWithRetry } from "../bookSeatWithRetry";
+import { bookSeatWithRetry, bookSeatsBulkWithRetry } from "../bookSeatWithRetry";
 import { seatQueryKeys } from "@/entities/booking/lib/useSeatState";
 import { Seat, SEAT_STATUS } from "@/entities/booking/model/types";
 
 vi.mock("../bookSeatWithRetry", () => ({
   bookSeatWithRetry: vi.fn(),
-}));
-
-vi.mock("@/entities/booking/api/getMySeat", () => ({
-  getMySeats: vi.fn(),
+  bookSeatsBulkWithRetry: vi.fn(),
 }));
 
 vi.mock("sonner", () => ({
@@ -89,8 +86,30 @@ describe("useSeatBooking", () => {
 });
 
 describe("useMultipleSeatBooking", () => {
+  it("좌석이 여러 개여도 bulk 요청을 한 번만 보낸다", async () => {
+    vi.mocked(bookSeatsBulkWithRetry).mockResolvedValue(undefined as never);
+
+    const { result } = renderHook(() => useMultipleSeatBooking(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    const seats = [
+      { section: "RED" as const, row: "B", seatNumber: "1" },
+      { section: "GREEN" as const, row: "C", seatNumber: "5" },
+    ];
+
+    act(() => {
+      result.current.mutate(seats);
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(bookSeatsBulkWithRetry).toHaveBeenCalledTimes(1);
+    expect(bookSeatsBulkWithRetry).toHaveBeenCalledWith(seats);
+    expect(bookSeatWithRetry).not.toHaveBeenCalled();
+  });
+
   it("다중 예매에 성공하면 선택한 좌석 전부를 즉시 occupied로 반영한다", async () => {
-    vi.mocked(bookSeatWithRetry).mockResolvedValue(undefined as never);
+    vi.mocked(bookSeatsBulkWithRetry).mockResolvedValue(undefined as never);
     queryClient.setQueryData<Seat[]>(seatQueryKeys.seatState("RED"), [
       seat("RED", "B", "1"),
       seat("RED", "B", "2"),
@@ -123,12 +142,9 @@ describe("useMultipleSeatBooking", () => {
     expect(findSeat(greenSeats, "C", "5")?.status).toBe(SEAT_STATUS.OCCUPIED);
   });
 
-  it("일부 좌석 예매가 실패하면 캐시를 occupied로 바꾸지 않는다", async () => {
-    vi.mocked(bookSeatWithRetry)
-      .mockResolvedValueOnce(undefined as never)
-      .mockRejectedValueOnce(new Error("이미 예매된 좌석입니다."));
-    const { getMySeats } = await import("@/entities/booking/api/getMySeat");
-    vi.mocked(getMySeats).mockResolvedValueOnce([]);
+  it("bulk 예매가 실패하면 캐시를 occupied로 바꾸지 않고 좌석 현황을 다시 조회한다", async () => {
+    vi.mocked(bookSeatsBulkWithRetry).mockRejectedValueOnce(new Error("이미 예매된 좌석입니다."));
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
     queryClient.setQueryData<Seat[]>(seatQueryKeys.seatState("RED"), [
       seat("RED", "B", "1"),
       seat("RED", "B", "2"),
@@ -148,5 +164,9 @@ describe("useMultipleSeatBooking", () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
     const seats = queryClient.getQueryData<Seat[]>(seatQueryKeys.seatState("RED"));
     expect(findSeat(seats, "B", "1")?.status).toBe(SEAT_STATUS.AVAILABLE);
+    expect(findSeat(seats, "B", "2")?.status).toBe(SEAT_STATUS.AVAILABLE);
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: seatQueryKeys.seatState("RED"),
+    });
   });
 });

--- a/src/widgets/booking/lib/bookSeatWithRetry.ts
+++ b/src/widgets/booking/lib/bookSeatWithRetry.ts
@@ -1,4 +1,4 @@
-import { seatBooking } from "@/entities/booking/api/seatBooking";
+import { bulkSeatBooking, seatBooking } from "@/entities/booking/api/seatBooking";
 import { Seat } from "@/entities/booking/model/types";
 
 export const RATE_LIMIT_RETRY_DELAYS_MS = [1500, 4000, 8000];
@@ -7,10 +7,10 @@ const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 // 429는 서버가 요청을 처리하지 않은 상태라 같은 좌석을 다시 보내도 중복 예매가 되지 않는다.
 // 거부된 요청까지 카운트하는 limiter도 있어서 간격을 넉넉히 두고, 서버가 Retry-After를 주면 그 값을 따른다
-export const bookSeatWithRetry = async (seat: Omit<Seat, "status">) => {
+const withRateLimitRetry = async <T>(request: () => Promise<T>): Promise<T> => {
   for (let attempt = 0; ; attempt += 1) {
     try {
-      return await seatBooking(seat);
+      return await request();
     } catch (error) {
       const { status, retryAfterMs } = error as { status?: number; retryAfterMs?: number };
       if (status !== 429 || attempt >= RATE_LIMIT_RETRY_DELAYS_MS.length) throw error;
@@ -18,3 +18,9 @@ export const bookSeatWithRetry = async (seat: Omit<Seat, "status">) => {
     }
   }
 };
+
+export const bookSeatWithRetry = (seat: Omit<Seat, "status">) =>
+  withRateLimitRetry(() => seatBooking(seat));
+
+export const bookSeatsBulkWithRetry = (seats: Array<Omit<Seat, "status">>) =>
+  withRateLimitRetry(() => bulkSeatBooking(seats));

--- a/src/widgets/booking/lib/useSeatBooking.ts
+++ b/src/widgets/booking/lib/useSeatBooking.ts
@@ -4,7 +4,22 @@ import { bookSeatWithRetry } from "@/widgets/booking/lib/bookSeatWithRetry";
 import { getMySeats } from "@/entities/booking/api/getMySeat";
 import { Seat, formatSeatLabel } from "@/entities/booking/model/types";
 import { useQueryClient } from "@tanstack/react-query";
-import { seatQueryKeys } from "@/entities/booking/lib/useSeatState";
+import { seatQueryKeys, applySeatChange } from "@/entities/booking/lib/useSeatState";
+
+// 재조회·SSE를 기다리지 않고 캐시를 먼저 갱신 — 예매 직후 좌석이 즉시 회색으로 전환된다
+const markSeatsOccupied = (
+  queryClient: ReturnType<typeof useQueryClient>,
+  seats: Array<Omit<Seat, "status">>,
+) => {
+  seats.forEach(seat => {
+    applySeatChange(queryClient, {
+      seat_section: seat.section,
+      seat_row: seat.row,
+      seat_number: Number(seat.seatNumber),
+      is_available: false,
+    });
+  });
+};
 
 export function useSeatBooking() {
   const queryClient = useQueryClient();
@@ -12,6 +27,7 @@ export function useSeatBooking() {
   return useMutation({
     mutationFn: (data: Omit<Seat, "status">) => bookSeatWithRetry(data),
     onSuccess: (_result, vars) => {
+      markSeatsOccupied(queryClient, [vars]);
       queryClient.invalidateQueries({ queryKey: seatQueryKeys.seatState(vars.section) });
       queryClient.invalidateQueries({ queryKey: ["mySeat"] });
       queryClient.invalidateQueries({ queryKey: ["mySeats"] });
@@ -70,6 +86,8 @@ export function useMultipleSeatBooking() {
       };
     },
     onSuccess: (result, vars) => {
+      markSeatsOccupied(queryClient, vars);
+
       const sections = [...new Set(vars.map(seat => seat.section))];
       sections.forEach(section => {
         queryClient.invalidateQueries({ queryKey: seatQueryKeys.seatState(section) });

--- a/src/widgets/booking/lib/useSeatBooking.ts
+++ b/src/widgets/booking/lib/useSeatBooking.ts
@@ -1,8 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { bookSeatWithRetry } from "@/widgets/booking/lib/bookSeatWithRetry";
-import { getMySeats } from "@/entities/booking/api/getMySeat";
-import { Seat, formatSeatLabel } from "@/entities/booking/model/types";
+import { bookSeatWithRetry, bookSeatsBulkWithRetry } from "@/widgets/booking/lib/bookSeatWithRetry";
+import { Seat } from "@/entities/booking/model/types";
 import { useQueryClient } from "@tanstack/react-query";
 import { seatQueryKeys, applySeatChange } from "@/entities/booking/lib/useSeatState";
 
@@ -42,71 +41,27 @@ export function useSeatBooking() {
 export function useMultipleSeatBooking() {
   const queryClient = useQueryClient();
 
+  const revalidateSeats = (seats: Array<Omit<Seat, "status">>) => {
+    [...new Set(seats.map(seat => seat.section))].forEach(section => {
+      queryClient.invalidateQueries({ queryKey: seatQueryKeys.seatState(section) });
+    });
+    queryClient.invalidateQueries({ queryKey: ["allSectionsSeatState"] });
+    queryClient.invalidateQueries({ queryKey: ["mySeat"] });
+    queryClient.invalidateQueries({ queryKey: ["mySeats"] });
+  };
+
   return useMutation({
-    // 좌석을 동시에 요청하면 서버 rate limit(429)에 걸리므로 한 건씩 순차로 보내고, 429는 재시도한다
-    mutationFn: async (seats: Array<Omit<Seat, "status">>) => {
-      const failures: Array<{ seat: Omit<Seat, "status">; detail: string }> = [];
+    // 서버가 좌석 전체를 한 트랜잭션으로 처리하므로 부분 성공이 없다 — 요청도 한 번만 보낸다
+    mutationFn: (seats: Array<Omit<Seat, "status">>) => bookSeatsBulkWithRetry(seats),
+    onSuccess: (_result, seats) => {
+      markSeatsOccupied(queryClient, seats);
+      revalidateSeats(seats);
 
-      for (const seat of seats) {
-        try {
-          await bookSeatWithRetry(seat);
-        } catch (error) {
-          const detail = error instanceof Error ? error.message : "예매에 실패했습니다.";
-          failures.push({ seat, detail });
-        }
-      }
-
-      // 429가 예매를 처리한 뒤에 떨어지는 경우가 있어 에러만 믿으면 성공을 실패로 알린다.
-      // 실패로 잡힌 좌석은 서버 상태로 한 번 더 확인한다
-      let unbooked = failures;
-      if (failures.length > 0) {
-        const bookedSeats = await getMySeats().catch(() => null);
-        if (bookedSeats) {
-          unbooked = failures.filter(
-            ({ seat }) =>
-              !bookedSeats.some(
-                booked =>
-                  booked.section === seat.section &&
-                  booked.row === seat.row &&
-                  booked.seatNumber === seat.seatNumber,
-              ),
-          );
-        }
-      }
-
-      if (unbooked.length > 0) {
-        const errorMessages = unbooked.map(({ seat, detail }) => `${formatSeatLabel(seat)} ${detail}`);
-        throw new Error(`일부 좌석 예매에 실패했습니다: ${errorMessages.join(", ")}`);
-      }
-
-      return {
-        success: true,
-        message: `${seats.length}개 좌석이 성공적으로 예매되었습니다.`,
-        bookedSeats: seats,
-      };
+      toast.success(`${seats.length}개 좌석이 성공적으로 예매되었습니다.`);
     },
-    onSuccess: (result, vars) => {
-      markSeatsOccupied(queryClient, vars);
-
-      const sections = [...new Set(vars.map(seat => seat.section))];
-      sections.forEach(section => {
-        queryClient.invalidateQueries({ queryKey: seatQueryKeys.seatState(section) });
-      });
-
-      queryClient.invalidateQueries({ queryKey: ["mySeat"] });
-      queryClient.invalidateQueries({ queryKey: ["mySeats"] });
-
-      toast.success(result.message);
-    },
-    // 일부만 실패해도 성공한 좌석은 이미 예매됐으므로 좌석 상태를 다시 불러온다
-    onError: (error, vars) => {
-      const sections = [...new Set(vars.map(seat => seat.section))];
-      sections.forEach(section => {
-        queryClient.invalidateQueries({ queryKey: seatQueryKeys.seatState(section) });
-      });
-
-      queryClient.invalidateQueries({ queryKey: ["mySeat"] });
-      queryClient.invalidateQueries({ queryKey: ["mySeats"] });
+    // 전부 실패했더라도 다른 사용자가 좌석을 채웠을 수 있으니 서버 좌석 현황을 다시 불러온다
+    onError: (error, seats) => {
+      revalidateSeats(seats);
 
       console.error(error);
       toast.error(error.message ?? "알 수 없는 오류가 발생했습니다.");


### PR DESCRIPTION
## 💡 PR 요약

- 참가자 좌석 예매를 좌석별 `POST /seat` 반복 호출에서 `POST /seat/bulk` 단일 요청으로 전환했습니다.
- 서버가 좌석 전체를 한 트랜잭션으로 처리하므로 부분 성공 상태가 사라지고, rate limit(429)로 두 번째 좌석만 실패하던 흐름이 없어집니다.
- Close #305 / 서버 연동: School-of-Company/Gwangju-talent-festival-Server-V2#224

## 📋 작업 내용

- `bulkSeatBooking` 추가 — `POST /seat/bulk`, 요청 본문은 `{ seats: [{ seatSection, seatNumber }] }`
- 단건·bulk가 같은 에러 매핑을 쓰도록 `toSeatBookingError`로 분리 (상태 코드, `Retry-After` 전달 유지)
- 429 재시도 로직을 `withRateLimitRetry(request)`로 일반화하고 `bookSeatsBulkWithRetry` 추가 — 서버가 동일 요청을 멱등 처리하므로 재시도가 중복 예매를 만들지 않습니다
- `useMultipleSeatBooking`에서 순차 루프와 `getMySeats` 대조 로직을 제거하고 요청 한 번으로 교체
  - 성공: 선택 좌석을 즉시 예매 완료로 반영한 뒤 좌석 현황·내 좌석 재검증
  - 실패: 부분 성공 UI 없이 서버 좌석 현황만 다시 조회
- 예매 요청 중 버튼 비활성화 + 핸들러 가드로 중복 클릭 차단 (단건 예매도 동일 적용)
- 테스트 추가: bulk 단일 요청 검증, 429 재시도, 성공·실패 시 캐시 동기화

참가자 예매 한도(2석)와 선택 한도 테스트는 이전 작업에 이미 반영되어 있어 그대로 두었습니다.

## 🤝 리뷰 시 참고사항

- PR #304(#303, `fix/seat-state-sync`)가 아직 열려 있어 해당 커밋 3개가 이 PR diff에도 함께 보입니다. #304가 머지되면 정리됩니다.
- 서버 응답(`List<GetSeatResponse>`)이 요청 좌석을 그대로 돌려주므로, 캐시 반영은 응답 역변환 없이 요청한 좌석 값을 사용했습니다.
- `npx vitest run src/widgets/booking src/entities/booking`: 134개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)